### PR TITLE
fix(rxPageObjects): Exercise written with incompatible require path.

### DIFF
--- a/grunt-tasks/options/concat.js
+++ b/grunt-tasks/options/concat.js
@@ -43,7 +43,7 @@ module.exports = {
             banner: removeFromExercises.join(''),
             process: function (src) {
                 // replace all exercise require statements from src/ directory to index.js (published version)
-                src = src.replace(/require\('\.\/(.\w+\.page)'\)/g, 'require(\'./index\')');
+                src = src.replace(/require\('\.\/(.\w+\.page)'\)(?:\.js)?/g, 'require(\'./index\')');
                 removeFromExercises.forEach(function (toRemove) {
                     // a regex is faster, but this is less work for me
                     src = src.replace(toRemove, '');

--- a/src/rxCharacterCount/rxCharacterCount.exercise.js
+++ b/src/rxCharacterCount/rxCharacterCount.exercise.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var rxCharacterCount = require('./rxCharacterCount.page.js').rxCharacterCount;
+var rxCharacterCount = require('./rxCharacterCount.page').rxCharacterCount;
 
 /**
    rxCharacterCount exercises.


### PR DESCRIPTION
The [regex rule for concatenation](https://github.com/rackerlabs/encore-ui/blob/master/grunt-tasks/options/concat.js#L46) does not support having the `.js` file extension.  This breaks v1.9.0 of the npm module.
```
$ node
> require('rx-page-objects')
Error: Cannot find module './rxCharacterCount.page.js'
```