### PR TITLE
chore(test): @droogans still can't spell

### DIFF
--- a/src/rxNotify/rxNotify.page.js
+++ b/src/rxNotify/rxNotify.page.js
@@ -89,8 +89,8 @@ var rxNotify = {
         value: function () {
             var page = this;
             return this.tblNotifications.map(function (notificationElement, index) {
-                return notification(notificationElement).isDismissable().then(function (dimissable) {
-                    if (dimissable) {
+                return notification(notificationElement).isDismissable().then(function (dismissable) {
+                    if (dismissable) {
                         return index;
                     }
                 });


### PR DESCRIPTION
Actually, none of you guys can spell... the code uses 'dismissable'
in about 1000 places.  This isn`t a word!  Should be 'dismissible'.
Changing it would break the interwebs though, so I recommend a firm
"Will Not Fix" on that.