### PR TITLE
fix(select): Adjust height of before content.

### DIFF
--- a/src/rxForm/rxForm.less
+++ b/src/rxForm/rxForm.less
@@ -243,7 +243,7 @@ Replace default UI of select fields and adds custom border/arrow
         right: 1px;
         top: 1px;
         width: 20px;
-        height: 94%;
+        height: 93%;
         background: #fff;
         position: absolute;
         pointer-events: none;


### PR DESCRIPTION
There is a visual bug with our select inputs.  These screenshots are taken from [this doc page](http://rackerlabs.github.io/encore-ui/#/styleguide/forms) (except locally).

using Chrome 40.0.2214.93 and Firefox 35.0.1

# Before
### Chrome
![screen shot 2015-01-27 at 2 59 26 pm](https://cloud.githubusercontent.com/assets/5414922/5927408/e46bd80e-a637-11e4-85ee-ae2da59f9dbb.png)
### Firefox
![screen shot 2015-01-27 at 2 59 46 pm](https://cloud.githubusercontent.com/assets/5414922/5927410/e5d57c04-a637-11e4-9d10-43247b256a25.png)

# After
### Chrome
![screen shot 2015-01-27 at 3 00 15 pm](https://cloud.githubusercontent.com/assets/5414922/5927411/e79b91fe-a637-11e4-9e54-c0199225d2b6.png)
![screen shot 2015-01-27 at 3 01 01 pm](https://cloud.githubusercontent.com/assets/5414922/5927417/ed68276e-a637-11e4-8332-064acb7d7835.png)
### Firefox
![screen shot 2015-01-27 at 3 00 21 pm](https://cloud.githubusercontent.com/assets/5414922/5927413/e8f2801c-a637-11e4-85bf-439373810efc.png)
![screen shot 2015-01-27 at 3 01 14 pm](https://cloud.githubusercontent.com/assets/5414922/5927421/efc8b3de-a637-11e4-8bfc-2ff24807d98d.png)