### PR TITLE
docs(statusColumn): update demo to reflect real status usage

### DIFF
--- a/src/rxStatusColumn/README.md
+++ b/src/rxStatusColumn/README.md
@@ -62,7 +62,7 @@ To accommodate different statuses, the `rxStatusMappings` factory includes metho
     rxStatusMappings.addGlobal({
         'RUNNING': 'ACTIVE',
         'STANDBY': 'INFO',
-        'REBOOTING': 'WARNING',
+        'SUSPENDED': 'WARNING',
         'FAILURE': 'ERROR'
     })
 

--- a/src/rxStatusColumn/docs/rxStatusColumn.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.js
@@ -5,10 +5,13 @@ function rxStatusColumnCtrl ($scope, rxStatusMappings, rxSortUtil) {
     $scope.servers = [
         { status: 'ACTIVE', title: 'ACTIVE status' },
         { status: 'ERROR', title: 'ERROR status' },
-        { status: 'BUILD', title: 'BUILD status mapped to INFO' },
-        { status: 'REBOOT', title: 'REBOOT status mapped to INFO' },
+        { status: 'DELETED', title: 'DELETED status mapped to ERROR' },
+        { status: 'UNKNOWN', title: 'UNKNOWN status mapped to ERROR' },
+        { status: 'RESCUE', title: 'RESCUE status mapped to INFO' },
         { status: 'SUSPENDED', title: 'SUSPENDED status mapped to WARNING' },
-        { status: 'INPROGRESS', title: 'INPROGRESS status mapped to PENDING' },
+        { status: 'REBUILD', title: 'REBUILD status mapped to PENDING' },
+        { status: 'RESIZE', title: 'RESIZE status mapped to PENDING' },
+        { status: 'MIGRATING', title: 'MIGRATING status mapped to PENDING' },
         { status: 'DELETING', title: 'DELETING status mapped to PENDING, using `fooApi` mapping', api:'fooApi' }
     ];
 
@@ -16,10 +19,10 @@ function rxStatusColumnCtrl ($scope, rxStatusMappings, rxSortUtil) {
     rxStatusMappings.addGlobal({
         'DELETING': 'PENDING'
     });
-    rxStatusMappings.mapToInfo(['BUILD', 'REBOOT']);
+    rxStatusMappings.mapToInfo('RESCUE');
     rxStatusMappings.mapToWarning('SUSPENDED');
-    rxStatusMappings.mapToPending('INPROGRESS');
-
+    rxStatusMappings.mapToPending(['REBUILD','RESIZE','MIGRATING']);
+    rxStatusMappings.mapToError(['DELETED', 'UNKNOWN']);
     rxStatusMappings.addAPI('fooApi', { 'DELETING': 'PENDING' });
     rxStatusMappings.mapToPending('SomeApiSpecificStatus', 'fooApi');
     $scope.sortCol = function (predicate) {

--- a/src/rxStatusColumn/docs/rxStatusColumn.midway.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.midway.js
@@ -127,34 +127,14 @@ describe('rxStatusColumn', function () {
 
         describe('info cells', function () {
 
-            describe('build cell', function () {
+            describe('rescue cell', function () {
 
                 before(function () {
-                    status = tablePageObject.row(1).status;
+                    status = tablePageObject.row(6).status;
                 });
 
                 it('should have a status by type', function () {
-                    expect(status.byType).to.eventually.equal(statuses.build);
-                });
-
-                it('should not have a status by icon', function () {
-                    expect(status.byIcon).to.eventually.equal(icons.info);
-                });
-
-                it('should have a status by color', function () {
-                    expect(status.byColor).to.eventually.equal(colors.info);
-                });
-
-            });
-
-            describe('reboot cell', function () {
-
-                before(function () {
-                    status = tablePageObject.row(5).status;
-                });
-
-                it('should have a status by type', function () {
-                    expect(status.byType).to.eventually.equal(statuses.reboot);
+                    expect(status.byType).to.eventually.equal(statuses.rescue);
                 });
 
                 it('should not have a status by icon', function () {
@@ -171,14 +151,14 @@ describe('rxStatusColumn', function () {
 
         describe('pending cells', function () {
 
-            describe('in progress cell', function () {
+            describe('migrating cell', function () {
 
                 before(function () {
                     status = tablePageObject.row(4).status;
                 });
 
                 it('should have a status by type', function () {
-                    expect(status.byType).to.eventually.equal(statuses.inProgress);
+                    expect(status.byType).to.eventually.equal(statuses.migrating);
                 });
 
                 it('should have a status by icon', function () {

--- a/src/rxStatusColumn/rxStatusColumn.page.js
+++ b/src/rxStatusColumn/rxStatusColumn.page.js
@@ -100,12 +100,15 @@ exports.rxStatusColumn = {
 
     statuses: {
         active: 'ACTIVE',
-        build: 'BUILD',
+        deleted: 'DELETED',
         deleting: 'DELETING',
         error: 'ERROR',
-        inProgress: 'INPROGRESS',
-        reboot: 'REBOOT',
-        suspended: 'SUSPENDED'
+        migrating: 'MIGRATING',
+        rebuild: 'REBUILD',
+        rescue: 'RESCUE',
+        resize: 'RESIZE',
+        suspended: 'SUSPENDED',
+        unknown: 'UNKNOWN'
     },
 
     icons: {


### PR DESCRIPTION
Updated statuses here to provide more real-world examples of how we use them, so new teams are more likely to understand and utilize status mappings correctly.