### PR TITLE
fix(rxFormOptionTable): Change color of empty message text.

### DIFF
--- a/src/rxForm/rxForm.page.js
+++ b/src/rxForm/rxForm.page.js
@@ -331,7 +331,7 @@ var rxOptionFormTable = {
 
     lblEmptyWarningMessage: {
         get: function () {
-            return this.rootElement.$('.msg-warn');
+            return this.rootElement.$('.empty-data');
         }
     },
 

--- a/src/rxForm/templates/rxFormOptionTable.html
+++ b/src/rxForm/templates/rxFormOptionTable.html
@@ -36,9 +36,7 @@
             </td>
         </tr>
         <tr ng-if="data.length === 0 && emptyMessage">
-            <td colspan="{{columns.length + 1}}" class="empty-data">
-                <span class="msg-warn">{{emptyMessage}}</span>
-            </td>
+            <td colspan="{{columns.length + 1}}" class="empty-data">{{emptyMessage}}</td>
         </tr>
     </table>
 </div>


### PR DESCRIPTION
This is part of @glynnis's work to enforce an empty message in all tables in Encore UI.  Here, the text color is simply changing from red to the default color.

![screen shot 2015-01-26 at 10 04 38 am](https://cloud.githubusercontent.com/assets/5414922/5902753/c43df670-a542-11e4-98e8-f1bc6dacf104.png)

