### PR TITLE
fix(exercises): Resolve require-loop

### DIFF
--- a/grunt-tasks/options/concat.js
+++ b/grunt-tasks/options/concat.js
@@ -1,8 +1,7 @@
 var removeFromIndex = ['/*jshint node:true*/\n',
                        'var _ = require(\'lodash\');\n',
                        'var moment = require(\'moment\');\n',
-                       'var Page = require(\'astrolabe\').Page;\n',
-                       'var exercise = require(\'./exercise\')\n'];
+                       'var Page = require(\'astrolabe\').Page;\n'];
 
 var removeFromExercises = ['/*jshint node:true*/\n',
                            'var _ = require(\'lodash\');\n'];
@@ -26,6 +25,7 @@ module.exports = {
         options: {
             // Replace all third-party requires with a single one up top
             banner: removeFromIndex.join(''),
+            footer: '\nexports.exercise = require(\'./exercise\');',
             process: function (src) {
                 removeFromIndex.forEach(function (toRemove) {
                     // a regex is faster, but this is less work for me


### PR DESCRIPTION
Since exercises need their underlying components to run, the
`exports.exercise = require('./exercise');` line needs to be below all
index.js components in order to prevent an infinite require loop from
occurring.