### PR TITLE
docs(tests): Publish after creating docs

### DIFF
--- a/grunt-tasks/rxPageObjects.js
+++ b/grunt-tasks/rxPageObjects.js
@@ -4,8 +4,8 @@ module.exports = function (grunt) {
         'concat:rxPageObjectsExercises',
         'shell:rxPageObjects',
         'copy:rxPageObjects',
-        'shell:npmPublish',
         'jsdoc2md:rxPageObjects',
+        'shell:npmPublish',
         'clean:rxPageObjects'
     ]);
 };


### PR DESCRIPTION
Didn't catch this in the big rebase operation on Thursday. This is why there are no docs in the npm module home page.