### PR TITLE
test(rxStatusColumn): Page objects

### DIFF
--- a/src/rxStatusColumn/docs/rxStatusColumn.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.js
@@ -9,7 +9,7 @@ function rxStatusColumnCtrl ($scope, rxStatusMappings) {
         { status: 'REBOOT', title: 'REBOOT status mapped to INFO' },
         { status: 'SUSPENDED', title: 'SUSPENDED status mapped to WARNING' },
         { status: 'INPROGRESS', title: 'INPROGRESS status mapped to PENDING' },
-        { status: 'DELETING', title: 'DELETING status mapped to PENDING, using `fooApi` mapping', api:'fooApi' },
+        { status: 'DELETING', title: 'DELETING status mapped to PENDING, using `fooApi` mapping', api:'fooApi' }
     ];
 
     // We have a few different ways of adding mappings. We've tried to show them all here

--- a/src/rxStatusColumn/docs/rxStatusColumn.midway.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.midway.js
@@ -1,95 +1,209 @@
-var rxStatusColumnPage = require('../rxStatusColumn.page.js').rxStatusColumn;
+var Page = require('astrolabe').Page;
 
+var rxStatusColumn = require('../rxStatusColumn.page.js').rxStatusColumn;
+
+// an anonymous page object to demonstrate table and cell creation
+var tablePageObject = Page.create({
+
+    rootElement: {
+        get: function () {
+            return $('.demo-status-column-table');
+        }
+    },
+
+    tblServers: {
+        get: function () {
+            return this.rootElement.all(by.repeater('server in servers'));
+        }
+    },
+
+    row: {
+        value: function (rowIndex) {
+            var rowElement = this.tblServers.get(rowIndex);
+            return Page.create({
+                // The tests below focus heavily on this table row property
+                status: {
+                    get: function () {
+                        return rxStatusColumn.initialize(rowElement.$('[rx-status-column]'));
+                    }
+                },
+
+                // goo.gl/OJdysF
+                title: {
+                    get: function () {
+                        return rowElement.$('td+td').getText();
+                    }
+                }
+            });
+        }
+    }
+
+});
+
+var statuses = rxStatusColumn.statuses;
+var icons = rxStatusColumn.icons;
+var colors = rxStatusColumn.colors;
 describe('rxStatusColumn', function () {
-    var rxStatusColumn, all;
 
     before(function () {
         demoPage.go('#/component/rxStatusColumn');
-        rxStatusColumn = rxStatusColumnPage.initialize($('.demo-status-column-table'));
-        rxStatusColumn.statusCells().then(function (allStatusCells) {
-            all = allStatusCells;
-        });
     });
 
-    it('should show element', function () {
-        expect(rxStatusColumn.isDisplayed()).to.eventually.be.true;
+    describe('rows', function () {
+        var status;
+
+        describe('active cell', function () {
+
+            before(function () {
+                status = tablePageObject.row(0).status;
+            });
+
+            it('should have a status by type', function () {
+                expect(status.byType).to.eventually.equal(statuses.active);
+            });
+
+            it('should not have a status by icon', function () {
+                expect(status.byIcon).to.eventually.be.null;
+            });
+
+            it('should have a status by color', function () {
+                expect(status.byColor).to.eventually.equal(colors.active);
+            });
+
+            it('should not have an api ', function () {
+                expect(status.api).to.eventually.be.null;
+            });
+
+            it('should not have a tooltip', function () {
+                expect(status.tooltip.exists).to.eventually.be.false;
+            });
+
+            it('should have no tooltip text', function () {
+                expect(status.tooltip.text).to.eventually.be.null;
+            });
+
+        });
+
+        describe('error cell', function () {
+
+            before(function () {
+                status = tablePageObject.row(1).status;
+            });
+
+            it('should have a status by type', function () {
+                expect(status.byType).to.eventually.equal(statuses.error);
+            });
+
+            it('should not have a status by icon', function () {
+                expect(status.byIcon).to.eventually.equal(statuses.error);
+            });
+
+            it('should have a status by color', function () {
+                expect(status.byColor).to.eventually.equal(colors.error);
+            });
+
+            it('should have a tooltip', function () {
+                expect(status.tooltip.exists).to.eventually.be.true;
+            });
+
+            it('should have tooltip text', function () {
+                expect(status.tooltip.text).to.eventually.equal('ERROR');
+            });
+
+        });
+
+        describe('info cells', function () {
+
+            describe('build cell', function () {
+
+                before(function () {
+                    status = tablePageObject.row(2).status;
+                });
+
+                it('should have a status by type', function () {
+                    expect(status.byType).to.eventually.equal(statuses.build);
+                });
+
+                it('should not have a status by icon', function () {
+                    expect(status.byIcon).to.eventually.equal(icons.info);
+                });
+
+                it('should have a status by color', function () {
+                    expect(status.byColor).to.eventually.equal(colors.info);
+                });
+
+            });
+
+            describe('reboot cell', function () {
+
+                before(function () {
+                    status = tablePageObject.row(3).status;
+                });
+
+                it('should have a status by type', function () {
+                    expect(status.byType).to.eventually.equal(statuses.reboot);
+                });
+
+                it('should not have a status by icon', function () {
+                    expect(status.byIcon).to.eventually.equal(icons.info);
+                });
+
+                it('should have a status by color', function () {
+                    expect(status.byColor).to.eventually.equal(colors.info);
+                });
+
+            });
+
+        });
+
+        describe('pending cells', function () {
+
+            describe('in progress cell', function () {
+
+                before(function () {
+                    status = tablePageObject.row(-2).status;
+                });
+
+                it('should have a status by type', function () {
+                    expect(status.byType).to.eventually.equal(statuses.inProgress);
+                });
+
+                it('should have a status by icon', function () {
+                    expect(status.byIcon).to.eventually.be.null;
+                });
+
+                it('should have a status by color', function () {
+                    expect(status.byColor).to.eventually.equal(colors.pending);
+                });
+
+            });
+
+            describe('deleting cell', function () {
+
+                before(function () {
+                    status = tablePageObject.row(-1).status;
+                });
+
+                it('should have a status by type', function () {
+                    expect(status.byType).to.eventually.equal(statuses.deleting);
+                });
+
+                it('should have a status by icon', function () {
+                    expect(status.byIcon).to.eventually.be.null;
+                });
+
+                it('should have a status by color', function () {
+                    expect(status.byColor).to.eventually.equal(colors.pending);
+                });
+
+                it('should be using an api', function () {
+                    expect(status.api).to.eventually.equal('fooApi');
+                });
+
+            });
+
+        });
+
     });
 
-    it('should have seven cells', function () {
-        expect(rxStatusColumn.tblStatusCells.count()).to.eventually.equal(7);
-    });
-
-    describe('first cell', function () {
-        var first;
-        before(function () {
-            first = all[0];
-        });
-
-        it('should have the right input status', function () {
-            expect(first.inputStatus).to.eventually.equal('ACTIVE');
-        });
-
-        it('should have the correct final status', function () {
-            expect(first.finalStatus).to.eventually.equal('ACTIVE');
-        });
-
-        it('should have the correct tooltip', function () {
-            expect(first.tooltip).to.eventually.equal('ACTIVE');
-        });
-
-        it('should have no icon', function () {
-            expect(first.icon).to.eventually.equal('');
-        });
-
-    });
-
-    describe('third cell', function () {
-        var third;
-        before(function () {
-            third = all[2];
-        });
-
-        it('should have the right input status', function () {
-            expect(third.inputStatus).to.eventually.equal('BUILD');
-        });
-
-        it('should have mapped the input status to the correct final status', function () {
-            expect(third.finalStatus).to.eventually.equal('INFO');
-        });
-
-        it('should have the correct tooltip', function () {
-            expect(third.tooltip).to.eventually.equal('BUILD');
-        });
-
-        it('should have an INFO icon', function () {
-            expect(third.icon).to.eventually.equal('INFO');
-        });
-    });
-
-    describe('last cell', function () {
-        var last;
-        before(function () {
-            last = all[all.length - 1];
-        });
-
-        it('should have the right input status', function () {
-            expect(last.inputStatus).to.eventually.equal('DELETING');
-        });
-
-        it('should have mapped the input status to the correct final status', function () {
-            expect(last.finalStatus).to.eventually.equal('PENDING');
-        });
-
-        it('should have the correct tooltip', function () {
-            expect(last.tooltip).to.eventually.equal('DELETING');
-        });
-
-        it('should reference the right api', function () {
-            expect(last.api).to.eventually.equal('fooApi');
-        });
-
-        it('should have no icon', function () {
-            expect(last.icon).to.eventually.equal('');
-        });
-    });
 });

--- a/src/rxStatusColumn/rxStatusColumn.page.js
+++ b/src/rxStatusColumn/rxStatusColumn.page.js
@@ -1,84 +1,89 @@
 /*jshint node:true*/
 var Page = require('astrolabe').Page;
 
-var statusCell = function (rootElement) {
-    return Page.create({
-        inputStatus: {
-            get: function () {
-                return rootElement.getAttribute('status');
-            }
-        },
-
-        finalStatus: {
-            get: function () {
-                return rootElement.getAttribute('class').then(function (classes) {
-                    var index = classes.indexOf('status-');
-                    // move past the `status-`
-                    return classes.slice(index + 7).split(' ')[0];
-                });
-            }
-        },
-
-        tooltip: {
-            get: function () {
-                return rootElement.$('span').getAttribute('tooltip');
-            }
-        },
-
-        api: {
-            get: function () {
-                return rootElement.getAttribute('api');
-            }
-        },
-
-        icon: {
-            get: function () {
-                return rootElement.$('i').getAttribute('class').then(function (classes) {
-                    var removeClasses = 'fa fa-lg';
-                    var iconClasses = classes.slice(removeClasses.length).trim();
-                    switch (iconClasses) {
-                        case 'fa-ban': {
-                                return 'ERROR';
-                            }
-                        case 'fa-exclamation-triangle': {
-                                return 'WARNING';
-                            }
-                        case 'fa-info-circle': {
-                                return 'INFO';
-                            }
-                        case 'fa-repeat fa-spin': {
-                                return 'PENDING';
-                            }
-                        default: {
-                                return '';
-                            }
-                    }
-                });
-            }
-        }
-    });
+var classNameToStatus = function (iconClassName) {
+    iconClassName = iconClassName.replace(/fa fa-lg/, '').trim();
+    return {
+        'fa-ban': 'ERROR',
+        'fa-exclamation-triangle': 'WARNING',
+        'fa-info-circle': 'INFO'
+    }[iconClassName] || null;
 };
 
+/*
+  This is actually a page object for a single status column cell. The name is misleading only in that it's
+  more important to follow the naming convention of the directive rather than being completely correct here.
+*/
 var rxStatusColumn = {
 
-    isDisplayed: {
-        value: function () {
-            return this.rootElement.isDisplayed();
-        }
-    },
-
-    tblStatusCells: {
+    byType: {
+        /*
+          Represents the custom defined status type.
+          This has no relation to the tooltip text, the icon chosen, or the color used to represent it.
+        */
         get: function () {
-            return this.rootElement.$$('td[rx-status-column]');
+            return this.rootElement.getAttribute('status');
         }
     },
 
-    statusCells: {
-        value: function () {
-            return this.tblStatusCells.reduce(function (acc, statusCellElement) {
-                acc.push(statusCell(statusCellElement));
-                return acc;
-            }, []);
+    byIcon: {
+        /*
+          Represents the status as summarized by the icon selection alone. Extracted from the font-awesome icon used.
+        */
+        get: function () {
+            return this.rootElement.$('i').getAttribute('class').then(classNameToStatus);
+        }
+    },
+
+    byColor: {
+        /*
+          Represents the status as summarized by the color selection alone. Extracted from the class name.
+        */
+        get: function () {
+            return this.rootElement.getAttribute('class').then(function (classes) {
+                return classes.match(/status-(\w+)/)[1];
+            });
+        }
+    },
+
+    api: {
+        get: function () {
+            return this.rootElement.getAttribute('api').then(function (api) {
+                return api ? api : null;
+            });
+        }
+    },
+
+    tooltip: {
+        get: function () {
+            var cellElement = this.rootElement;
+            return Page.create({
+                rootElement: {
+                    get: function () {
+                        return cellElement.$('.tooltip-inner');
+                    }
+                },
+
+                exists: {
+                    /*
+                      Hovers over the current row's status column and returns whether or not a tooltip appears.
+                    */
+                    get: function () {
+                        browser.actions().mouseMove(cellElement.$('i')).perform();
+                        return this.rootElement.isPresent();
+                    }
+                },
+
+                text: {
+                    get: function () {
+                        var tooltip = this;
+                        return this.exists.then(function (exists) {
+                            return exists ? tooltip.rootElement.getText() : null;
+                        });
+                    }
+                }
+
+            });
         }
     }
 
@@ -86,11 +91,35 @@ var rxStatusColumn = {
 
 exports.rxStatusColumn = {
 
-    initialize: function (rxStatusColumnElement) {
+    initialize: function (rxStatusCellElement) {
         rxStatusColumn.rootElement = {
-            get: function () { return rxStatusColumnElement; }
+            get: function () { return rxStatusCellElement; }
         };
         return Page.create(rxStatusColumn);
     },
+
+    statuses: {
+        active: 'ACTIVE',
+        build: 'BUILD',
+        deleting: 'DELETING',
+        error: 'ERROR',
+        inProgress: 'INPROGRESS',
+        reboot: 'REBOOT',
+        suspended: 'SUSPENDED'
+    },
+
+    icons: {
+        error: 'ERROR',
+        info: 'INFO',
+        warning: 'WARNING'
+    },
+
+    colors: {
+        active: 'ACTIVE',
+        error: 'ERROR',
+        info: 'INFO',
+        pending: 'PENDING',
+        warning: 'WARNING'
+    }
 
 };


### PR DESCRIPTION
BREAKING CHANGE: Completely overhauls the page objects for
rxStatusColumn, anything that was there before is almost certainly
invalid now. The only exception to this is the `.api` property.