### PR TITLE
fix(rxDOMHelper): Properly wrap a select node instead of its options.

### DIFF
--- a/src/rxFloatingHeader/rxFloatingHeader.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.js
@@ -193,8 +193,8 @@ angular.module('encore.ui.rxFloatingHeader', [])
     var wrapAll = function (newParent, elms) {
 
         // Figure out if it's one element or an array
-        var isNonEmptyArray = (elms.length && elms.tagName !== 'SELECT');
-        var el = isNonEmptyArray ? elms[0] : elms;
+        var isGroupParent = ['SELECT', 'FORM'].indexOf(elms.tagName) !== -1;
+        var el = (elms.length && !isGroupParent) ? elms[0] : elms;
 
         // cache the current parent node and sibling 
         // of the first element
@@ -208,8 +208,10 @@ angular.module('encore.ui.rxFloatingHeader', [])
         // If there are other elements, wrap them. Each time
         // it will remove the element from its current parent,
         // and also from the `elms` array
-        while (isNonEmptyArray) {
-            newParent.appendChild(elms[0]);
+        if (!isGroupParent) {
+            while (elms.length) {
+                newParent.appendChild(elms[0]);
+            }
         }
 
         // If there was a sibling to the first element,

--- a/src/rxFloatingHeader/rxFloatingHeader.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.js
@@ -193,7 +193,8 @@ angular.module('encore.ui.rxFloatingHeader', [])
     var wrapAll = function (newParent, elms) {
 
         // Figure out if it's one element or an array
-        var el = elms.length ? elms[0] : elms;
+        var isNonEmptyArray = (elms.length && elms.tagName !== 'SELECT');
+        var el = isNonEmptyArray ? elms[0] : elms;
 
         // cache the current parent node and sibling 
         // of the first element
@@ -207,7 +208,7 @@ angular.module('encore.ui.rxFloatingHeader', [])
         // If there are other elements, wrap them. Each time
         // it will remove the element from its current parent,
         // and also from the `elms` array
-        while (elms.length) {
+        while (isNonEmptyArray) {
             newParent.appendChild(elms[0]);
         }
 

--- a/src/rxFloatingHeader/rxFloatingHeader.spec.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.spec.js
@@ -160,4 +160,14 @@ describe('rxDOMHelper', function () {
         expect(div.find('span.hi span.foo').text()).to.equal('Test');
         expect(div.find('span.hi span.foo').hasClass('foo')).to.be.true;
     });
+
+    it('should work for select elements', function () {
+        var select = $('<select><option class="foo">Foo</option><option class="bar">Bar</option></select>');
+        var div = $('<div></div>');
+        rxjq.wrapAll(div[0], select[0]);
+        expect(div.find('select > option.foo').text()).to.equal('Foo');
+        expect(div.find('select > option.foo').hasClass('foo')).to.be.true;
+        expect(div.find('select > option.bar').text()).to.equal('Bar');
+        expect(div.find('select > option.bar').hasClass('bar')).to.be.true;
+    });
 });


### PR DESCRIPTION
Fixes #756 
The issue is that a `select` element has a `length` property, which returns the number of options it has.  That was causing the `wrapAll` method to thing that the element was actually an array of elements.  Further, it is possible to access a specific option by its index, e.g. `selectElement[0] === optionElement`.