### PR TITLE
Remove reference Style Docco

### DIFF
--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -49,10 +49,6 @@
 
 - [Pure.css](http://purecss.io) (currently just for Grids)
 
-### Documentation Tool
-
-- [StyleDocco](http://jacobrask.github.io/styledocco/)
-
 ### Reset
 
 - [Normalize.css](http://necolas.github.io/normalize.css/)


### PR DESCRIPTION
We've removed Style Docco from Encore, so I'm taking it out of docs here too.