### PR TITLE
chore(dependencies): Go to grunt-connect-proxy 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-bump": "~0.3.0",
     "grunt-cloudfiles": "~0.3.0",
     "grunt-complexity": "~0.2.0",
-    "grunt-connect-proxy": "^0.1.11",
+    "grunt-connect-proxy": "0.2.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.9.0",


### PR DESCRIPTION
Our ability to run grunt tasks was breaking because of
some breaking dependency changes. This fixes that.