### PR TITLE
fix(flexbox): normalize flexbox mixins and usage

### DIFF
--- a/src/rxApp/rxApp.less
+++ b/src/rxApp/rxApp.less
@@ -7,16 +7,16 @@
     @appMenuWidth: 300px;
 
     min-height: 100%;
-    .flexbox-display();
-    .flexbox-direction(row);
+    .flexbox();
+    .flex-direction(row);
     background: @appBg;
 
     .rx-app-content {
-        .flexbox(1 1 0);
+        .flex(1 1 0);
     }
 
     .rx-app-menu {
-        .flexbox(0 0 @appMenuWidth);
+        .flex(0 0 @appMenuWidth);
         color: #fff;
         font-size: 15px;
         font-weight: 300;
@@ -97,7 +97,7 @@
 
     &.collapsed {
         .rx-app-menu {
-            .flexbox(0 0 25px);
+            .flex(0 0 25px);
             padding-bottom: 0;
             position: relative;
         }

--- a/src/rxForm/rxForm.less
+++ b/src/rxForm/rxForm.less
@@ -57,16 +57,15 @@ field-prefix, field-suffix and field-description are all optional.
 
 .form-item {
     margin-top: 5px;
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: baseline;
+    .flexbox();
+    .flex-flow(row nowrap);
+    .justify-content(flex-start);
+    .align-items(baseline);
 }
 
 .text-area-label {
     &.form-item {
-        align-items: flex-start;
-        -webkit-align-items: flex-start;
-        -moz-align-items: flex-start;
+        .align-items(flex-start);
     }
 }
 
@@ -86,17 +85,15 @@ field-prefix, field-suffix and field-description are all optional.
 .field-legend, {
     color: @subduedTitle;
     font-size: 1.1em;
-    flex: 0 0 @fieldLabelWidth;
+    .flex(0 0 @fieldLabelWidth);
 }
 
 .field-content {
-    display: flex;
-    flex: 1 auto;
-
-    -webkit-flex-flow: row wrap;
-    flex-flow: row wrap;
-    justify-content: flex-start;
-    align-items: center;
+    .flexbox();
+    .flex(1 auto);
+    .flex-flow(row wrap);
+    .justify-content(flex-start);
+    .align-items(center);
 
     .field-prefix,
     .field-suffix {
@@ -110,7 +107,7 @@ field-prefix, field-suffix and field-description are all optional.
     }
 
     .field-description {
-        flex: 1 100%;
+        .flex(1 100%);
         font-size: 0.8em;
         font-style: italic;
         margin-top: 5px;
@@ -394,13 +391,13 @@ Replace default UI of select fields and adds custom border/arrow
 
 .rx-form.layout-compressed {
     .rx-form-row {
-        display: flex;
-        flex-wrap: nowrap;
-        flex: 1 auto;
+        .flexbox();
+        .flex-wrap(nowrap);
+        .flex(1 auto);
 
         .form-item {
             padding: 0px 3px;
-            flex: 1;
+            .flex(1);
         }
     }
 

--- a/src/rxPaginate/rxPaginate.less
+++ b/src/rxPaginate/rxPaginate.less
@@ -75,9 +75,8 @@ Add the class `disabled` to classes `pagination-first`, `pagination-prev`, `pagi
 
 .rx-paginate {
     .pagination {
-        display: flex;
-        flex-direction: row;
-        flex-flow: row;
+        .flexbox();
+        .flex-flow(row nowrap);
         padding-left: 0;
         width: 100%;
     }

--- a/src/styles/flexbox.less
+++ b/src/styles/flexbox.less
@@ -1,62 +1,121 @@
-/*
-FlexBox Columns
-*/
-
-.flexbox-direction(@direction: row) {
-    -webkit-flex-direction: @direction;
-    -moz-flex-direction: @direction;
-    -ms-flex-direction: @direction;
-    flex-direction: @direction;
+// pulled from https://github.com/CITguy/moar-elements/blob/master/flexbox.less
+/* Flexbox LESS Elements
+ *
+ * This file will contain those mixins that pertain to the flexbox W3C Candidate Recommendation
+ *
+ * Useful Links:
+ *  http://www.w3.org/TR/css3-flexbox/
+ *  http://css-tricks.com/snippets/css/a-guide-to-flexbox/
+ *  http://caniuse.com/flexbox
+ *  https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes
+ *
+ */
+.flexbox {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
 }
 
-.flexbox-order(@order: 0) {
-    -webkit-box-order: @order;
-    -mox-box-order: @order;
-    -webkit-flex-order: @order;
-    order: @order;
+
+/* NOTE:
+ *  Firefox does not support 'flex-flow' or 'flex-wrap' properties.
+ *  'flex-direction' will be the only usable property by Firefox 27 and earlier for this purpose.
+ */
+.flex-flow(...) {
+  -webkit-flex-flow: @arguments;
+     -moz-flex-flow: @arguments;
+      -ms-flex-flow: @arguments;
+          flex-flow: @arguments;
 }
 
-.flexbox-wrap(@wrap: nowrap) {
-    -webkit-box-wrap: @wrap;
-    -moz-box-wrap: @wrap;
-    flex-wrap: @wrap;
+
+/* NOTE:
+ *  Firefox does not support the 'flex-wrap' property.
+ *  This property defaults to 'nowrap'.
+ */
+.flex-wrap(...) {
+  -webkit-flex-wrap: @arguments;
+     -moz-flex-wrap: @arguments;
+      -ms-flex-wrap: @arguments;
+          flex-wrap: @arguments;
 }
 
-.flexbox-display() {
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
-    display: flex;
+
+.flex(...) {
+  -webkit-flex: @arguments;
+     -moz-flex: @arguments;
+      -ms-flex: @arguments;
+          flex: @arguments;
 }
 
-.flexbox(@count: 1) {
-    -webkit-box-flex: @count;
-    -moz-box-flex: @count;
-    -webkit-flex: @count;
-    -ms-flex: @count;
-    flex: @count;
+
+.order(...) {
+  -webkit-box-ordinal-group: @arguments;
+     -moz-box-ordinal-group: @arguments;
+             -ms-flex-order: @arguments;
+              -webkit-order: @arguments;
+                      order: @arguments;
 }
 
-.flex-flow(@direction: row, @wrap: nowrap) {
-    .flexbox-direction(@direction);
-    .flexbox-wrap(@wrap);
+
+.flex-direction(...) {
+  -webkit-flex-direction: @arguments;
+     -moz-flex-direction: @arguments;
+      -ms-flex-direction: @arguments;
+          flex-direction: @arguments;
 }
 
-.flexbox-pack(@pack: start) {
-    -webkit-box-pack: @pack;
-    -moz-box-pack: @pack;
-    -webkit-flex-pack: @pack;
+
+.flex-basis(...) {
+  -webkit-flex-basis: @arguments;
+     -moz-flex-basis: @arguments;
+      -ms-flex-basis: @arguments;
+          flex-basis: @arguments;
 }
 
-.flexbox-align(@align: stretch) {
-    -webkit-box-pack: @align;
-    -moz-box-pack: @align;
-    -webkit-flex-pack: @align;
+
+.flex-grow(...) {
+  -webkit-flex-grow: @arguments;
+     -moz-flex-grow: @arguments;
+      -ms-flex-grow: @arguments;
+          flex-grow: @arguments;
 }
 
-.flexbox-grow(@ratio: 1) {
-    -webkit-flex-grow: @ratio;
-    -moz-flex-grow: @ratio;
-    -webkit-box-grow: @ratio;
+
+.flex-shrink(...) {
+  -webkit-flex-shrink: @arguments;
+     -moz-flex-shrink: @arguments;
+      -ms-flex-shrink: @arguments;
+          flex-shrink: @arguments;
+}
+
+
+.justify-content(...) {
+  -webkit-justify-content: @arguments;
+     -moz-justify-content: @arguments;
+          justify-content: @arguments;
+}
+
+
+.align-items(...) {
+  -webkit-align-items: @arguments;
+     -moz-align-items: @arguments;
+      -ms-align-items: @arguments;
+          align-items: @arguments;
+}
+
+
+.align-content(...) {
+  -webkit-align-content: @arguments;
+     -moz-align-content: @arguments;
+          align-content: @arguments;
+}
+
+
+.align-self(...) {
+  -webkit-align-self: @arguments;
+     -moz-align-self: @arguments;
+          align-self: @arguments;
 }

--- a/src/tabs/tabs.less
+++ b/src/tabs/tabs.less
@@ -34,12 +34,12 @@ Provides styling for the Angular-UI tab HTML
 ```
 */
 .nav-tabs {
-    display: flex;
+    .flexbox();
     border-bottom: 9px solid @tabBorder;
     clear: both;
 
     li {
-        flex: 0 0 auto;
+        .flex(0 0 auto);
         font-size: 14px;
     }
 


### PR DESCRIPTION
* pulled in better flexbox mixins from https://github.com/CITguy/moar-elements/blob/master/flexbox.less
  * majority of mixins match non-prefixed properties
* replaced prefixed properties with mixins
* Modified existing mixins to use new mixin definitions
  * .flexbox-direction() -> .flex-direction()
  * .flexbox-order() -> .order()
  * .flexbox-display() -> .flexbox()
  * .flexbox-wrap() -> .flex-wrap()
  * .flexbox-pack() -> .justify-content()
  * .flexbox-align() -> .align-items()
  * .flexbox-grow() -> .flex-grow()
  * .flexbox() -> .flex()