### PR TITLE
feat(rxModalAction): Make footer content stateful.

### DIFF
--- a/src/rxModalAction/README.md
+++ b/src/rxModalAction/README.md
@@ -28,24 +28,19 @@ The `<rx-modal-form>` directive is helpful for providing a common format to form
 
 - Title
 - Subtitle
-- isLoading
- - whether the modal form should have a 'loading' message by default. This is usually tied in with a `pre-hook` to load data
-- submitText
- - Override of the 'submit' button text
-- cancelText
- - Override of the 'cancel' button text
-- returnText
- - Override of the 'return' button text
+- isLoading - whether the modal form should have a 'loading' message by default. This is usually tied in with a `pre-hook` to load data
+- submitText - Override of the 'submit' button text
+- cancelText - Override of the 'cancel' button text
+- returnText - Override of the 'return' button text
 
- This directive also provides an 'autofocus' mechanism, which will move the keyboard focus cursor to the first 'tabbable' input available in the form.
+This directive also provides an 'autofocus' mechanism, which will move the keyboard focus cursor to the first 'tabbable' input available in the form.
 
 ## rxModalFooter
 
 When a modal has multiple views or kicks off a process that should be tracked within the modal, the `<rx-modal-footer>` directive should be used.  Its attributes are:
 
 - state
-- global
- - This is just a flag and takes no value.
+- global - This is just a flag and takes no value.
 
 Modal Footers should be defined in the same template as the Modal Form unless the footer is global, in which case it should be loaded in `module.run()`.  Global footers can be used in any subsequent modal by changing to the state they were defined with.
 

--- a/src/rxModalAction/README.md
+++ b/src/rxModalAction/README.md
@@ -34,5 +34,20 @@ The `<rx-modal-form>` directive is helpful for providing a common format to form
  - Override of the 'submit' button text
 - cancelText
  - Override of the 'cancel' button text
+- returnText
+ - Override of the 'return' button text
 
  This directive also provides an 'autofocus' mechanism, which will move the keyboard focus cursor to the first 'tabbable' input available in the form.
+
+## rxModalFooter
+
+When a modal has multiple views or kicks off a process that should be tracked within the modal, the `<rx-modal-footer>` directive should be used.  Its attributes are:
+
+- state
+- global
+ - This is just a flag and takes no value.
+
+Modal Footers should be defined in the same template as the Modal Form unless the footer is global, in which case it should be loaded in `module.run()`.  Global footers can be used in any subsequent modal by changing to the state they were defined with.
+
+The modal's controller also inherits the `setState()` method on the scope, which should be used to toggle different views or footers. See the Multi-View Example of this design pattern's usage.
+The default `editing` state shows the standard submit and cancel buttons, and the only other state provided by the framework is `complete` (showing the return button).

--- a/src/rxModalAction/docs/rxModalAction.html
+++ b/src/rxModalAction/docs/rxModalAction.html
@@ -15,16 +15,17 @@
         <rx-modal-action
             classes="button"
             controller="rxModalStateCtrl"
-            template-url="multiview.html">
+            template-url="multiview.html"
+            disable-esc>
             Multi-View Example
         </rx-modal-action>
     </p>
 
     <script type="text/ng-template" id="changePassword.html">
         <rx-modal-form title="Change {{user}} Admin Password"
-        submit-text="Submit Password"
-        cancel-text="Cancel Request"
-        subtitle="Please read instructions below">
+            submit-text="Submit Password"
+            cancel-text="Cancel Request"
+            subtitle="Please read instructions below">
             <h1>Password must:</h1>
             <ul class="list">
                 <li>have at least one uppercase letter</li>
@@ -52,7 +53,7 @@
                 </div>
                 <div ng-switch-when="confirm">
                     <h3 class="title">Are you sure you want to continue?</h3>
-                    <p ng-click="confirm()">This action cannot be undone.</p>
+                    <p>This action cannot be undone.</p>
                 </div>
                 <p ng-switch-when="pending">Man, this takes forever!</p>
                 <p ng-switch-when="complete">Nothing left to do here.</p>

--- a/src/rxModalAction/docs/rxModalAction.html
+++ b/src/rxModalAction/docs/rxModalAction.html
@@ -11,6 +11,15 @@
         </rx-modal-action>
     </p>
 
+    <p>
+        <rx-modal-action
+            classes="button"
+            controller="rxModalStateCtrl"
+            template-url="multiview.html">
+            Multi-View Example
+        </rx-modal-action>
+    </p>
+
     <script type="text/ng-template" id="changePassword.html">
         <rx-modal-form title="Change {{user}} Admin Password"
         submit-text="Submit Password"
@@ -31,4 +40,29 @@
             </rx-form-item>
         </rx-modal-form>
     </script>
+
+    <script type="text/ng-template" id="multiview.html">
+        <rx-modal-form title="State-Changing Modal"
+            submit-text="Send Request"
+            return-text="Return to rxModalAction docs">
+            <rx-notifications stack="modal"></rx-notifications>
+            <div ng-switch="state">
+                <div ng-switch-when="editing">
+                    <p>Press "Send Request" to start the fake process.</p>
+                </div>
+                <div ng-switch-when="confirm">
+                    <h3 class="title">Are you sure you want to continue?</h3>
+                    <p ng-click="confirm()">This action cannot be undone.</p>
+                </div>
+                <p ng-switch-when="pending">Man, this takes forever!</p>
+                <p ng-switch-when="complete">Nothing left to do here.</p>
+            </div>
+        </rx-modal-form>
+
+        <rx-modal-footer state="confirm">
+            <button class="button" ng-click="confirm()">Yes</button>
+            <button class="button cancel" ng-click="setState('editing')">No</button>
+        </rx-modal-footer>
+    </script>
+
 </div>

--- a/src/rxModalAction/docs/rxModalAction.js
+++ b/src/rxModalAction/docs/rxModalAction.js
@@ -10,3 +10,34 @@ function rxModalActionCtrl ($scope) {
         $scope.password = fields.password;
     };
 }
+
+function rxModalStateCtrl ($scope, $modalInstance, $timeout, rxNotify) {
+    function complete () {
+        $scope.loaded = true;
+        $scope.setState('complete');
+        rxNotify.add('Operation Success!', {
+            stack: 'modal',
+            type: 'success'
+        });
+    }
+
+    $scope.submit = function () {
+        $scope.setState('confirm');
+    }
+
+    $scope.confirm = function () {
+        $scope.loaded = false;
+        $scope.setState('pending');
+        rxNotify.add('Performing Operation...', {
+            stack: 'modal',
+            loading: true,
+            dismiss: [$scope, 'loaded']
+        });
+        $timeout(complete, 2000);
+    }
+
+    $scope.cancel = function () {
+        rxNotify.clear('modal');
+        $modalInstance.dismiss();
+    }
+}

--- a/src/rxModalAction/rxModalAction.js
+++ b/src/rxModalAction/rxModalAction.js
@@ -1,4 +1,7 @@
 angular.module('encore.ui.rxModalAction', ['ui.bootstrap'])
+.run(function ($compile, $templateCache) {
+    $compile($templateCache.get('templates/rxModalFooters.html'));
+})
 /**
 * @ngdoc directive
 * @name encore.ui.rxModalAction:rxModalForm
@@ -17,7 +20,7 @@ angular.module('encore.ui.rxModalAction', ['ui.bootstrap'])
 * @example
 * <rx-modal-form title="My Form" is-loading="true" submit-text="Yes!"></rx-modal-form>
 */
-.directive('rxModalForm', function ($timeout) {
+.directive('rxModalForm', function ($timeout, $compile, rxModalFooterTemplates) {
     return {
         transclude: true,
         templateUrl: 'templates/rxModalActionForm.html',
@@ -28,10 +31,16 @@ angular.module('encore.ui.rxModalAction', ['ui.bootstrap'])
             isLoading: '=',
             submitText: '@',
             cancelText: '@',
+            returnText: '@',
             defaultFocus: '@'
         },
+        controller: function ($scope, $element) {
+            _.assign($scope.$parent, _.pick($scope, ['submitText', 'cancelText', 'returnText']));
+            $compile(rxModalFooterTemplates.flush())($scope.$parent, function (clone) {
+                $element.children('div.modal-footer').append(clone);
+            });
+        },
         link: function (scope, element) {
-
             var focusSelectors = {
                 'cancel': 'button.cancel',
                 'submit': 'button.submit',
@@ -43,30 +52,24 @@ angular.module('encore.ui.rxModalAction', ['ui.bootstrap'])
                 if (focus === 'cancel' || focus === 'submit') {
                     formSelector = element[0].querySelector('.modal-footer');
                     focusElement = formSelector.querySelector(focusSelectors[focus]);
-                    // wait for $modalWindow to run so it doesn't steal focus
-                    $timeout(function () {
-                        if (focusElement) {
-                            focusElement.focus();
-                        }
-                    }, 10);
                 } else {
                     focus = 'firstTabbable';
                     formSelector = element[0].querySelector('.modal-form');
-                    // Give content some time to load to get first tabbable
-                    $timeout(function () {
-                        // first check for an element with autofocus
-                        focusElement = formSelector.querySelector('[autofocus]');
-                        if (!focusElement) {
-                            focusElement = formSelector.querySelector(focusSelectors[focus]);
-                        }
-                        if (focusElement) {
-                            focusElement.focus();
-                        }
-                    }, 400);
+                    // first check for an element with autofocus
+                    focusElement = formSelector.querySelector('[autofocus]');
+                    if (!focusElement) {
+                        focusElement = formSelector.querySelector(focusSelectors[focus]);
+                    }
+                }
+                if (focusElement) {
+                    focusElement.focus();
                 }
             };
 
-            setFocus(scope.defaultFocus);
+            // Give content some time to load to set the focus
+            $timeout(function () {
+                setFocus(scope.defaultFocus);
+            }, 400);
 
             // Remove the title attribute, as it will cause a popup to appear when hovering over page content
             // @see https://github.com/rackerlabs/encore-ui/issues/256
@@ -84,6 +87,62 @@ angular.module('encore.ui.rxModalAction', ['ui.bootstrap'])
 
     // cancel out of the modal if the route is changed
     $rootScope.$on('$routeChangeSuccess', $modalInstance.dismiss);
+})
+.factory('rxModalFooterTemplates', function () {
+    var globals = {};
+    var locals = {};
+
+    return {
+        flush: function () {
+            var states = _.assign({}, globals, locals);
+            locals = {};
+            return _.values(states).reduce(function (html, template) {
+                return html + template;
+            }, '<div ng-switch="state">') + '</div>';
+        },
+        add: function (state, template, options) {
+            if (options.global) {
+                globals[state] = template;
+            } else {
+                locals[state] = template;
+            }
+        }
+    };
+})
+/**
+* @ngdoc directive
+* @name encore.ui.rxModalAction:rxModalFooter
+* @restrict E
+* @scope
+* @description
+* Define a footer for the next modal.
+*
+* @param {string} [state] The content will be shown in the footer when this state is activated.
+* @param {string} [global] If the global attribute is present, then this footer can be used
+*                          in other modals. This attribute takes no values.
+*
+* @example
+* <rx-modal-footer state="confirm">
+*     <button class="button" ng-click="setState('pending')">I understand the risks.</button>
+* </rx-modal-footer>
+*/
+.directive('rxModalFooter', function (rxModalFooterTemplates) {
+    return {
+        restrict: 'E',
+        compile: function (element, attrs) {
+            var footer = angular.element('<div></div>')
+                .append(element.html())
+                .attr('ng-switch-when', attrs.state);
+
+            rxModalFooterTemplates.add(attrs.state, footer[0].outerHTML, {
+               global: attrs.global !== undefined
+            });
+
+            return function (scope, el) {
+                el.remove();
+            };
+        }
+    };
 })
 /**
 * @ngdoc directive
@@ -150,6 +209,11 @@ angular.module('encore.ui.rxModalAction', ['ui.bootstrap'])
                 // Note: don't like having to create a 'fields' object in here,
                 // but we need it so that the child input fields can bind to the modalScope
                 scope.fields = {};
+
+                scope.setState = function (state) {
+                    scope.state = state;
+                };
+                scope.setState('editing');
 
                 // Since we don't want to isolate the scope, we have to eval our attr instead of using `&`
                 // The eval will execute function (if it exists)

--- a/src/rxModalAction/templates/rxModalActionForm.html
+++ b/src/rxModalAction/templates/rxModalActionForm.html
@@ -7,7 +7,4 @@
     <div ng-show="$parent.isLoading" class="loading" rx-spinner="dark" toggle="$parent.isLoading"></div>
     <form ng-hide="$parent.isLoading" name="$parent.modalActionForm" class="modal-form rx-form" ng-transclude></form>
 </div>
-<div class="modal-footer">
-    <button class="button submit" ng-click="$parent.submit()" type="submit" ng-disabled="$parent.modalActionForm.$invalid">{{submitText || "Submit"}}</button>
-    <button class="button cancel" ng-click="$parent.cancel()">{{cancelText || "Cancel"}}</button>
-</div>
+<div class="modal-footer"></div>

--- a/src/rxModalAction/templates/rxModalFooters.html
+++ b/src/rxModalAction/templates/rxModalFooters.html
@@ -1,0 +1,8 @@
+<rx-modal-footer state="editing" global>
+    <button class="button submit" ng-click="submit()" type="submit" ng-disabled="$parent.modalActionForm.$invalid">{{submitText || "Submit"}}</button>
+    <button class="button cancel" ng-click="cancel()">{{cancelText || "Cancel"}}</button>
+</rx-modal-footer>
+
+<rx-modal-footer state="complete" global>
+    <button class="button" ng-click="cancel()">{{returnText || "Return"}}</button>
+</rx-modal-footer>


### PR DESCRIPTION
This PR addresses issue #799, and I suppose #814 to some degree.  It is intended for modals that kick of tracked processes to hide the submit and cancel buttons after the process is kicked off.  It could possibly be used/adapted for implementing a wizard in the modal.

This solution is backwards compatible with existing modals, meaning existing (and some future) uses of  `rxModalForm` do not have to worry about manipulating the modal's state.

![screen shot 2015-02-25 at 9 48 42 am](https://cloud.githubusercontent.com/assets/5414922/6374010/bf677ea2-bcd3-11e4-8d57-f420ffedd715.png)
![screen shot 2015-02-25 at 9 48 49 am](https://cloud.githubusercontent.com/assets/5414922/6374012/c0efd29c-bcd3-11e4-9e50-a6523bf7dea1.png)
![screen shot 2015-02-25 at 9 49 07 am](https://cloud.githubusercontent.com/assets/5414922/6374016/c23f8016-bcd3-11e4-80b8-8e02a60fdd07.png)
![screen shot 2015-02-25 at 9 48 56 am](https://cloud.githubusercontent.com/assets/5414922/6374017/c3c07daa-bcd3-11e4-810a-fb2298ac0524.png)
