### PR TITLE
test(tabs): Remove `.all`, use `.names` instead

### DIFF
--- a/src/tabs/docs/tabs.midway.js
+++ b/src/tabs/docs/tabs.midway.js
@@ -18,7 +18,7 @@ describe('tabs', function () {
     });
 
     it('should still have all tabs match the test data', function () {
-        expect(tabs.allNames).to.eventually.eql(tabNames);
+        expect(tabs.names).to.eventually.eql(tabNames);
     });
 
     it('should not find tabs that are not represented', function () {
@@ -79,29 +79,14 @@ describe('tabs', function () {
 
     });
 
-    describe('all tabs', function () {
-        var allTabs;
+    describe('main tabs', function () {
 
         before(function () {
             demoPage.go('#/component/hotkeys');
-            tabsPage.main.all.then(function (mainTabs) {
-                allTabs = mainTabs;
-            });
         });
 
-        it('should match the count from the tabs group', function () {
-            expect(tabsPage.main.count()).to.eventually.equal(allTabs.length);
-        });
-
-        it('should match the tabs by index', function () {
-            tabsPage.main.byIndex(1).name.then(function (name) {
-                expect(allTabs[1].name).to.eventually.equal(name);
-            });
-        });
-
-        it('should update the active tab in all tabs', function () {
-            allTabs[2].visit();
-            expect(allTabs[2].isActive()).to.eventually.be.true;
+        it('should find the only tabs on the page', function () {
+            expect(tabsPage.main.names).to.eventually.eql(['Demo', 'Markup', 'JavaScript', 'Protractor']);
         });
 
     });

--- a/src/tabs/tabs.page.js
+++ b/src/tabs/tabs.page.js
@@ -116,7 +116,7 @@ var tabs = {
         }
     },
 
-    allNames: {
+    names: {
         get: function () {
             return this.tblTabs.map(function (tabElement) {
                 return tabElement.getText().then(function (text) {
@@ -129,15 +129,6 @@ var tabs = {
     activeTab: {
         get: function () {
             return tabFromElement(this.rootElement.$('.nav-tabs .active'));
-        }
-    },
-
-    all: {
-        get: function () {
-            return this.tblTabs.reduce(function (acc, tabElement) {
-                acc.push(tabFromElement(tabElement));
-                return acc;
-            }, []);
         }
     },
 


### PR DESCRIPTION
BREAKING CHANGE: Avoid functions that iterate over a collection of sub
components and return them as an object. It's slow and typically not
used. Prefer the use of the term `.names` (as is used everywhere else),
instead of `.allNames`.