### PR TITLE
fix(rxCharacterCount): Clean up the generated elements

### DIFF
--- a/demo/assets/demo.less
+++ b/demo/assets/demo.less
@@ -100,3 +100,13 @@ ul.colors {
         background-color: #fc0f1d;
     }
 }
+
+.styleguide-character-count {
+    .counted-input-wrapper {
+        width: 328px;
+
+        .input-highlighting, textarea {
+            width: 328px;
+        }
+    }
+}

--- a/demo/assets/generated_demo.css
+++ b/demo/assets/generated_demo.css
@@ -79,3 +79,10 @@ ul.colors .action-system {
 ul.colors .action-delete {
   background-color: #fc0f1d;
 }
+.styleguide-character-count .counted-input-wrapper {
+  width: 328px;
+}
+.styleguide-character-count .counted-input-wrapper .input-highlighting,
+.styleguide-character-count .counted-input-wrapper textarea {
+  width: 328px;
+}

--- a/demo/styleguide/forms.html
+++ b/demo/styleguide/forms.html
@@ -16,7 +16,7 @@
 
 <div class="component-description clear">
     <ul class="list">
-        <li>The framework provides styles for a character counter, including a generic wrapper (<code>.character-count-wrapper</code>) with the proper width needed to position the character counter in relation to a text area. Note that if you need a different text area width for specific use cases in a project, a custom wrapper class and text area width can be set.</li>
+        <li>The framework provides styles for a character counter, including a generic wrapper (<code>.counted-input-wrapper</code>) with the proper width needed to position the character counter in relation to a text area. Note that if you need a different text area width for specific use cases in a project, a custom wrapper class and text area width can be set.</li>
         <li>Counters are most often used with <code>textarea</code>s, where there is enough space for a user to type several sentences. It is rarely appropriate to use a counter on a different type or size input field.</li>
         <li>Character counters provide color feedback to the user in addition to numeric feedback. As a user approaches the character limit, the numeric value turns from gray to yellow, then yellow to red.</li>
         <li>See <a href="#/component/rxCharacterCount/">rxCharacterCount</a> for more specific documentation about implementing a counter on an input field.</li>

--- a/demo/styleguide/forms/rx-form-item.html
+++ b/demo/styleguide/forms/rx-form-item.html
@@ -6,7 +6,7 @@
     <textarea rows="10" cols="50"></textarea>
 </rx-form-item>
 <rx-form-item label="Text area with character countdown">
-    <div class="character-count-wrapper" ng-controller="rxCharacterCountCtrl">
+    <div class="styleguide-character-count" ng-controller="rxCharacterCountCtrl">
         <textarea ng-model="model" rows="10" cols="50" rx-character-count></textarea>
     </div>
 </rx-form-item>

--- a/src/rxCharacterCount/README.md
+++ b/src/rxCharacterCount/README.md
@@ -13,3 +13,20 @@ By default, any text field using `ng-model` has `ng-trim="true"` applied to it. 
 
 ### Styling ###
 When specifying a width other than the default, you should style some built-in classes in addition to the text field itself. As in the demo, the `.input-highlighting` class should have the same width as the text field, and the `.character-count-wrapper` should be used to correctly position the counter.
+
+### ngShow/ngHide/ngIf/ngSwitch/etc. ###
+If you wish to show/hide your `textarea` element, we recommend placing the element inside of a `<div>` or `<span>`, and doing the `ng-show` / `ng-hide` /etc. on that `div` / `span`. For example, 
+
+```
+<span ng-show="isShown">
+  <textarea rx-character-count>{{someValue}}</textarea>
+</span>
+```
+
+We _do_ have preliminary support for putting these directives directly inside the `textarea`, i.e. 
+
+```
+<textarea rx-character-count ng-show="isShown">{{someValue}}</textarea>
+```
+
+But this support should be considered experimental. If you choose to take advantage of it, please ensure you've extensively tested that it performs correctly for your uses.

--- a/src/rxCharacterCount/docs/rxCharacterCount.html
+++ b/src/rxCharacterCount/docs/rxCharacterCount.html
@@ -1,5 +1,5 @@
 <!-- Sample HTML goes here as a live example of how the component can be used -->
-<div class="character-count-wrapper" ng-controller="rxCharacterCountCtrl">
+<div ng-controller="rxCharacterCountCtrl">
     <div>
         <h3>Default Values</h3>
         <textarea ng-model="data.comment1" rows="10" cols="50" rx-character-count class="demo-default-values"></textarea>

--- a/src/rxCharacterCount/rxCharacterCount.js
+++ b/src/rxCharacterCount/rxCharacterCount.js
@@ -1,11 +1,31 @@
 angular.module('encore.ui.rxCharacterCount', [])
 .directive('rxCharacterCount', function ($compile) {
-    var counter = '<div class="character-countdown" ' +
-                  'ng-class="{ \'near-limit\': nearLimit, \'over-limit\': overLimit }"' +
+    var counterStart = '<div class="character-countdown" ';
+    var counterEnd =   'ng-class="{ \'near-limit\': nearLimit, \'over-limit\': overLimit }"' +
                   '>{{ remaining }}</div>';
 
-    var background = '<div class="input-highlighting"><span>{{ underLimitText }}</span>' +
+    var backgroundStart = '<div class="input-highlighting" ';
+    var backgroundEnd = '><span>{{ underLimitText }}</span>' +
                      '<span class="over-limit-text">{{ overLimitText }}</span></div>';
+
+    var extraDirectives = function (attrs) {
+        var extra = '';
+        if (_.has(attrs, 'ngShow')) {
+            extra += 'ng-show="' + attrs.ngShow + '" ';
+        }
+        if (_.has(attrs, 'ngHide')) {
+            extra += 'ng-hide="' + attrs.ngHide + '" ';
+        }
+        return extra;
+    };
+
+    var buildCounter = function (attrs) {
+        return counterStart + extraDirectives(attrs) + counterEnd;
+    };
+
+    var buildBackground = function (attrs) {
+        return backgroundStart + extraDirectives(attrs) + backgroundEnd;
+    };
 
     return {
         restrict: 'A',
@@ -19,13 +39,13 @@ angular.module('encore.ui.rxCharacterCount', [])
             var wrapper = angular.element('<div class="counted-input-wrapper" />');
             element.after(wrapper);
 
-            $compile(background)(scope, function (clone) {
+            $compile(buildBackground(attrs))(scope, function (clone) {
                 wrapper.append(clone);
                 wrapper.append(element);
             });
 
-            $compile(counter)(scope, function (clone) {
-                wrapper.after(clone);
+            $compile(buildCounter(attrs))(scope, function (clone) {
+                wrapper.append(clone);
             });
 
             var maxCharacters = _.parseInt(attrs.maxCharacters) || 254;
@@ -74,6 +94,7 @@ angular.module('encore.ui.rxCharacterCount', [])
 
             scope.$on('$destroy', function () {
                 element.off('input', writeLimitText);
+                wrapper.remove();
             });
         }
     };

--- a/src/rxCharacterCount/rxCharacterCount.less
+++ b/src/rxCharacterCount/rxCharacterCount.less
@@ -5,26 +5,12 @@
 // Wrapper provides proper width for text area and positioning 
 // character count. For specific use cases in a project, 
 // custom wrappers with custom widths can be set.
-.character-count-wrapper {
+.counted-input-wrapper {
     width: 375px;
     // These two selectors must always be styled with the same width.
     .input-highlighting, textarea {
         width: 370px;
     }
-}
-
-.character-countdown {
-    text-align: right;
-    color: @subduedTitle;
-    &.near-limit {
-        color: #db7820;
-    }
-    &.over-limit {
-        color: #fc0f1d;
-    }
-}
-
-.counted-input-wrapper {
     position: relative;
     background-color: #ffffff;
     input, textarea {
@@ -43,6 +29,17 @@
         .over-limit-text {
             background-color: @warnRed;
             opacity: 0.3;
+        }
+    }
+
+    .character-countdown {
+        text-align: right;
+        color: @subduedTitle;
+        &.near-limit {
+            color: #db7820;
+        }
+        &.over-limit {
+            color: #fc0f1d;
         }
     }
 }

--- a/src/rxCharacterCount/rxCharacterCount.spec.js
+++ b/src/rxCharacterCount/rxCharacterCount.spec.js
@@ -20,6 +20,8 @@ describe('rxCharacterCount', function () {
             originalScope = $rootScope.$new();
             originalScope.comment = '';
             originalScope.initComment = 'I have an initial value';
+            originalScope.showTextArea = true;
+            originalScope.hideTextArea = true;
             compile = $compile;
         });
 
@@ -117,6 +119,44 @@ describe('rxCharacterCount', function () {
             changeText(el, '123456789012345678901234567890123456789012345678901');
             expect(scope.nearLimit, 'near, 51 chars').to.be.false;
             expect(scope.overLimit, 'over, 51 chars').to.be.true;
+        });
+    });
+
+    describe('cleanup', function () {
+        var parentDiv;
+        var ngIfTemplate = '<div class="parent">' +
+                           '<textarea ng-if="showTextArea" ng-model="comment" rx-character-count></textarea></div>';
+        var ngShowTemplate = '<div class="parent">' +
+                           '<textarea ng-show="showTextArea" ng-model="comment" rx-character-count></textarea></div>';
+        var ngHideTemplate = '<div class="parent">' +
+                           '<textarea ng-hide="hideTextArea" ng-model="comment" rx-character-count></textarea></div>';
+
+        it('should remove the character count if the element disappears', function () {
+            parentDiv = helpers.createDirective(ngIfTemplate, compile, originalScope);
+            el = parentDiv.find('textarea');
+            originalScope.showTextArea = false;
+            originalScope.$apply();
+            expect(parentDiv.is(':empty')).to.be.true;
+        });
+        
+        it('should hide the character count if the element hides (ngShow)', function () {
+            parentDiv = helpers.createDirective(ngShowTemplate, compile, originalScope);
+            el = parentDiv.find('textarea');
+            var characterCount = parentDiv.find('.character-countdown');
+            originalScope.showTextArea = false;
+            originalScope.$apply();
+            expect(el.hasClass('ng-hide'), 'textarea').to.be.true;
+            expect(characterCount.hasClass('ng-hide'), 'character countdown').to.be.true;
+        });
+        
+        it('should show the character count if the element becomes visible (ngHide)', function () {
+            parentDiv = helpers.createDirective(ngHideTemplate, compile, originalScope);
+            el = parentDiv.find('textarea');
+            var characterCount = parentDiv.find('.character-countdown');
+            originalScope.hideTextArea = false;
+            originalScope.$apply();
+            expect(el.hasClass('ng-hide'), 'textarea should be visible').to.be.false;
+            expect(characterCount.hasClass('ng-hide'), 'character countdown should be visible').to.be.false;
         });
     });
 


### PR DESCRIPTION
Closes #847

Properly clean up the character count and other generated elements,
created when rx-character-count is used on an element.

This also moves the character count into the `.counted-input-wrapper`
div. Previously it sat outside of it.

BREAKING CHANGE
We've removed the `.character-count-wrapper` class. Previously we
set widths on this class. It ended up being redundant, widths
should now be set w.r.t. `.counted-input-wrapper`