### PR TITLE
chore(ngAnnotate): Upgrade to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "grunt-karma": "~0.10.1",
     "grunt-karma-coveralls": "~2.5.3",
     "grunt-lib-phantomjs": "~0.6.0",
-    "grunt-ng-annotate": "~0.8.0",
+    "grunt-ng-annotate": "~0.10.0",
     "grunt-ngdocs": "~0.2.6",
     "grunt-shell": "~1.1.1",
     "grunt-text-replace": "~0.4.0",


### PR DESCRIPTION
Trying to do a release, and we're running into https://github.com/olov/ng-annotate/issues/139 Updating our grunt-ng-annotate (which brings in a new ngAnnotate) fixes it.