### PR TITLE
feat(rxNotification): add ability to add a notification from a stack

### DIFF
--- a/src/rxNotify/README.md
+++ b/src/rxNotify/README.md
@@ -10,6 +10,14 @@ There may be situations where you will need to use the styling/markup of rxNotif
 
 For all notification types, please look below under Message options, under `type`.
 
+Another situation that you might encounter is adding a notification to the default stack but needing to do it via the template.  With the `stack` parameter you're allowed do define a notification and have it get added via `rxNotify.add`:
+
+> `<rx-notification type="error" stack="page">`
+
+>> `   This is an error message being added to the "page" stack with <strong>Custom</strong> html.`
+
+> `</rx-notification>`
+
 ## Adding a New Message Queue via rxNotify
 
 To add a new message to a stack, inject 'rxNotify' into your function and run:

--- a/src/rxNotify/docs/rxNotify.html
+++ b/src/rxNotify/docs/rxNotify.html
@@ -71,4 +71,20 @@
     <rx-notification type="error">Hello, world!</rx-notification>
     <rx-notification type="warning">Hello, world!</rx-notification>
     <rx-notification type="info">Hello, world!</rx-notification>
+
+    <p>Using rx-notification with custom stack</p>
+    <div class="pure-g">
+        <div class="pure-u-1-2">
+            <h2>Demo Stack (demo-stack)</h2>
+            <rx-notifications stack="demo-stack"></rx-notifications>
+        </div>
+
+        <div class="pure-u-1-2">
+            <h2>Custom Stack (custom-stack)</h2>
+            <rx-notifications stack="custom-stack"></rx-notifications>
+        </div>
+    </div>
+
+    <rx-notification stack="demo-stack" type="info">Hello, world in demo-stack stack!</rx-notification>
+    <rx-notification stack="custom-stack" type="warning">Hello, world in custom-stack stack!</rx-notification>
 </div>

--- a/src/rxNotify/docs/rxNotify.midway.js
+++ b/src/rxNotify/docs/rxNotify.midway.js
@@ -119,7 +119,7 @@ describe('rxNotify', function () {
     describe('all notifications', function () {
 
         it('should have 6 notifications in it', function () {
-            expect(notifications.all.count()).to.eventually.equal(6);
+            expect(notifications.all.count()).to.eventually.equal(8);
         });
 
         describe('by type', function () {
@@ -232,7 +232,7 @@ describe('rxNotify', function () {
         });
 
         it('should have actually dismissed the message', function () {
-            expect(notifications.all.count()).to.eventually.equal(5);
+            expect(notifications.all.count()).to.eventually.equal(7);
         });
 
         describe('by stack', function () {

--- a/src/rxNotify/rxNotify.js
+++ b/src/rxNotify/rxNotify.js
@@ -12,14 +12,46 @@ angular.module('encore.ui.rxNotify', ['ngSanitize', 'ngAnimate'])
 * @example
 * <rx-notification type="warning">This is a message!</rx-notification>
 */
-.directive('rxNotification', function () {
+.directive('rxNotification', function (rxNotify) {
     return {
         scope: {
             type: '@'
         },
         transclude: true,
         restrict: 'E',
-        templateUrl: 'templates/rxNotification.html'
+        templateUrl: 'templates/rxNotification.html',
+        link: {
+            // Transclude returns a jqLite object of the content in the directive pre transclusion into the template.
+            pre: function (scope, el, attrs, ctrl, transclude) {
+                if (!_.isEmpty(attrs.stack)) {
+                    /* jshint maxlen:false */
+                    /**
+                     * transclude().parent() - returns a jqLite instance of the parent (this directive as defined
+                     *                           in the template pre-rendering).
+                     * transclude().parent().html() - returns the inner HTML of the parent, as a string, as it was
+                     *                                  defined in the template pre-rendering (Text Only)
+                     * ----------------------------
+                     * el                           -> [<rx-notification stack=​"demo-stack" type=​"info">​
+                     *                                  <div class=​"rx-notifications">​...template...​</div>​
+                     *                                  </rx-notification>​]
+                     *
+                     * transclude()                 -> [<span class=​"ng-scope">​Hello, world in demo-stack stack!​</span>​]
+                     *
+                     * transclude().parent()        -> [<rx-notification stack=​"demo-stack" type=​"info">​
+                     *                                  <span class=​"ng-scope">​Hello, world in demo-stack stack!​</span>
+                     *                                  ​</rx-notification>​]
+                     *
+                     * transclude().parent().html() -> "<span class="ng-scope">Hello, world in demo-stack stack!</span>"
+                     **/
+                    var content = transclude().parent().html();
+                    rxNotify.add(content, {
+                        type: attrs.type,
+                        stack: attrs.stack
+                    });
+                    el.remove();
+                }
+            }
+        }
     };
 })
  /**

--- a/src/rxNotify/rxNotify.spec.js
+++ b/src/rxNotify/rxNotify.spec.js
@@ -404,6 +404,23 @@ describe('rxNotify', function () {
             var newEl = el2.find('span').eq(1);
             expect(newEl.text()).to.contain(messageText1);
         });
+
+        it('should add notification to stack and remove original element', function () {
+            var stackTemplate = '<div><rx-notification stack="page" type="info">' + messageText1 +
+                                    '</rx-notification></div>';
+
+            // Before compiling this notification, stack should be empty
+            expect(notifySvc.stacks[defaultStack].length).to.equal(0);
+            el2 = helpers.createDirective(stackTemplate, compile, scope);
+
+            // Stack should now have the contents of the notification directive
+            expect(notifySvc.stacks[defaultStack].length).to.equal(1);
+            expect(notifySvc.stacks[defaultStack][0].type).to.equal('info');
+            expect(notifySvc.stacks[defaultStack][0].text).to.contain(messageText1);
+
+            // el2 is now <div></div> and it should have no children
+            expect(el2.children().length).to.equal(0);
+        });
     });
 
     describe('Directive: rxNotifications', function () {


### PR DESCRIPTION
Adds an optional parameter to `rx-notification` directive that allows it to specify a target stack to put the contents of current notification into that stack.  

By specifying the current stack, the `rx-notification` element will be removed from the DOM and it's contents put into the defined stack via `rxNotify.add`

