### PR TITLE
E2e multiline comments everywhere, with minor breaking changes

### DIFF
--- a/src/rxAccountInfo/rxAccountInfo.page.js
+++ b/src/rxAccountInfo/rxAccountInfo.page.js
@@ -68,8 +68,10 @@ var rxAccountInfo = {
                 },
 
                 byName: {
-                    // Accepts strings for a fast, exact match only.
-                    // For a more flexible match, see `badges.matchingName`, which uses regular expressions.
+                    /*
+                      Accepts strings for a fast, exact match only.
+                      For a more flexible match, see `badges.matchingName`, which uses regular expressions.
+                    */
                     value: function (badgeName) {
                         return badge(page.rootElement.$('img[data-name="' + badgeName + '"]'));
                     }

--- a/src/rxActionMenu/rxActionMenu.page.js
+++ b/src/rxActionMenu/rxActionMenu.page.js
@@ -12,11 +12,13 @@ var action = function (actionElement) {
         },
 
         openModal: {
-            // Returns a modal object to manipulate later, with given `customFunctionality`.
-            //
-            // This is the default behavior, since many instances of the action menu serve to launch
-            // modals. If you're not using rxActionMenu to launch modals, over-ride this entire `action`
-            // function within the `initialize` function, where it accepts a custom `actionConstructorFn`.
+            /*
+              Returns a modal object to manipulate later, with given `customFunctionality`.
+
+              This is the default behavior, since many instances of the action menu serve to launch
+              modals. If you're not using rxActionMenu to launch modals, over-ride this entire `action`
+              function within the `initialize` function, where it accepts a custom `actionConstructorFn`.
+            */
             value: function (customFunctionality) {
                 actionElement.$('.modal-link').click();
                 var rxModal = exports.rxModalAction || require('../rxModalAction/rxModalAction.page').rxModalAction;
@@ -44,12 +46,14 @@ var rxActionMenu = {
     },
 
     cssFirstAny: {
-        // This selector will grab any top-level child elements under `.actions-area`, one level deep.
-        //
-        // Since action menus allow for free-form html entry, there is no guarantee that any
-        // particular structure will appear inside the action menu. However, we can be sure
-        // that they'll use the `.actions-area` class to style it, and inside of it will be some
-        // sort of element list. This exposes a hook into the html for matching text or counting nodes.
+        /*
+          This selector will grab any top-level child elements under `.actions-area`, one level deep.
+
+          Since action menus allow for free-form html entry, there is no guarantee that any
+          particular structure will appear inside the action menu. However, we can be sure
+          that they'll use the `.actions-area` class to style it, and inside of it will be some
+          sort of element list. This exposes a hook into the html for matching text or counting nodes.
+        */
         get: function () {
             return '.actions-area > *';
         }
@@ -121,11 +125,13 @@ var rxActionMenu = {
 
 exports.rxActionMenu = {
 
-    // Passing in an `actionConstructorFn` will default to calling that for any
-    // calls made to `rxActionMenu.action('Action Name')`.
-    //
-    // If this is left undefined, a simple default will be returned. For more information,
-    // see the underlying definition for the `action` function.
+    /*
+      Passing in an `actionConstructorFn` will default to calling that for any
+      calls made to `rxActionMenu.action('Action Name')`.
+
+      If this is left undefined, a simple default will be returned. For more information,
+      see the underlying definition for the `action` function.
+    */
     initialize: function (rxActionMenuElement, actionConstructorFn) {
         rxActionMenu.rootElement = {
             get: function () {

--- a/src/rxApp/docs/rxApp.midway.js
+++ b/src/rxApp/docs/rxApp.midway.js
@@ -22,10 +22,6 @@ describe('rxApp', function () {
         expect(rxAppCustom.sectionTitle).to.eventually.equal('Example Menu');
     });
 
-    it('should have a logout link', function () {
-        expect(rxAppCustom.lnkLogout.isDisplayed()).to.eventually.be.true;
-    });
-
     it('should logout', function () {
         rxAppCustom.logout();
         expect(demoPage.currentUrl).to.eventually.contain('login');

--- a/src/rxApp/rxApp.page.js
+++ b/src/rxApp/rxApp.page.js
@@ -9,32 +9,16 @@ var rxApp = {
         get: function () { return '.collapsible-toggle'; }
     },
 
-    lblNavTitle: {
-        get: function () { return this.rootElement.$('.site-title'); }
-    },
-
-    lblNavSectionTitle: {
-        get: function () { return this.rootElement.$('.nav-section-title'); }
-    },
-
-    eleSiteNav: {
-        get: function () { return this.rootElement.$('.rx-app-nav'); }
-    },
-
     btnCollapseToggle: {
         get: function () { return this.rootElement.$(this.cssCollapseButtonSelector); }
     },
 
-    lnkLogout: {
-        get: function () { return this.rootElement.$('.site-logout'); }
-    },
-
     title: {
-        get: function () { return this.lblNavTitle.getText(); }
+        get: function () { return this.rootElement.$('.site-title').getText(); }
     },
 
     sectionTitle: {
-        get: function () { return this.lblNavSectionTitle.getText(); }
+        get: function () { return this.rootElement.$('.nav-section-title').getText(); }
     },
 
     expand: {
@@ -92,7 +76,7 @@ var rxApp = {
 
     logout: {
         value: function () {
-            this.lnkLogout.click();
+            this.rootElement.$('.site-logout').click();
         }
     },
 
@@ -158,9 +142,6 @@ var rxPage = {
 exports.rxPage = {
 
     initialize: function (rxPageElement) {
-        if (rxPageElement === undefined) {
-            rxPageElement = $('html');
-        }
         rxPage.rootElement = {
             get: function () { return rxPageElement; }
         };

--- a/src/rxApp/rxApp.page.js
+++ b/src/rxApp/rxApp.page.js
@@ -4,8 +4,10 @@ var Page = require('astrolabe').Page;
 var rxApp = {
 
     cssCollapseButtonSelector: {
-        // Keep just the css string available for both the button element
-        // and the check made in `isCollapsible()`, which uses findAllBy.
+        /*
+          Keep just the css string available for both the button element
+          and the check made in `isCollapsible()`, which uses findAllBy.
+        */
         get: function () { return '.collapsible-toggle'; }
     },
 

--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
@@ -123,9 +123,9 @@ describe('rxBreadcrumbs', function () {
         it('should have the name "Components"', function () {
             expect(middle.name).to.eventually.equal('Components');
         });
-        
+
         it('should not have a tag', function () {
-            expect(middle.tag).to.eventually.equal('');
+            expect(middle.tag).to.eventually.be.null;
             expect(middle.lblTag.isPresent()).to.eventually.be.false;
         });
 

--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
@@ -80,25 +80,6 @@ describe('rxBreadcrumbs', function () {
 
     });
 
-    describe('all breadcrumbs', function () {
-        var all;
-
-        before(function () {
-            breadcrumbs.toArray().then(function (allBreadcrumbs) {
-                all = allBreadcrumbs;
-            });
-        });
-
-        it('should have the first breadcrumb first', function () {
-            expect(all[0].isFirst()).to.eventually.be.true;
-        });
-
-        it('should have the last breadcrumb last', function () {
-            expect(all[2].isLast()).to.eventually.be.true;
-        });
-
-    });
-
     describe('by name', function () {
         var middle;
 

--- a/src/rxBreadcrumbs/rxBreadcrumbs.page.js
+++ b/src/rxBreadcrumbs/rxBreadcrumbs.page.js
@@ -74,15 +74,6 @@ var rxBreadcrumbs = {
         }
     },
 
-    toArray: {
-        value: function () {
-            return this.tblBreadcrumbs.reduce(function (acc, breadcrumbElement) {
-                acc.push(breadcrumb(breadcrumbElement));
-                return acc;
-            }, []);
-        }
-    },
-
     byName: {
         // Return a single breadcrumb entry, located by the text of the element, case sensitive.
         // If multiple entries exist with the same name, the first will be returned.

--- a/src/rxBreadcrumbs/rxBreadcrumbs.page.js
+++ b/src/rxBreadcrumbs/rxBreadcrumbs.page.js
@@ -75,8 +75,10 @@ var rxBreadcrumbs = {
     },
 
     byName: {
-        // Return a single breadcrumb entry, located by the text of the element, case sensitive.
-        // If multiple entries exist with the same name, the first will be returned.
+        /*
+          Return a single breadcrumb entry, located by the text of the element, case sensitive.
+          If multiple entries exist with the same name, the first will be returned.
+        */
         value: function (breadcrumbName) {
             return this.tblBreadcrumbs.filter(function (breadcrumbElement) {
                 return breadcrumbElement.element(by.exactBinding('breadcrumb.name')).getText().then(function (name) {

--- a/src/rxBreadcrumbs/rxBreadcrumbs.page.js
+++ b/src/rxBreadcrumbs/rxBreadcrumbs.page.js
@@ -21,9 +21,7 @@ var breadcrumb = function (rootElement) {
                     if (present) {
                         return page.lblTag.getText();
                     } else {
-                        var deferred = protractor.promise.defer();
-                        deferred.fulfill('');
-                        return deferred.promise;
+                        return null;
                     }
                 });
             }
@@ -35,7 +33,7 @@ var breadcrumb = function (rootElement) {
                     if (isLink) {
                         return rootElement.$('a').getAttribute('href');
                     } else {
-                        return protractor.promise.fulfilled(null);
+                        return null;
                     }
                 });
             }

--- a/src/rxEnvironment/rxEnvironment.page.js
+++ b/src/rxEnvironment/rxEnvironment.page.js
@@ -2,10 +2,12 @@ var _ = require('lodash');
 
 exports.rxEnvironment = {
 
-    // Return the current environment the user sees.
-    // The default is set to something simple and reasonable,
-    // but should you find a need to supply your own environments, be
-    // sure to have `environments` defined in your protractor conf's params section.
+    /*
+      Return the current environment the user sees.
+      The default is set to something simple and reasonable,
+      but should you find a need to supply your own environments, be
+      sure to have `environments` defined in your protractor conf's params section.
+    */
     current: function () {
         var component = this;
         return browser.getCurrentUrl().then(function (url) {
@@ -13,8 +15,10 @@ exports.rxEnvironment = {
         });
     },
 
-    // Return the original environment, as defined in the current protractor conf file.
-    // Returns a promise to keep the usage consistent with `rxEnvironment.current`.
+    /*
+      Return the original environment, as defined in the current protractor conf file.
+      Returns a promise to keep the usage consistent with `rxEnvironment.current`.
+    */
     original: function () {
         return protractor.promise.fulfilled(this.compare(browser.baseUrl));
     },
@@ -50,7 +54,9 @@ exports.rxEnvironment = {
         return this.confirmEnvironment(namedParams, 'production');
     },
 
-    // `namedParams` only supports { useBaseUrl: true }. If { useBaseUrl: false }, just leave undefined.
+    /*
+      `namedParams` only supports { useBaseUrl: true }. If { useBaseUrl: false }, just leave undefined.
+    */
     confirmEnvironment: function (namedParams, environment) {
         var component = this;
         if (namedParams === undefined) {

--- a/src/rxFeedback/rxFeedback.page.js
+++ b/src/rxFeedback/rxFeedback.page.js
@@ -66,13 +66,15 @@ var rxFeedback = {
     },
 
     send: {
-        // Prepares, writes, and submits feedback.
-        // If `confirmSuccessWithin` is defined, a confirmation of submission success must appear
-        // within `confirmSuccessWithin` milliseconds.
-        //
-        // If confirmSuccessFn is undefined, the default behavior will look for an rxNotify success
-        // message. Otherwise, `confirmSuccessFn` will be attempted until it yields a truthy value,
-        // using Protractor's `wait` function.
+        /*
+          Prepares, writes, and submits feedback.
+          If `confirmSuccessWithin` is defined, a confirmation of submission success must appear
+          within `confirmSuccessWithin` milliseconds.
+
+          If confirmSuccessFn is undefined, the default behavior will look for an rxNotify success
+          message. Otherwise, `confirmSuccessFn` will be attempted until it yields a truthy value,
+          using Protractor's `wait` function.
+        */
         value: function (feedbackType, feedbackText, confirmSuccessWithin, confirmSuccessFn) {
             var page = this;
             return this.isDisplayed().then(function (isDisplayed) {

--- a/src/rxFloatingHeader/rxFloatingHeader.page.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.page.js
@@ -1,4 +1,5 @@
 /*jshint node:true*/
+var _ = require('lodash');
 
 exports.rxFloatingHeader = {
 
@@ -29,7 +30,7 @@ exports.rxFloatingHeader = {
             });
         } else {
             var location = elementOrLocation;
-            if (location[attribute]) {
+            if (_.has(location, attribute)) {
                 return protractor.promise.fulfilled(location[attribute]);
             } else {
                 return protractor.promise.fulfilled(location);
@@ -38,7 +39,6 @@ exports.rxFloatingHeader = {
     },
 
     compareLocations: function (e1, e2, attribute) {
-        attribute = attribute || 'y';
         var promises = [this.transformLocation(e1, attribute), this.transformLocation(e2, attribute)];
         return protractor.promise.all(promises).then(function (locations) {
             return locations[0] === locations[1];

--- a/src/rxFloatingHeader/rxFloatingHeader.page.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.page.js
@@ -18,10 +18,12 @@ exports.rxFloatingHeader = {
         return this.compareLocations(e1, e2, 'x');
     },
 
-    // Unify input from either a location object or a web element into a promise
-    // representing the location attribute (x or y) of either input.
-    // Both `transformLocation($('.element'), 'y')` and `transformLocation({x: 20, y: 0}, 'y')`
-    // return a promise representing the y value of the resulting (or provided) location object.
+    /*
+      Unify input from either a location object or a web element into a promise
+      representing the location attribute (x or y) of either input.
+      Both `transformLocation($('.element'), 'y')` and `transformLocation({x: 20, y: 0}, 'y')`
+      return a promise representing the y value of the resulting (or provided) location object.
+    */
     transformLocation: function (elementOrLocation, attribute) {
         if (protractor.promise.isPromise(elementOrLocation)) {
             var elem = elementOrLocation;

--- a/src/rxForm/rxForm.page.js
+++ b/src/rxForm/rxForm.page.js
@@ -124,25 +124,27 @@ exports.rxForm = {
 
     form: {
         fill: function (reference, formData) {
-            // Set `value` in `formData` to the page object's current method `key`.
-            // Aids in filling out form data via javascript objects.
-            //
-            // For example:
-            // yourPage.fill({
-            //     aTextbox: 'My Name',
-            //     aRadioButton: 'Second Option'
-            //     aSelectDropdown: 'My Choice'
-            //     aModule: {
-            //         hasMethods: 'Can Accept Input Too',
-            //         deepNesting: {
-            //             might: 'be overkill at this level'
-            //         }
-            //     }
-            // });
-            // Would invoke yourPage.aTextbox's set method, which might call sendKeys, and so on.
-            // For an example of this in use, see src/rxFormPage/docs/rxFormPage.midway.js
-            //
-            // Pass in the context to evaluate under as `reference` (typically, `this`).
+            /*
+              Set `value` in `formData` to the page object's current method `key`.
+              Aids in filling out form data via javascript objects.
+
+              For example:
+              yourPage.fill({
+                  aTextbox: 'My Name',
+                  aRadioButton: 'Second Option'
+                  aSelectDropdown: 'My Choice'
+                  aModule: {
+                      hasMethods: 'Can Accept Input Too',
+                      deepNesting: {
+                          might: 'be overkill at this level'
+                      }
+                  }
+              });
+              Would invoke yourPage.aTextbox's set method, which might call sendKeys, and so on.
+              For an example of this in use, see src/rxFormPage/docs/rxFormPage.midway.js
+
+              Pass in the context to evaluate under as `reference` (typically, `this`).
+            */
             var next = this;
             var page = reference;
             _.forEach(formData, function (value, key) {

--- a/src/rxPaginate/rxPaginate.page.js
+++ b/src/rxPaginate/rxPaginate.page.js
@@ -50,7 +50,9 @@ var rxPaginate = {
     },
 
     first: {
-        // Does nothing if already at the first page.
+        /*
+          Does nothing if already at the first page.
+        */
         value: function () {
             var page = this;
             return this.page.then(function (pageNumber) {
@@ -76,7 +78,9 @@ var rxPaginate = {
     },
 
     last: {
-        // Does nothing if already at the last page.
+        /*
+          Does nothing if already at the last page.
+        */
         value: function () {
             var page = this;
             var css = '.pagination-last a';
@@ -89,7 +93,9 @@ var rxPaginate = {
     },
 
     page: {
-        // Return the current page number, or change page numbers.
+        /*
+          Return the current page number, or change page numbers.
+        */
         get: function () {
             return this.lnkCurrentPage.getText().then(function (text) {
                 return parseInt(text, 10);
@@ -102,7 +108,9 @@ var rxPaginate = {
 
     pages: {
         get: function () {
-            // Return a list of page numbers available to paginate to.
+            /*
+              Return a list of page numbers available to paginate to.
+            */
             return this.tblPages.map(function (pageNumber) {
                 return pageNumber.getText().then(function (n) {
                     return parseInt(n, 10);
@@ -128,7 +136,9 @@ var rxPaginate = {
                 return parseInt(pageSize, 10);
             });
         },
-        // Will throw an exception if no matching `itemsPerPage` entry is found.
+        /*
+          Will throw an exception if no matching `itemsPerPage` entry is found.
+        */
         set: function (itemsPerPage) {
             var page = this;
             var css = '.pagination-per-page-button';
@@ -240,9 +250,11 @@ var rxPaginate = {
     },
 
     checkForInvalidLastPage: {
-        // Accepts an optional `pageNumber` argument to print to the exception
-        // should the `NoSuchPageException` get triggered during this call.
-        // Otherwise, it defaults to a generic invalid page message.
+        /*
+          Accepts an optional `pageNumber` argument to print to the exception
+          should the `NoSuchPageException` get triggered during this call.
+          Otherwise, it defaults to a generic invalid page message.
+        */
         value: function (pageNumber) {
             var page = this;
             return this.page.then(function (currentPage) {

--- a/src/rxPermission/rxPermission.page.js
+++ b/src/rxPermission/rxPermission.page.js
@@ -2,7 +2,6 @@
 var Page = require('astrolabe').Page;
 
 exports.rxPermission = Page.create({
-    // Elements
     rxPermission: {
         get: function () {
             return $('rx-permission');

--- a/src/rxSortableColumn/rxSortableColumn.page.js
+++ b/src/rxSortableColumn/rxSortableColumn.page.js
@@ -1,10 +1,12 @@
 /*jshint node:true*/
 var Page = require('astrolabe').Page;
 
-// This is a shared function for getting one column's sort direction, and all columns' sort directions.
-// Ascending sort:  (1)  means the arrow is pointed down. [0-9, a-z]
-// Descending sort: (0)  means the arrow is pointed up.   [z-a, 9-0]
-// Not sorted:     (-1)  means there is no arrow for this column.
+/*
+  This is a shared function for getting one column's sort direction, and all columns' sort directions.
+  Ascending sort:  (1)  means the arrow is pointed down. [0-9, a-z]
+  Descending sort: (0)  means the arrow is pointed up.   [z-a, 9-0]
+  Not sorted:     (-1)  means there is no arrow for this column.
+*/
 var currentSortDirection = function (columnElement) {
     var imgSortIcon = columnElement.$('.sort-icon');
     return imgSortIcon.getAttribute('style').then(function (style) {
@@ -46,7 +48,9 @@ var rxSortableColumn = {
     },
 
     sort: {
-        // Prefer using `sortAscending` and `sortDescending` over using this method directly.
+        /*
+          Prefer using `sortAscending` and `sortDescending` over using this method directly.
+        */
         value: function (namedParams) {
             var page = this;
             return this.currentSortDirection.then(function (sortDirection) {
@@ -81,8 +85,10 @@ var rxSortableColumn = {
     },
 
     getDataUsing: {
-        // Return a list of all cell contents in this column.
-        // Passes all cell elements to `customFn`.
+        /*
+          Return a list of all cell contents in this column.
+          Passes all cell elements to `customFn`.
+        */
         value: function (customFn) {
             if (customFn === undefined) {
                 return this.data;
@@ -111,7 +117,9 @@ var rxSortableColumn = {
 
 };
 
-// Functions for manipulating entire column sets of rx-sortable-columns.
+/*
+  Functions for manipulating entire column sets of rx-sortable-columns.
+*/
 var rxSortableColumns = {
 
     tblColumns: {
@@ -120,8 +128,10 @@ var rxSortableColumns = {
         }
     },
 
-    // Return all column names in `tableElement`.
-    // If any special work needs to be done, pass in a custom `mapFn` to `getNamesUsing` instead.
+    /*
+      Return all column names in `tableElement`.
+      If any special work needs to be done, pass in a custom `mapFn` to `getNamesUsing` instead.
+    */
     names: {
         get: function () {
             return this.getNamesUsing(function (columnElement) {

--- a/src/rxSpinner/docs/rxSpinner.midway.js
+++ b/src/rxSpinner/docs/rxSpinner.midway.js
@@ -2,7 +2,7 @@ var rxSpinnerPage = require('../rxSpinner.page.js').rxSpinner;
 
 describe('rxSpinner', function () {
 
-    it('beforeAll', function () {
+    before(function () {
         demoPage.go('#/component/rxSpinner');
     });
 

--- a/src/rxSpinner/rxSpinner.page.js
+++ b/src/rxSpinner/rxSpinner.page.js
@@ -2,7 +2,6 @@
 var Page = require('astrolabe').Page;
 
 exports.rxSpinner = Page.create({
-    // Elements
     rxSpinnerElement: {
         get: function () {
             return element(by.id('rxSpinnerElement'));

--- a/src/rxStatusColumn/docs/rxStatusColumn.midway.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.midway.js
@@ -1,5 +1,4 @@
 var rxStatusColumnPage = require('../rxStatusColumn.page.js').rxStatusColumn;
-var expect = require('chai').use(require('chai-as-promised')).expect;
 
 describe('rxStatusColumn', function () {
     var rxStatusColumn, all;
@@ -41,7 +40,7 @@ describe('rxStatusColumn', function () {
         it('should have no icon', function () {
             expect(first.icon).to.eventually.equal('');
         });
-        
+
     });
 
     describe('third cell', function () {
@@ -66,7 +65,7 @@ describe('rxStatusColumn', function () {
             expect(third.icon).to.eventually.equal('INFO');
         });
     });
-    
+
     describe('last cell', function () {
         var last;
         before(function () {

--- a/src/tabs/tabs.page.js
+++ b/src/tabs/tabs.page.js
@@ -99,9 +99,11 @@ var tabs = {
     },
 
     byName: {
-        // This will not be able to differentiate between similarly named tabs with
-        // different subtitled names. Include any subtitled text to differentiate between them.
-        // This will also return partial matches on the tab name since it uses `cssContainingText`.
+        /*
+          This will not be able to differentiate between similarly named tabs with
+          different subtitled names. Include any subtitled text to differentiate between them.
+          This will also return partial matches on the tab name since it uses `cssContainingText`.
+        */
         value: function (tabName) {
             var tabElement = this.rootElement.element(by.cssContainingText(this.cssTabs, tabName));
             return tabFromElement(tabElement);


### PR DESCRIPTION
This started as a chore to clean up comments, but it ended up becoming more. I realized that my editor makes it easy to make multiline comments by creating many single-line comments, and that this is a bit hard on the eyes. I'm switching over to multiline comments because they look better.

Also, since I submitted a pull request with breaking changes in it earlier this week, I thought I might as well get as many of them as I can for the minor version change that the first will cause.