### PR TITLE
feat(rxCharacterCount): turn highlighing off by default

### DIFF
--- a/src/rxCharacterCount/README.md
+++ b/src/rxCharacterCount/README.md
@@ -12,7 +12,7 @@ The 254 and 10 values are both configurable. To change the maximum number of cha
 By default, any text field using `ng-model` has `ng-trim="true"` applied to it. This means that any leading and trailing spaces/blanks in your text field will be ignored. They will not count towards the remaining character count. If you want it to count leading/trailing spaces, then just add `ng-trim="false"` to your `<textarea>`.
 
 ### Styling ###
-When specifying a width other than the default, you should style some built-in classes in addition to the text field itself. As in the demo, the `.input-highlighting` class should have the same width as the text field, and the `.character-count-wrapper` should be used to correctly position the counter.
+When specifying a width other than the default, you should style some built-in classes in addition to the text field itself. As in the demo, the `.input-highlighting` class should have the same width as the text field (if highlighting is used), and the `.counted-input-wrapper` should be used to correctly position the counter.
 
 ### ngShow/ngHide/ngIf/ngSwitch/etc. ###
 If you wish to show/hide your `textarea` element, we recommend placing the element inside of a `<div>` or `<span>`, and doing the `ng-show` / `ng-hide` /etc. on that `div` / `span`. For example, 
@@ -30,3 +30,10 @@ We _do_ have preliminary support for putting these directives directly inside th
 ```
 
 But this support should be considered experimental. If you choose to take advantage of it, please ensure you've extensively tested that it performs correctly for your uses.
+
+### Highlighting ###
+Characters that are over the limit will be highlighted in red if the `highlight="true"` attribute is on the directive's element. Because this functionality is currently unstable, it has been left off by default. Please test your use case heavily before shipping with this feature enabled.
+
+Known failure cases:
+* Content that causes a scrollbar in the textarea
+* Initial text (coming from the model) that is over the limit

--- a/src/rxCharacterCount/docs/rxCharacterCount.html
+++ b/src/rxCharacterCount/docs/rxCharacterCount.html
@@ -2,22 +2,61 @@
 <div ng-controller="rxCharacterCountCtrl">
     <div>
         <h3>Default Values</h3>
-        <textarea ng-model="data.comment1" rows="10" cols="50" rx-character-count class="demo-default-values"></textarea>
+        <textarea
+            ng-model="data.comment1"
+            rows="10" cols="50"
+            rx-character-count
+            class="demo-default-values">
+        </textarea>
     </div>
     <div>
         <h3>Custom <code>max-characters="25"</code></h3>
-        <textarea ng-model="data.comment2" rows="10" cols="50" rx-character-count max-characters="25" class="demo-custom-max-characters"></textarea>
+        <textarea
+            ng-model="data.comment2"
+            rows="10" cols="50"
+            rx-character-count
+            max-characters="25"
+            class="demo-custom-max-characters">
+        </textarea>
     </div>
     <div>
         <h3>Custom <code>low-boundary="250"</code></h3>
-        <textarea ng-model="data.comment3" rows="10" cols="50" rx-character-count low-boundary="250" class="demo-custom-low-boundary"></textarea>
+        <textarea
+            ng-model="data.comment3"
+            rows="10" cols="50"
+            rx-character-count
+            low-boundary="250"
+            class="demo-custom-low-boundary">
+        </textarea>
     </div>
     <div>
         <h3>Count leading and trailing spaces</h3>
-        <textarea ng-model="data.comment4" rows="10" cols="50" rx-character-count ng-trim="false" class="demo-custom-do-not-trim"></textarea>
+        <textarea
+            ng-model="data.comment4"
+            rows="10" cols="50"
+            rx-character-count
+            ng-trim="false"
+            class="demo-custom-do-not-trim">
+        </textarea>
     </div>
     <div>
         <h3>Accounts for initial values</h3>
-        <textarea ng-model="data.comment5" rows="10" cols="50" rx-character-count class="demo-initial-value"></textarea>
+        <textarea
+            ng-model="data.comment5"
+            rows="10" cols="50"
+            rx-character-count
+            class="demo-initial-value">
+        </textarea>
+    </div>
+    <div>
+        <h3>With highlighting</h3>
+        <textarea
+            ng-model="data.comment6"
+            rows="10" cols="50"
+            rx-character-count
+            highlight="true"
+            max-characters="10"
+            class="demo-highlighting">
+        </textarea>
     </div>
 </div>

--- a/src/rxCharacterCount/docs/rxCharacterCount.js
+++ b/src/rxCharacterCount/docs/rxCharacterCount.js
@@ -7,6 +7,7 @@ function rxCharacterCountCtrl ($scope) {
         comment2: '',
         comment3: '',
         comment4: '',
-        comment5: 'I have an initial value'
+        comment5: 'I have an initial value',
+        comment6: ''
     };
 }

--- a/src/rxCharacterCount/docs/rxCharacterCount.midway.js
+++ b/src/rxCharacterCount/docs/rxCharacterCount.midway.js
@@ -29,4 +29,10 @@ describe('rxCharacterCount', function () {
         cssSelector: '.demo-initial-value'
     }));
 
+    describe('with highlighting', exercise.rxCharacterCount({
+        cssSelector: '.demo-highlighting',
+        maxCharacters: 10,
+        highlight: true
+    }));
+
 });

--- a/src/rxCharacterCount/rxCharacterCount.exercise.js
+++ b/src/rxCharacterCount/rxCharacterCount.exercise.js
@@ -10,6 +10,7 @@ var rxCharacterCount = require('./rxCharacterCount.page').rxCharacterCount;
    @param {Number} [options.nearLimit=10] - The number of remaining characters needed to trigger the "near-limit" class.
    @param {Boolean} [options.ignoreInsignificantWhitespace=false] - Whether or not the textbox ignores leading and
    trailing whitespace when calculating the remaining character count.
+   @param {Boolean} [options.highlight=false] - Determines if text over the limit should be highlighted.
    @example
    ```js
    describe('default exercises', encore.exercise.rxCharacterCount({
@@ -28,7 +29,8 @@ exports.rxCharacterCount = function (options) {
     options = _.defaults(options, {
         maxCharacters: 254,
         nearLimit: 10,
-        ignoreInsignificantWhitespace: true
+        ignoreInsignificantWhitespace: true,
+        highlight: false
     });
 
     return function () {
@@ -69,10 +71,6 @@ exports.rxCharacterCount = function (options) {
             expect(component.isOverLimit()).to.eventually.be.false;
         });
 
-        it('should not show any highlights on an empty text box', function () {
-            expect(component.overLimitText).to.eventually.equal('');
-        });
-
         var belowNearLimitLength = options.maxCharacters + 1 - options.nearLimit;
         it('should not set the near-limit class when ' + belowNearLimitLength + ' characters are entered', function () {
             component.comment = Array(belowNearLimitLength).join('a');
@@ -97,10 +95,6 @@ exports.rxCharacterCount = function (options) {
             expect(component.isOverLimit()).to.eventually.be.false;
         });
 
-        it('should not highlight any characters', function () {
-            expect(component.overLimitText).to.eventually.equal('');
-        });
-
         it('should have zero remaining characters', function () {
             expect(component.remaining).to.eventually.equal(0);
         });
@@ -111,17 +105,8 @@ exports.rxCharacterCount = function (options) {
             expect(component.isOverLimit()).to.eventually.be.true;
         });
 
-        it('should highlight the characters over the limit', function () {
-            expect(component.overLimitText).to.eventually.equal('a');
-        });
-
         it('should display a negative number when the over-limit class is reached', function () {
             expect(component.remaining).to.eventually.equal(-1);
-        });
-
-        it('should clear the over-limit text highlighting when the text is reduced', function () {
-            component.comment = 'a';
-            expect(component.overLimitText).to.eventually.equal('');
         });
 
         var whitespace = '    leading and trailing whitespace    ';
@@ -136,6 +121,33 @@ exports.rxCharacterCount = function (options) {
             it('should count insignificant leading and trailing whitespace', function () {
                 component.comment = whitespace;
                 expect(component.remaining).to.eventually.equal(options.maxCharacters - whitespaceLength);
+            });
+        }
+
+        if (options.highlight) {
+            describe('highlighting', function () {
+
+                it('should not show any highlights on an empty text box', function () {
+                    // A space is used because the `input` event is not fired by clear() or sendKeys('')
+                    component.comment = ' ';
+                    expect(component.overLimitText).to.eventually.equal('');
+                });
+
+                it('should not highlight any characters when ' + atLimit + ' characters are entered', function () {
+                    component.comment = Array(atLimit).join('a');
+                    expect(component.overLimitText).to.eventually.equal('');
+                });
+
+                it('should highlight a single characters when ' + overLimit + ' characters are entered', function () {
+                    component.comment = Array(overLimit).join('a');
+                    expect(component.overLimitText).to.eventually.equal('a');
+                });
+
+                it('should clear the over-limit text highlighting when the text is reduced', function () {
+                    component.comment = 'a';
+                    expect(component.overLimitText).to.eventually.equal('');
+                });
+
             });
         }
 

--- a/src/rxCharacterCount/rxCharacterCount.js
+++ b/src/rxCharacterCount/rxCharacterCount.js
@@ -1,4 +1,21 @@
 angular.module('encore.ui.rxCharacterCount', [])
+/**
+ *
+ * @ngdoc directive
+ * @name encore.ui.rxCharacterCount:rxCharacterCount
+ * @restrict A
+ * @description
+ * Monitors the number of characters in a text input and compares it to the desired length.
+ *
+ * @param {number} [low-boundary=10] How far from the maximum to enter a warning state
+ * @param {number} [max-characters=254] The maximum number of characters allowed
+ * @param {boolean} [highlight=false] Whether or not characters over the limit are highlighted
+ *
+ * @example
+ * <pre>
+ *     <textarea ng-model="model" rx-character-count></textarea>
+ * </pre>
+ */
 .directive('rxCharacterCount', function ($compile) {
     var counterStart = '<div class="character-countdown" ';
     var counterEnd =   'ng-class="{ \'near-limit\': nearLimit, \'over-limit\': overLimit }"' +
@@ -39,12 +56,8 @@ angular.module('encore.ui.rxCharacterCount', [])
             var wrapper = angular.element('<div class="counted-input-wrapper" />');
             element.after(wrapper);
 
-            $compile(buildBackground(attrs))(scope, function (clone) {
-                wrapper.append(clone);
-                wrapper.append(element);
-            });
-
             $compile(buildCounter(attrs))(scope, function (clone) {
+                wrapper.append(element);
                 wrapper.append(clone);
             });
 
@@ -90,7 +103,13 @@ angular.module('encore.ui.rxCharacterCount', [])
                 scope.$apply();
             }
 
-            element.on('input', writeLimitText);
+            if (attrs.highlight === 'true') {
+                $compile(buildBackground(attrs))(scope, function (clone) {
+                    wrapper.prepend(clone);
+                });
+
+                element.on('input', writeLimitText);
+            }
 
             scope.$on('$destroy', function () {
                 element.off('input', writeLimitText);

--- a/src/rxCharacterCount/rxCharacterCount.spec.js
+++ b/src/rxCharacterCount/rxCharacterCount.spec.js
@@ -5,8 +5,6 @@ describe('rxCharacterCount', function () {
     var initialTemplate = '<textarea ng-model="initComment" rx-character-count></textarea>';
     var defaultTemplate = '<textarea ng-model="comment" rx-character-count></textarea>';
     var maxCharsTemplate = '<textarea ng-model="comment" rx-character-count max-characters="50"></textarea>';
-    var noTrimTemplate = '<textarea ng-model="comment" rx-character-count max-characters="50" ng-trim="false">' +
-                         '</textarea>';
     var boundaryTemplate = '<textarea ng-model="comment" rx-character-count max-characters="20" low-boundary="5">' +
                            '</textarea>';
 
@@ -162,10 +160,15 @@ describe('rxCharacterCount', function () {
 
     describe('character highlighting', function () {
 
+        function getHighlightingTemplate (trim) {
+            return '<textarea ng-model="comment" rx-character-count max-characters="50" ' +
+                   'highlight="true" ng-trim="' + trim + '"></textarea>';
+        }
+
         describe('with ngTrim', function ()  {
 
             beforeEach(function () {
-                el = helpers.createDirective(maxCharsTemplate, compile, originalScope);
+                el = helpers.createDirective(getHighlightingTemplate(true), compile, originalScope);
                 scope = el.scope();
             });
 
@@ -201,7 +204,7 @@ describe('rxCharacterCount', function () {
         describe('without ngTrim', function () {
 
             beforeEach(function () {
-                el = helpers.createDirective(noTrimTemplate, compile, originalScope);
+                el = helpers.createDirective(getHighlightingTemplate(false), compile, originalScope);
                 scope = el.scope();
             });
 


### PR DESCRIPTION
This is a quick fix to add the `highlight` attribute to `rx-character-count`.  It is not intended to address any of the known issues with the highlighting, but rather to get the general component to a better state.