### PR TITLE
chore(npm): replace node-markdown with marked

### DIFF
--- a/grunt-tasks/modules.js
+++ b/grunt-tasks/modules.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 module.exports = function (grunt) {
-    var markdown = require('node-markdown').Markdown;
+    var markdown = require('marked');
 
     function enquote (str) {
         return '\'' + str + '\'';
@@ -28,6 +28,10 @@ module.exports = function (grunt) {
             });
         }
 
+        function parseMarkdown (text) {
+            return markdown(text);
+        }
+
         var module = {
             name: name,
             moduleName: enquote('encore.ui.' + name),
@@ -37,7 +41,7 @@ module.exports = function (grunt) {
             tplJsFiles: grunt.file.expand('templates/' + name + '/templates/*.html'),
             dependencies: dependenciesForModule(name),
             docs: {
-                md: grunt.file.expand('src/' + name + '/*.md').map(grunt.file.read).map(markdown).join('\n'),
+                md: grunt.file.expand('src/' + name + '/*.md').map(grunt.file.read).map(parseMarkdown).join('\n'),
                 js: grunt.file.expand('src/' + name + '/docs/!(*.midway).js').map(grunt.file.read).join('\n'),
                 html: grunt.file.expand('src/' + name + '/docs/*.html').map(grunt.file.read).join('\n'),
                 less: grunt.file.expand('src/' + name + '/*.less').map(grunt.file.read).join('\n'),
@@ -140,7 +144,5 @@ module.exports = function (grunt) {
 
         // Set the copy task to process via grunt template
         grunt.config('copy.demohtml.options.process', grunt.template.process);
-
-
     });
 };

--- a/grunt-tasks/options/copy.js
+++ b/grunt-tasks/options/copy.js
@@ -31,7 +31,7 @@ module.exports = {
         }],
         options: {
             process: function (content) {
-                var markdown = require('node-markdown').Markdown;
+                var markdown = require('marked');
 
                 // Replace the [![Build Status...]] line with an empty string
                 // (note that /m makes $ match newlines

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "karma-requirejs": "~0.2.2",
     "load-grunt-tasks": "~2.0.0",
     "lodash": "~2.4.1",
+    "marked": "^0.3.3",
     "mocha": "^2.1.0",
     "moment": "~2.9.0",
-    "node-markdown": "0.1.1",
     "protractor": "latest",
     "semver": "~4.2.0"
   }


### PR DESCRIPTION
Specifically to fix:

```
npm WARN deprecated node-markdown@0.1.1: highlight is deprecated in favor of "highliht.js"
```

[`node-markdown`](https://github.com/andris9/node-markdown) has been abandoned. Maintainer suggests replacing in favor of [`marked`](https://www.npmjs.com/package/marked).

* replace `node-markdown` with `marked`