### PR TITLE
test(rxForm): Prefer options' text over allOptions

### DIFF
--- a/src/rxForm/docs/rxForm.midway.js
+++ b/src/rxForm/docs/rxForm.midway.js
@@ -118,9 +118,7 @@ describe('rxForm', function () {
         it('should have every option listed', function () {
             var options = ['SATA', 'SSD', 'CD', 'DVD', 'BLURAY', 'TAPE', 'FLOPPY',
                            'LASERDISC', 'JAZDRIVE', 'PUNCHCARDS', 'RNA'];
-            dropdown.allOptions.then(function (allOptions) {
-                expect(Object.keys(allOptions)).to.eql(options);
-            });
+            expect(dropdown.options).to.eventually.eql(options);
         });
 
         it('should have a selected option by default', function () {

--- a/src/rxForm/rxForm.page.js
+++ b/src/rxForm/rxForm.page.js
@@ -36,15 +36,11 @@ var optionFromElement = function (optionElement) {
 
 var dropdown = {
 
-    allOptions: {
+    options: {
         get: function () {
-            return this.rootElement.$$('option').reduce(function (acc, optionElement) {
-                var option = optionFromElement(optionElement);
-                return option.text.then(function (text) {
-                    acc[text] = option;
-                    return acc;
-                });
-            }, {});
+            return this.rootElement.$$('option').map(function (optionElement) {
+                return optionFromElement(optionElement).text;
+            });
         }
     },
 


### PR DESCRIPTION
I have no idea why I exposed an `allOptions` call that returned every option as an object. This replaces that with a more suitable `options` call that returns all option's text, and does away with `allOptions` altogether.

This does make it a breaking change, but I'm almost certain no one was using it before. It can wait until other breaking changes are planned for a release to avoid excessive version increments.