### PR TITLE
docs(tables): add demo for table rows with a single action

### DIFF
--- a/demo/styleguide/tables.html
+++ b/demo/styleguide/tables.html
@@ -60,6 +60,15 @@
     </div>
     <rx-styleguide code-url="styleguide/tables/delete.html"></rx-styleguide>
 
+    <h3 class="title">Other single action</h3>
+    <div class="component-description clear">
+        <ul class="list">
+            <li>A button link is used for tables where each row has a single action that is not a deletion.</li>
+            <li>If the action is unavailable for a row, the link should be disabled and have a tooltip indicating why.</li>
+        </ul>
+    </div>
+    <rx-styleguide code-url="styleguide/tables/single-action.html"></rx-styleguide>
+
     <h3 class="title">Status columns</h3>
     <ul>
         <li><span class="msg-info">ENCORE-SPECIFIC:</span> We provide a standardized mechanism for color coding of status columns, via <a href="http://rackerlabs.github.io/encore-ui/#/component/rxStatusColumn">rxStatusColumn</a>. Ticket Queues has their own styling that predates this, and can be seen in <a href="https://github.com/rackerlabs/encore-tq-ui/blob/master/app/styles/tickets.less">their tickets.less file.</a> For consistency, new projects should use <code>rxStatusColumn</code>. If it doesn't satisfy your needs, please let us know and we'll see what we can do.</li>

--- a/demo/styleguide/tables/single-action.html
+++ b/demo/styleguide/tables/single-action.html
@@ -1,0 +1,29 @@
+<table class="table-striped">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Occupation</th>
+            <th>Resume</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Patrick Deuley</td>
+            <td>Design Chaplain</td>
+            <td>
+                <span tooltip="No resume has been uploaded.">
+                    <button class="btn-link" disabled>
+                        <span><i class="fa fa-download"></i> Download</span>
+                    </button>
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td>Hussam Dawood</td>
+            <td>Evangelist of Roger Enriquez</td>
+            <td>
+                <button class="btn-link"><i class="fa fa-download"></i> Download</button>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/src/rxButton/rxButton.less
+++ b/src/rxButton/rxButton.less
@@ -145,6 +145,11 @@
     &:focus {
         text-decoration: underline;
     }
+
+    &[disabled], &[disabled]:hover {
+        cursor: not-allowed;
+        color: @buttonDisabledBg;
+    }
 }
 thead th .btn-link {
     color: @tableHeaderText;


### PR DESCRIPTION
Fixes #908 
![screen shot 2015-04-28 at 10 27 24 am](https://cloud.githubusercontent.com/assets/5414922/7373295/2f838de6-ed91-11e4-8826-59f7cbe4c2c2.png)

The markup is a little more verbose than I would like, but pointer events aren't allowed on disabled elements, hence the need to wrap the button (and to use a button instead of a link).