### PR TITLE
feat(rxCharacterCount): Highlight characters over the limit.

### DIFF
--- a/src/rxCharacterCount/README.md
+++ b/src/rxCharacterCount/README.md
@@ -11,3 +11,5 @@ The 254 and 10 values are both configurable. To change the maximum number of cha
 ### Leading and Trailing characters ###
 By default, any text field using `ng-model` has `ng-trim="true"` applied to it. This means that any leading and trailing spaces/blanks in your text field will be ignored. They will not count towards the remaining character count. If you want it to count leading/trailing spaces, then just add `ng-trim="false"` to your `<textarea>`.
 
+### Styling ###
+When specifying a width other than the default, you should style some built-in classes in addition to the text field itself. As in the demo, the `.input-highlighting` class should have the same width as the text field, and the `.character-count-wrapper` should be used to correctly position the counter.

--- a/src/rxCharacterCount/rxCharacterCount.exercise.js
+++ b/src/rxCharacterCount/rxCharacterCount.exercise.js
@@ -69,6 +69,10 @@ exports.rxCharacterCount = function (options) {
             expect(component.isOverLimit()).to.eventually.be.false;
         });
 
+        it('should not show any highlights on an empty text box', function () {
+            expect(component.overLimitText).to.eventually.equal('');
+        });
+
         var belowNearLimitLength = options.maxCharacters + 1 - options.nearLimit;
         it('should not set the near-limit class when ' + belowNearLimitLength + ' characters are entered', function () {
             component.comment = Array(belowNearLimitLength).join('a');
@@ -93,6 +97,10 @@ exports.rxCharacterCount = function (options) {
             expect(component.isOverLimit()).to.eventually.be.false;
         });
 
+        it('should not highlight any characters', function () {
+            expect(component.overLimitText).to.eventually.equal('');
+        });
+
         it('should have zero remaining characters', function () {
             expect(component.remaining).to.eventually.equal(0);
         });
@@ -103,8 +111,17 @@ exports.rxCharacterCount = function (options) {
             expect(component.isOverLimit()).to.eventually.be.true;
         });
 
+        it('should highlight the characters over the limit', function () {
+            expect(component.overLimitText).to.eventually.equal('a');
+        });
+
         it('should display a negative number when the over-limit class is reached', function () {
             expect(component.remaining).to.eventually.equal(-1);
+        });
+
+        it('should clear the over-limit text highlighting when the text is reduced', function () {
+            component.comment = 'a';
+            expect(component.overLimitText).to.eventually.equal('');
         });
 
         var whitespace = '    leading and trailing whitespace    ';

--- a/src/rxCharacterCount/rxCharacterCount.less
+++ b/src/rxCharacterCount/rxCharacterCount.less
@@ -28,6 +28,7 @@
     position: relative;
     background-color: #ffffff;
     input, textarea {
+      position: relative; // Ensure the input is layered over the highlighting without z-index
       background-color: transparent;
       resize: none;
       .inputBorderPadding;

--- a/src/rxCharacterCount/rxCharacterCount.less
+++ b/src/rxCharacterCount/rxCharacterCount.less
@@ -7,7 +7,8 @@
 // custom wrappers with custom widths can be set.
 .character-count-wrapper {
     width: 375px;
-    textarea {
+    // These two selectors must always be styled with the same width.
+    .input-highlighting, textarea {
         width: 370px;
     }
 }
@@ -20,5 +21,27 @@
     }
     &.over-limit {
         color: #fc0f1d;
+    }
+}
+
+.counted-input-wrapper {
+    position: relative;
+    background-color: #ffffff;
+    input, textarea {
+      background-color: transparent;
+      resize: none;
+      .inputBorderPadding;
+    }
+    .input-highlighting {
+        position: absolute;
+        top: 4px;
+        left: 6px;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        color: transparent;
+        .over-limit-text {
+            background-color: @warnRed;
+            opacity: 0.3;
+        }
     }
 }

--- a/src/rxCharacterCount/rxCharacterCount.page.js
+++ b/src/rxCharacterCount/rxCharacterCount.page.js
@@ -6,9 +6,15 @@ var Page = require('astrolabe').Page;
  */
 var rxCharacterCount = {
 
+    eleParent: {
+        get: function () {
+            return this.rootElement.element(by.xpath('../..'));
+        }
+    },
+
     lblRemaining: {
         get: function () {
-            return this.rootElement.element(by.xpath('..')).element(by.binding('remaining'));
+            return this.eleParent.element(by.binding('remaining'));
         }
     },
 
@@ -81,6 +87,15 @@ var rxCharacterCount = {
             return this.lblRemaining.getAttribute('class').then(function (classNames) {
                 return classNames.indexOf('over-limit') > -1;
             });
+        }
+    },
+
+    /**
+       @returns {String} The characters that are over the limit.
+     */
+    overLimitText: {
+        get: function () {
+            return this.eleParent.$('.over-limit-text').getText();
         }
     }
 

--- a/src/rxForm/rxForm.less
+++ b/src/rxForm/rxForm.less
@@ -1,10 +1,5 @@
 @import 'vars';
-
-.inputBorderPadding() {
-    border: 1px solid @inputBorder;
-    padding: 3px 5px;
-}
-
+@import 'mixins';
 
 /* Form Fields & Fieldsets */
 

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -69,3 +69,8 @@
     -webkit-transition: all .2s;
     transition: all .2s;
 }
+
+.inputBorderPadding() {
+    border: 1px solid @inputBorder;
+    padding: 3px 5px;
+}


### PR DESCRIPTION
Fixes #820 
There are some concerns about the accessibility of using a `contenteditable` element instead of an input, so instead a background is provided for the input.  A drawback of this approach is that the width of the background must be the same as the input.  Since we already direct developers to apply an overriding style to change the width (see comments), this seemed like an acceptable constraint.
![screen shot 2015-03-04 at 9 16 58 am](https://cloud.githubusercontent.com/assets/5414922/6486264/57fb45ec-c24f-11e4-897d-839c2090f83c.png)
