### PR TITLE
fix(rxForm): Remove blue ng-valid border on dirty form fields

### DIFF
--- a/src/rxForm/rxForm.less
+++ b/src/rxForm/rxForm.less
@@ -74,10 +74,6 @@
         color: @inputColor;
         font-size: 1.2em;
 
-        &.ng-valid.ng-dirty {
-            border-color: @inputBorderColorValid;
-        }
-
         &.ng-invalid.ng-dirty {
             border-color: @inputBorderColorInvalid;
         }

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -114,7 +114,6 @@
 @inputBackgroundDisabled: #dededd;
 @inputBorderRadius: 0px;
 @inputBorderColor: #ccc;
-@inputBorderColorValid: #00afec;
 @inputBorderColorInvalid: #ff2400;
 
 /*


### PR DESCRIPTION
Please see [EOD-646](https://jira.rax.io/browse/EOD-646) for more details. This now means the variable `@inputBorderColorValid` is unused -- I can remove it as well if we see no future need for it. 

@glynnis @ElementE 