### PR TITLE
style(rxNotify): add styles for link color

### DIFF
--- a/src/rxNotify/docs/rxNotify.html
+++ b/src/rxNotify/docs/rxNotify.html
@@ -68,9 +68,10 @@
 
     <p>Using rx-notification</p>
 
-    <rx-notification type="error">Hello, world!</rx-notification>
-    <rx-notification type="warning">Hello, world!</rx-notification>
-    <rx-notification type="info">Hello, world!</rx-notification>
+    <rx-notification type="error">Hello, world! <a href="#">This is a link.</a></rx-notification>
+    <rx-notification type="warning">Hello, world! <a href="#">This is a link.</a></rx-notification>
+    <rx-notification type="info">Hello, world! <a href="#">This is a link.</a></rx-notification>
+    <rx-notification type="success">Hello, world! <a href="#">This is a link.</a></rx-notification>
 
     <p>Using rx-notification with custom stack</p>
     <div class="pure-g">

--- a/src/rxNotify/docs/rxNotify.midway.js
+++ b/src/rxNotify/docs/rxNotify.midway.js
@@ -180,7 +180,7 @@ describe('rxNotify', function () {
         });
 
         it('should say hello', function () {
-            expect(notification.text).to.eventually.equal('Hello, world!');
+            expect(notification.text).to.eventually.equal('Hello, world! This is a link.');
         });
 
         it('should not be dismissable', function () {

--- a/src/rxNotify/rxNotify.less
+++ b/src/rxNotify/rxNotify.less
@@ -1,45 +1,5 @@
 @import 'mixins';
 
-/*
-# rxNotify
-
-Note: **Styledocco will not display the images associated with the notification bars.** Please reference the main Encore demo to view this. The class `rx-notifications` is a container div, and is required.
-
-In the second example we added `<button class="notification-dismiss btn-link">&times;</button>` to add a dismiss marker. If you are not using Encore UI's angular.js directives, it's up to you to flesh out this functionality.
-
-Note that `<rx-app></rx-app>` uses the `<rx-notifications>` directive, where each individual status message has the class `animate-fade`. This class uses CSS3 animations and requires the `ngAnimate` module which adds `ng-enter` and `ng-leave` classes as the element appears and dissapears. The `<rx-notification>` directive does not include the animation class.
-
-```
-<div class="rx-notifications">
-    <div class="rx-notification animate-fade notification-error">
-        Error Message
-    </div>
-
-    <div class="rx-notification animate-fade notification-error">
-        Error Message
-        <button class="notification-dismiss btn-link">&times;</button>
-    </div>
-
-    <div class="rx-notification animate-fade notification-info">
-        Informational Message
-    </div>    
-
-    <div class="rx-notification animate-fade notification-info notification-loading">
-        <div class="rx-spinner"></div>
-        Loading
-    </div>
-
-    <div class="rx-notification animate-fade notification-success">
-        Success Message
-    </div>
-
-    <div class="rx-notification animate-fade notification-warning">
-        Warning Message
-    </div>
-</div>
-```
-*/
-
 .rx-notifications {
     margin-bottom: 1.5em;
 
@@ -56,21 +16,33 @@ Note that `<rx-app></rx-app>` uses the `<rx-notifications>` directive, where eac
             background-color: #ddffd3;
             background-image: url('images/green-checkmark-circled.png');
             color: #45ad26;
+            a {
+              color: #7db162;
+            }
         }
         &.notification-info {
             background-color: #83c9fe;
             background-image: url('images/info-circled.png');
             color: #1672b9;
+            a {
+              color: #568fb8;
+            }
         }
         &.notification-warning {
             background-color: #ffa61b;
             background-image: url('images/warning-triangle.png');
             color: #fff;
+            a {
+              color: #f1d6af;
+            }
         }
         &.notification-error {
             background-color: #f21a1a;
             background-image: url('images/error-stop.png');
             color: #fff;
+            a {
+              color: #fdaaab;
+            }
         }
         &.notification-loading {
             // Hide icon since it's replaced by spinner


### PR DESCRIPTION
Removed StyleDocco lines since we already have those examples represented in the current demo.

Added styles for link colors within rxNotify, and put links into the demo to illustrate:
![screen shot 2015-01-27 at 1 42 21 pm](https://cloud.githubusercontent.com/assets/1529366/5925622/7a21685e-a62a-11e4-9754-6ce63770f70f.png)

Closes #743.