### PR TITLE
feat(rxButton): add button group styles

### DIFF
--- a/demo/styleguide/buttons.html
+++ b/demo/styleguide/buttons.html
@@ -26,6 +26,10 @@
         <p>The Framework provides a spinner style for use with buttons. Note that different spinner styles are used when content is loading or being fetched (see <a href="#colors">Using Colors and Icons With Links demo</a>).</p>
         <p>When a user takes an action with results that cannot be immediately displayed, a spinner is shown on a disabled button state until the call completes or the results of the user's action can be displayed in the UI. Text for buttons with spinners should describe the action being taken using "-ing" verbs, so the user understands why the button appearance has changed. Note that the disabled state ensures the user cannot submit the same data multiple times while the initial action completes.
         </p>
+
+        <h2>Button Groups</h2>
+        <p>This control should NOT be used as a replacement for radio inputs. Instead, it should be used to indicate state on a page. For example, the legend of a time plot may allow the user to select a range of a week, month, or year. In this situation, there is no form being submitted, but there is an indication of the graph's state that can be interacted with. Conversely, radio inputs are the correct way to implement a form input where one of a few options can be selected.</p>
+        <p>Also, this type of control should only be used with at most four segments.</p>
     </div>
 
     <rx-styleguide code-url="styleguide/buttons/custom-buttons.html"></rx-styleguide>

--- a/demo/styleguide/buttons/custom-buttons.html
+++ b/demo/styleguide/buttons/custom-buttons.html
@@ -26,6 +26,18 @@
 </div>
 
 <hr />
+
+<h3 class="title">Button Group</h3>
+<div class="button-group" style="width: 250px;" ng-init="status = 'off'">
+    <input id="status-off" type="radio" ng-model="status" value="off">
+    <label for="status-off">Off</label>
+    <input id="status-manual" type="radio" ng-model="status" value="manual">
+    <label for="status-manual">Manual</label>
+    <input id="status-auto" type="radio" ng-model="status" value="status">
+    <label for="status-auto">Auto</label>
+</div>
  
+<hr />
+
 <h3 class="title">Buttons as text</h3>
 <button class="btn-link">Link</button>

--- a/src/rxButton/rxButton.less
+++ b/src/rxButton/rxButton.less
@@ -158,3 +158,44 @@ thead th .btn-link {
         color: @tableHeaderText;
     }
 }
+
+.button-group {
+    display: flex;
+    border: @buttonGroupBorder;
+    border-radius: @buttonGroupBorderRadius + 2;
+    font-size: 1.1em;
+
+    input {
+        display: none;
+    }
+    label {
+
+        flex: 1;
+        text-align: center;
+        padding: 7px 13px;
+        color: #989998;
+
+        &:first-of-type {
+            border-top-left-radius: @buttonGroupBorderRadius;
+            border-bottom-left-radius: @buttonGroupBorderRadius;
+        }
+        &:last-of-type {
+            border-top-right-radius: @buttonGroupBorderRadius;
+            border-bottom-right-radius: @buttonGroupBorderRadius;
+        }
+        &:not(:last-of-type) {
+            border-right: @buttonGroupBorder;
+        }
+
+        &:hover,
+        &:focus {
+            cursor: pointer;
+            color: @white;
+            background: @buttonCancelBgHover;
+        }
+    }
+    input:checked + label {
+        color: @white;
+        background: #757575;
+    }
+}

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -136,3 +136,9 @@
  * rxCollapse
  */
 @borderGrey: #c7c7c7;
+
+/*
+ * Button Groups
+ */
+@buttonGroupBorder: 2px solid #eaeaea;
+@buttonGroupBorderRadius: 4px;


### PR DESCRIPTION
Fixes #910 
![screen shot 2015-04-28 at 1 44 33 pm](https://cloud.githubusercontent.com/assets/5414922/7377556/c18cddc6-edac-11e4-9262-cf8eecba4d00.png)
*In the screenshot, the rightmost button is showing the hover styles (the mouse was not captured).

@ElementE I guessed at some of the dimensions you posted in the issue, so let me know where I have erred.  Also, I purposefully gave corners (not rounded) to the inner buttons so that the control looks good with more than two buttons, though that was not part of your demo either.

@glynnis any suggestions for the docs?