### PR TITLE
fix(rxSortableColumn): Put sort arrow in <button> and show how to sort rxStatusColumn

### DIFF
--- a/src/rxSortableColumn/rxSortableColumn.page.js
+++ b/src/rxSortableColumn/rxSortableColumn.page.js
@@ -88,8 +88,18 @@ var rxSortableColumn = {
         /*
           Return a list of all cell contents in this column.
           Passes all cell elements to `customFn`.
+
+          The second argument, `allByCssSelectorString` is used when your column's binding
+          (which is used by `by.repeater().column`) is for some reason unreachable by protractor.
+          A common reason why this wouldn't be the case is because the binding is not used as text
+          within a web element, but instead used within the tag's attrs. An example of this is here:
+
+          https://github.com/rackerlabs/encore-ui/blob/c200b7ca5019635724faefff8fbf5a16ccb0c8b7/src/rxStatusColumn/docs/rxStatusColumn.html#L14
+
+          In these cases, you should specify a css selector that will select each element in the column you
+          care about, since `by.binding` is not an option.
         */
-        value: function (customFn) {
+        value: function (customFn, allByCssSelectorString) {
             if (customFn === undefined) {
                 return this.data;
             }
@@ -100,7 +110,12 @@ var rxSortableColumn = {
                     page.CellUndiscoverableError.thro('data');
                 }
 
-                return customFn(element.all(by.repeater(page.repeaterString).column(sortProperty)));
+                if (allByCssSelectorString === undefined) {
+                    return customFn(element.all(by.repeater(page.repeaterString).column(sortProperty)));
+                } else {
+                    var elements = element.all(by.repeater(page.repeaterString));
+                    return customFn(elements.$$(allByCssSelectorString));
+                }
             });
         }
     },

--- a/src/rxSortableColumn/templates/rxSortableColumn.html
+++ b/src/rxSortableColumn/templates/rxSortableColumn.html
@@ -2,10 +2,10 @@
     <button class="sort-action btn-link" ng-click="sortMethod({property:sortProperty})">
         <span class="visually-hidden">Sort by&nbsp;</span>
         <span ng-transclude></span>
+        <i class="sort-icon"
+            ng-style="{visibility: predicate === '{{sortProperty}}' && 'visible' || 'hidden'}"
+            ng-class="{'desc': !reverse, 'asc': reverse}">
+            <span class="visually-hidden">Sorted {{reverse ? 'ascending' : 'descending'}}</span>
+        </i>
     </button>
-    <i class="sort-icon"
-        ng-style="{visibility: predicate === '{{sortProperty}}' && 'visible' || 'hidden'}"
-        ng-class="{'desc': !reverse, 'asc': reverse}">
-        <span class="visually-hidden">Sorted {{reverse ? 'ascending' : 'descending'}}</span>
-    </i>
 </div>

--- a/src/rxStatusColumn/README.md
+++ b/src/rxStatusColumn/README.md
@@ -9,6 +9,25 @@ For the `<th>` component representing the status column, add the `rx-status-head
 
     <th rx-status-header></th>
 
+Note that status columns are sortable with <a href="#/component/rxSortableColumn">rxSortableColumn</a>, just like any other column. The demo below shows an example of this.
+
+One few things to note about the demo: The <code>&lt;th&gt;<code> is defined as:
+<pre><code>
+        &lt;th rx-status-header&gt;
+            &lt;rx-sortable-column
+              sort-method="sortCol(property)"
+              sort-property="status"
+              predicate="sort.predicate"
+              reverse="sort.reverse">
+                Status
+            &lt;/rx-sortable-column&gt;
+        &lt;th&gt;
+</code></pre>
+
+In particular, note that the word <code>Status</code> is used as the content of the <code>&lt;rx-sortable-column&gt;</code> directive, but this word doesn't actually appear in the header of the status column. This is because of a bug in <code>rxSortableColumn</code> that we will fix later. We purposely do not want the word to appear in that column, but we require <em>something</em> to be there, otherwise the column header is not clickable.
+
+Also note that <code>sort-property="status"</code> is referring to the <code>server.status</code> property on each row. Thus the sorting is done in this example by the status text coming from the API.
+
 ## rx-status-column
 
 For the corresponding `<td>`, you will need to add the `rx-status-column` attribute, and set the `status` attribute appropriately. You can optionally set `api` and `tooltip-content` attributes. `tooltip-content` sets the tooltip that will be used. If not set, it will default to the value you passed in for `status`. The `api` attribute will be explained below.

--- a/src/rxStatusColumn/docs/rxStatusColumn.html
+++ b/src/rxStatusColumn/docs/rxStatusColumn.html
@@ -2,14 +2,22 @@
     <table class="table-striped demo-status-column-table">
         <thead>
             <tr>
-                <th rx-status-header></th>
+                <th rx-status-header>
+                    <rx-sortable-column
+                      sort-method="sortCol(property)"
+                      sort-property="status"
+                      predicate="sort.predicate"
+                      reverse="sort.reverse">
+                        Status
+                    </rx-sortable-column>
+                </th>
                 <th class="column-title">
                     Title
                 </th>
             </tr>
         </thead>
         <tbody>
-            <tr ng-repeat="server in servers">
+            <tr ng-repeat="server in servers | orderBy: sort.predicate:sort.reverse ">
                 <!-- Both `api` and `tooltip-content` are optional -->
                 <td rx-status-column status="{{ server.status }}" api="{{ server.api }}" tooltip-content="{{ server.status }}"></td>
                 <td>{{ server.title }}</td>

--- a/src/rxStatusColumn/docs/rxStatusColumn.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.js
@@ -1,7 +1,7 @@
 /*jshint unused:false*/
 
 // This file is used to help build the 'demo' documentation page and should be updated with example code
-function rxStatusColumnCtrl ($scope, rxStatusMappings) {
+function rxStatusColumnCtrl ($scope, rxStatusMappings, rxSortUtil) {
     $scope.servers = [
         { status: 'ACTIVE', title: 'ACTIVE status' },
         { status: 'ERROR', title: 'ERROR status' },
@@ -22,4 +22,8 @@ function rxStatusColumnCtrl ($scope, rxStatusMappings) {
 
     rxStatusMappings.addAPI('fooApi', { 'DELETING': 'PENDING' });
     rxStatusMappings.mapToPending('SomeApiSpecificStatus', 'fooApi');
+    $scope.sortCol = function (predicate) {
+        return rxSortUtil.sortCol($scope, predicate);
+    };
+    $scope.sort = rxSortUtil.getDefault('status');
 }

--- a/src/rxStatusColumn/docs/rxStatusColumn.midway.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.midway.js
@@ -75,11 +75,11 @@ describe('rxStatusColumn', function () {
             });
 
             it('should not have a tooltip', function () {
-                expect(status.tooltip.exists).to.eventually.be.false;
+                expect(status.tooltip.exists).to.eventually.be.true;
             });
 
-            it('should have no tooltip text', function () {
-                expect(status.tooltip.text).to.eventually.be.null;
+            it('should have tooltip text', function () {
+                expect(status.tooltip.text).to.eventually.equal('ACTIVE');
             });
 
         });
@@ -87,7 +87,7 @@ describe('rxStatusColumn', function () {
         describe('error cell', function () {
 
             before(function () {
-                status = tablePageObject.row(1).status;
+                status = tablePageObject.row(3).status;
             });
 
             it('should have a status by type', function () {
@@ -117,7 +117,7 @@ describe('rxStatusColumn', function () {
             describe('build cell', function () {
 
                 before(function () {
-                    status = tablePageObject.row(2).status;
+                    status = tablePageObject.row(1).status;
                 });
 
                 it('should have a status by type', function () {
@@ -137,7 +137,7 @@ describe('rxStatusColumn', function () {
             describe('reboot cell', function () {
 
                 before(function () {
-                    status = tablePageObject.row(3).status;
+                    status = tablePageObject.row(5).status;
                 });
 
                 it('should have a status by type', function () {
@@ -161,7 +161,7 @@ describe('rxStatusColumn', function () {
             describe('in progress cell', function () {
 
                 before(function () {
-                    status = tablePageObject.row(-2).status;
+                    status = tablePageObject.row(4).status;
                 });
 
                 it('should have a status by type', function () {
@@ -181,7 +181,7 @@ describe('rxStatusColumn', function () {
             describe('deleting cell', function () {
 
                 before(function () {
-                    status = tablePageObject.row(-1).status;
+                    status = tablePageObject.row(2).status;
                 });
 
                 it('should have a status by type', function () {
@@ -198,6 +198,10 @@ describe('rxStatusColumn', function () {
 
                 it('should be using an api', function () {
                     expect(status.api).to.eventually.equal('fooApi');
+                });
+
+                it('should have tooltip text', function () {
+                    expect(status.tooltip.text).to.eventually.equal('DELETING');
                 });
 
             });

--- a/src/rxStatusColumn/rxStatusColumn.js
+++ b/src/rxStatusColumn/rxStatusColumn.js
@@ -24,7 +24,10 @@ angular.module('encore.ui.rxStatusColumn', [])
         link: function (scope, element) {
             scope.mappedStatus = rxStatusMappings.getInternalMapping(scope.status, scope.api);
             scope.tooltipText = scope.tooltipContent || scope.status;
-            scope.statusIcon = rxStatusColumnIcons[scope.mappedStatus] || '';
+
+            // We use `fa-exclamation-circle` when no icon should be visible. Our LESS file
+            // makes it transparent
+            scope.statusIcon = rxStatusColumnIcons[scope.mappedStatus] || 'fa-exclamation-circle';
             element.addClass('status');
             element.addClass('status-' + scope.mappedStatus);
             element.addClass('rx-status-column');

--- a/src/rxStatusColumn/rxStatusColumn.less
+++ b/src/rxStatusColumn/rxStatusColumn.less
@@ -3,11 +3,22 @@
  */
 
 th.rx-status-header {
-    width: 17px;
+    width: 20px;
     padding: 0;
+    rx-sortable-column {
+        .sort-action {
+            color: transparent;
+        }
+        .sort-icon {
+            margin: -9px 14px;
+        }
+    }
 }
 
 td.rx-status-column {
+    i {
+        padding-left: 2px;
+    }
     &.status-ACTIVE {
         background: #ddffd3;
     }
@@ -33,5 +44,10 @@ td.rx-status-column {
             color: #287BBD;
         }
     }
+
+    .fa-exclamation-circle {
+        color: transparent;
+    }
+
 
 }


### PR DESCRIPTION
This commit puts the sort icon into the <button> that rxSortableColumn
creates, allowing us to click on the sort arrow itself.

This also updates rxStatusColumn to allow for sorting of the status
column. It adds documentation to the rxStatusColumn demo page to show
how to do this.

Finally, we also fixed a problem where tooltips would not show for
ACTIVE and PENDING status column cells. It was slightly related to
the sorting issue, so it has been bundled in to this commit.

Closes #732
Closes #733