### PR TITLE
fix(typeahead): Show typeahead in front of textarea.

### DIFF
--- a/src/typeahead/typeahead.less
+++ b/src/typeahead/typeahead.less
@@ -10,6 +10,7 @@
     background: @white;
     border: 1px solid #ccc;
     padding: 6px 0;
+    z-index: 3; // Will display over a textarea element
 
     a {
         display: block;


### PR DESCRIPTION
Fixes #813.

## Before
![screen shot 2015-02-25 at 10 32 32 am](https://cloud.githubusercontent.com/assets/5414922/6376127/a6fa1574-bce1-11e4-8fe9-2f84b6082e13.png)
## After
![screen shot 2015-02-25 at 11 29 27 am](https://cloud.githubusercontent.com/assets/5414922/6376129/a8016a76-bce1-11e4-8bbb-79ce39759890.png)