### PR TITLE
fix(rxBreadcrumbs): Fix rxBreadcrumbs.visit();

### DIFF
--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
@@ -115,6 +115,14 @@ describe('rxBreadcrumbs', function () {
             expect(middle.href).to.eventually.equal(browser.baseUrl + '/');
         });
 
+        it('should visit the correct page when clicking on the breadcrumb', function () {
+            var homeHref = browser.baseUrl + '/#/overview';
+
+            middle.visit();
+            expect(browser.getCurrentUrl()).to.eventually.equal(homeHref);
+        });
+        // Note that after this test, we are now at the /#/overview page
+
     });
 
     describe('default breadcrumbs', function () {
@@ -132,7 +140,6 @@ describe('rxBreadcrumbs', function () {
         it('should have the correct names', function () {
             expect(defaultBreadcrumbs.names).to.eventually.eql(['Home', 'configs']);
         });
-
     });
 
 });

--- a/src/rxBreadcrumbs/rxBreadcrumbs.page.js
+++ b/src/rxBreadcrumbs/rxBreadcrumbs.page.js
@@ -41,7 +41,7 @@ var breadcrumb = function (rootElement) {
 
         visit: {
             value: function () {
-                return rootElement.click();
+                return rootElement.$('a').click();
             }
         },
 


### PR DESCRIPTION
Note that there were no midways or specs that test visit.  The click function does not bubble, so we need to actually click the link itself.