### PR TITLE
feat(rxSelect): add rxSelect component

### DIFF
--- a/src/rxCheckbox/rxCheckbox.page.js
+++ b/src/rxCheckbox/rxCheckbox.page.js
@@ -3,7 +3,97 @@ var _ = require('lodash');
 var Page = require('astrolabe').Page;
 
 /**
-   @namespace
+ * @namespace
+ */
+var htmlCheckbox = {
+    /**
+     * @function
+     * @returns {Boolean} Whether the checkbox is currently displayed.
+     */
+    isDisplayed: {
+        value: function () {
+            return this.rootElement.isDisplayed();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether the checkbox is valid.
+     */
+    isValid: {
+        value: function () {
+            return this.rootElement.getAttribute('class').then(function (classes) {
+                return _.contains(classes.split(' '), 'ng-valid');
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the checkbox is currently selected
+     */
+    isSelected: {
+        value: function () {
+            return this.rootElement.isSelected();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the checkbox is disabled
+     */
+    isDisabled: {
+        value: function () {
+            return this.rootElement.getAttribute('disabled').then(function (disabled) {
+                return (disabled ? true : false);
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the checkbox exists on the page
+     */
+    isPresent: {
+        value: function () {
+            return this.rootElement.isPresent();
+        }
+    },
+
+    /**
+     * @function
+     * @description Make sure checkbox is selected/checked
+     */
+    select: {
+        value: function () {
+            var checkbox = this.rootElement;
+            return this.isSelected().then(function (selected) {
+                if (!selected) {
+                    checkbox.click();
+                }
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @description make sure checkbox is deselected/unchecked
+     */
+    deselect: {
+        value: function () {
+            var checkbox = this.rootElement;
+            return this.isSelected().then(function (selected) {
+                if (selected) {
+                    checkbox.click();
+                }
+            });
+        }
+    }
+};
+
+/**
+ * @namespace
+ * @extends htmlCheckbox
  */
 var rxCheckbox = {
     eleWrapper: {
@@ -42,29 +132,7 @@ var rxCheckbox = {
 
     /**
      * @function
-     * @returns {Boolean} Whether the native checkbox element is valid.
-     */
-    isValid: {
-        value: function () {
-            return this.rootElement.getAttribute('class').then(function (classes) {
-                return _.contains(classes.split(' '), 'ng-valid');
-            });
-        }
-    },
-
-    /**
-       @function
-       @returns {Boolean} Whether or not the checkbox element is currently selected.
-    */
-    isSelected: {
-        value: function () {
-            return this.rootElement.isSelected();
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether or not the wrapper is disabled.
+     * @returns {Boolean} Whether or not the wrapper has expected disabled class name
      */
     isDisabled: {
         value: function () {
@@ -82,47 +150,50 @@ var rxCheckbox = {
         value: function () {
             return this.eleFakeCheckbox.isPresent();
         }
-    },
-
-    /**
-     * @function
-     * @description Make sure checkbox is selected/checked
-     */
-    select: {
-        value: function () {
-            var checkbox = this.rootElement;
-            return this.isSelected().then(function (selected) {
-                if (!selected) {
-                    checkbox.click();
-                }
-            });
-        }
-    },
-
-    /**
-     * @function
-     * @description make sure checkbox is deselected/unchecked
-     */
-    deselect: {
-        value: function () {
-            var checkbox = this.rootElement;
-            return this.isSelected().then(function (selected) {
-                if (selected) {
-                    checkbox.click();
-                }
-            });
-        }
     }
+};
+rxCheckbox = _.assign(htmlCheckbox, rxCheckbox);
+
+/**
+ * @exports encore.htmlCheckbox
+ * @description Page object for interacting with plain old html checkboxes
+ */
+exports.htmlCheckbox = {
+    /**
+     * @function
+     * @param {WebElement} checkboxElement
+     *   WebElement to be transformed into an htmlCheckbox page object.
+     * @returns {htmlCheckbox} Page object representing the checkbox object
+     */
+    initialize: function (checkboxElement) {
+        htmlCheckbox.rootElement = {
+            get: function () { return checkboxElement; }
+        };
+        return Page.create(htmlCheckbox);
+    },
+
+    /**
+     * @returns {htmlCheckbox}
+     *   Page object representing the _first_ `<input type="checkbox" />`
+     *   object found on the page.
+     */
+    main: (function () {
+        htmlCheckbox.rootElement = {
+            get: function () { return $('input[type="checkbox"]'); }
+        };
+        return Page.create(htmlCheckbox);
+    })()
 };
 
 /**
-   @exports encore.rxCheckbox
+ * @exports encore.rxCheckbox
+ * @description Page object for interacting with rxCheckbox elements
  */
 exports.rxCheckbox = {
     /**
-       @function
-       @param {WebElement} rxCheckboxElement - WebElement to be transformed into an rxCheckboxElement object.
-       @returns {rxCheckbox} Page object representing the rxCheckbox object.
+     * @function
+     * @param {WebElement} rxCheckboxElement - WebElement to be transformed into an rxCheckbox page object
+     * @returns {rxCheckbox} Page object representing the rxCheckbox element
      */
     initialize: function (rxCheckboxElement) {
         rxCheckbox.rootElement = {
@@ -132,8 +203,8 @@ exports.rxCheckbox = {
     },
 
     /**
-       @returns {rxCheckbox} Page object representing the _first_ rxCheckbox object found on the page.
-    */
+     * @returns {rxCheckbox} Page object representing the _first_ `<input rx-checkbox />` element found on the page
+     */
     main: (function () {
         rxCheckbox.rootElement = {
             get: function () { return $('input[rx-checkbox]'); }

--- a/src/rxRadio/rxRadio.page.js
+++ b/src/rxRadio/rxRadio.page.js
@@ -3,7 +3,60 @@ var _ = require('lodash');
 var Page = require('astrolabe').Page;
 
 /**
-   @namespace
+ * @namespace
+ */
+var htmlRadio = {
+    /**
+     * @function
+     * @returns {Boolean} Whether the radio is currently displayed
+     */
+    isDisplayed: {
+        value: function () {
+            return this.rootElement.isDisplayed();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether the radio element is valid
+     */
+    isValid: {
+        value: function () {
+            return this.rootElement.getAttribute('class').then(function (classes) {
+                return _.contains(classes.split(' '), 'ng-valid');
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the radio element is currently selected
+     */
+    isSelected: {
+        value: function () {
+            return this.rootElement.isSelected();
+        }
+    },
+
+    /**
+     * @function
+     * @description Make sure radio is selected
+     */
+    select: {
+        value: function () {
+            var radio = this.rootElement;
+            return this.isSelected(). then(function (selected) {
+                if (!selected) {
+                    radio.click();
+                }
+            });
+        }
+    }
+};
+
+/**
+ * @namespace
+ * @extends htmlRadio
  */
 var rxRadio = {
     eleWrapper: {
@@ -32,33 +85,11 @@ var rxRadio = {
 
     /**
      * @function
-     * @returns {Boolean} Whether the root element is currently displayed.
+     * @returns {Boolean} Whether the styled element is currently displayed.
      */
     isDisplayed: {
         value: function () {
             return this.eleFakeRadio.isDisplayed();
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether the native checkbox element is valid.
-     */
-    isValid: {
-        value: function () {
-            return this.rootElement.getAttribute('class').then(function (classes) {
-                return _.contains(classes.split(' '), 'ng-valid');
-            });
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether or not the radio element is currently selected.
-     */
-    isSelected: {
-        value: function () {
-            return this.rootElement.isSelected();
         }
     },
 
@@ -76,38 +107,51 @@ var rxRadio = {
 
     /**
      * @function
-     * @returns {Boolean} Whether or not the root element exists on the page
+     * @returns {Boolean} Whether or not the styled element exists on the page
      */
     isPresent: {
         value: function () {
             return this.eleFakeRadio.isPresent();
         }
+    }
+};
+rxRadio = _.assign(htmlRadio, rxRadio);
+
+/**
+ * @exports encore.htmlRadio
+ */
+exports.htmlRadio = {
+    /**
+     * @function
+     * @param {WebElement} radioElement - WebElement to be transformed into an htmlRadio page object.
+     * @returns {htmlRadio} Page object representing the radio element
+     */
+    initialize: function (radioElement) {
+        htmlRadio.rootElement = {
+            get: function () { return radioElement; }
+        };
+        return Page.create(htmlRadio);
     },
 
     /**
-     * @function
-     * @description Make sure radio is selected
+     * @returns {htmlRadio} Page object representing the _first_ `<input type="radio" />` element found on the page
      */
-    select: {
-        value: function () {
-            var radio = this.rootElement;
-            return this.isSelected(). then(function (selected) {
-                if (!selected) {
-                    radio.click();
-                }
-            });
-        }
-    }
+    main: (function () {
+        htmlRadio.rootElement = {
+            get: function () { return $('input[type="radio"]'); }
+        };
+        return Page.create(htmlRadio);
+    })()
 };
 
 /**
-   @exports encore.rxRadio
+ * @exports encore.rxRadio
  */
 exports.rxRadio = {
     /**
-       @function
-       @param {WebElement} rxRadioElement - WebElement to be transformed into an rxRadioElement object.
-       @returns {rxRadio} Page object representing the rxRadio object.
+     * @function
+     * @param {WebElement} rxRadioElement - WebElement to be transformed into an rxRadio page object
+     * @returns {rxRadio} Page object representing the rxRadio element
      */
     initialize: function (rxRadioElement) {
         rxRadio.rootElement = {
@@ -117,8 +161,8 @@ exports.rxRadio = {
     },
 
     /**
-       @returns {rxRadio} Page object representing the _first_ rxRadio object found on the page.
-    */
+     * @returns {rxRadio} Page object representing the _first_ `<input rx-radio />` element found on the page
+     */
     main: (function () {
         rxRadio.rootElement = {
             get: function () { return $('input[rx-radio]'); }

--- a/src/rxSelect/README.md
+++ b/src/rxSelect/README.md
@@ -1,0 +1,25 @@
+[![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
+
+The rxSelect component is an **attribute directive** that wraps native select elements in markup required for styling.
+
+## Styling
+
+* Directive results in a **block element** that takes up the *full width of its container*.
+* You can style the output against decendents of the **`.rxSelect`** CSS class.
+
+## Show/Hide
+If you wish to show/hide your `rxSelect` element, we recommend placing it within a `<div>` or `<span>`
+wrapper, and performing the show/hide logic on the wrapper.
+
+```html
+<span ng-show="isShown">
+  <select rx-select ng-model="selDemo">
+    <option value="1">First</option>
+    <option value="2">Second</option>
+    <option value="3">Third</option>
+  </select>
+</span>
+```
+
+It is highly recommended that you use `ng-show` and `ng-hide` for display logic. Because of the way that
+`ng-if` and `ng-switch` directives behave with scope, they may introduce unnecessary complexity in your code.

--- a/src/rxSelect/docs/rxSelect.html
+++ b/src/rxSelect/docs/rxSelect.html
@@ -1,0 +1,151 @@
+<style>
+  .demoContainer { width: 400px; }
+</style>
+
+<div ng-controller="rxSelectCtrl">
+  <div class="demoContainer">
+    <h2 class="title">Examples</h2>
+
+    <h3 class="title">With Validation</h3>
+    <p>
+      <strong>How do you like your bacon?</strong>
+      <small ng-if="baconPrep">({{baconPrep}})</small>
+      <br />
+      <select rx-select
+              id="selBaconPrep"
+              ng-model="baconPrep"
+              ng-required="true">
+        <option value="">I do not like bacon</option>
+        <option value="thin">Thin (light and crispy)</option>
+        <option value="medium">Medium (perfect balance of flavor)</option>
+        <option value="thick">Thick (borderline jerky)</option>
+        <option value="crumbled">Crumbled (great on salads)</option>
+      </select>
+    </p>
+    <br />
+
+    <h3 class="title">Show/Hide Select</h3>
+    <p>
+      <input rx-checkbox id="chkShow" ng-model="isShown" />
+      <label for="chkShow">Show?</label><br />
+      <span ng-show="isShown">
+        <select rx-select id="selTargetShow">
+          <option>I'm visible!</option>
+        </select>
+      </span>
+    </p>
+
+    <h3 class="title">Destroy Select</h3>
+    <p>Support for <code>$destroy</code> events.</p>
+    <p>
+      <span>
+        <input rx-radio
+               id="radDestroyed"
+               value="destroyed"
+               ng-model="radCreateDestroy" />
+        <label for="radDestroyed">Destroyed</label>
+      </span>
+      <span>
+        <input rx-radio
+               id="radCreated"
+               value="created"
+               ng-model="radCreateDestroy" />
+        <label for="radCreated">Created</label>
+      </span>
+    </p>
+    <p>
+      The following select is <code>{{radCreateDestroy}}</code>:
+      <select rx-select
+              id="selTargetCreated"
+              ng-if="radCreateDestroy === 'created'">
+        <option>CREATED!</option>
+      </select>
+    </p>
+    <br />
+  </div>
+
+  <!-- END OF DEMO -->
+  <!-- END OF DEMO -->
+  <!-- END OF DEMO -->
+
+  <h3 class="title">Select States</h3>
+  <table>
+    <thead>
+      <tr>
+        <th width="150px">State</th>
+        <th>Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th>Disabled</th>
+        <td>
+          <select rx-select
+                  id="selOne"
+                  ng-model="selOne"
+                  ng-disabled="true">
+            <option value="na">Disabled by 'ng-disabled' attribute</option>
+          </select>
+          <br />
+          <select rx-select
+                  id="selTwo"
+                  disabled
+                  ng-model="selTwo">
+            <option value="na">Disabled by 'disabled' attribute</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <th>Valid</th>
+        <td>
+          <select rx-select
+                  id="selThree"
+                  ng-model="selThree">
+            <option value="1">First</option>
+            <option value="2">Second</option>
+            <option value="3">Third</option>
+            <option value="4">Fourth</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <th>Invalid</th>
+        <td>
+          <select rx-select
+                  id="selFour"
+                  always-invalid
+                  ng-model="selFour">
+            <option value="1">First</option>
+            <option value="2">Second</option>
+            <option value="3">Third</option>
+            <option value="4">Fourth</option>
+          </select>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<h3 class="title">Attributes</h3>
+<table class="component-attributes table-striped">
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        <code>ng-disabled</code>
+      </th>
+      <td>
+        <em>optional</em>
+      </td>
+      <td>
+        In addition to default functionality, this will add/remove the <code>rx-disabled</code> class on the control wrapper for purposes of styling sibling elements.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/rxSelect/docs/rxSelect.js
+++ b/src/rxSelect/docs/rxSelect.js
@@ -1,0 +1,10 @@
+/*jshint unused:false*/
+angular.module('demoApp')
+.controller('rxSelectCtrl', function ($scope) {
+    $scope.radCreateDestroy = 'destroyed';
+
+    $scope.selOne = 'na';
+    $scope.selTwo = 'na';
+    $scope.selThree = 3;
+    $scope.selFour = 4;
+});

--- a/src/rxSelect/docs/rxSelect.midway.js
+++ b/src/rxSelect/docs/rxSelect.midway.js
@@ -1,0 +1,130 @@
+var rxSelect = require('../rxSelect.page').rxSelect;
+var htmlCheckbox = require('../../rxCheckbox/rxCheckbox.page').htmlCheckbox;
+var htmlRadio = require('../../rxRadio/rxRadio.page').htmlRadio;
+
+var exercise = require('../rxSelect.exercise');
+
+describe('rxSelect', function () {
+    var subject;
+
+    before(function () {
+        demoPage.go('#/component/rxSelect');
+    });
+
+    describe('(State) NG-Disabled', exercise.rxSelect({
+        cssSelector: '#selOne',
+        disabled: true,
+        visible: true,
+        valid: true
+    }));
+
+    describe('(State) Disabled', exercise.rxSelect({
+        cssSelector: '#selTwo',
+        disabled: true,
+        visible: true,
+        valid: true
+    }));
+
+    describe('(State) Valid', exercise.rxSelect({
+        cssSelector: '#selThree',
+        disabled: false,
+        visible: true,
+        valid: true
+    }));
+
+    describe('(State) Invalid', exercise.rxSelect({
+        cssSelector: '#selFour',
+        disabled: false,
+        visible: true,
+        valid: false
+    }));
+
+    describe('With Validation', function () {
+        before(function () {
+            subject = rxSelect.initialize($('#selBaconPrep'));
+        });
+
+        it('should not be valid', function () {
+            expect(subject.isValid()).to.eventually.be.false;
+        });
+
+        describe('Selecting "Thick (borderline jerky)"', function () {
+            before(function () {
+                subject.selectOption('Thick (borderline jerky)');
+            });
+
+            it('should be valid', function () {
+                expect(subject.isValid()).to.eventually.be.true;
+            });
+        });
+
+        describe('Selecting "I do not like bacon"', function () {
+            before(function () {
+                subject.selectOption('I do not like bacon');
+            });
+
+            it('should not be valid', function () {
+                expect(subject.isValid()).to.eventually.be.false;
+            });
+        });
+    });
+
+    describe('Show/Hide Select', function () {
+        var checkbox;
+
+        before(function () {
+            checkbox = htmlCheckbox.initialize($('#chkShow'));
+            subject = rxSelect.initialize($('#selTargetShow'));
+        });
+
+        describe('when checkbox checked', function () {
+            before(function () {
+                checkbox.select();
+            });
+
+            it('should be visible', function () {
+                expect(subject.isDisplayed()).to.eventually.be.true;
+            });
+        });
+
+        describe('when checkbox unchecked', function () {
+            before(function () {
+                checkbox.deselect();
+            });
+
+            it('should not be visible', function () {
+                expect(subject.isDisplayed()).to.eventually.be.false;
+            });
+        });
+    });
+
+    describe('Destroy Select', function () {
+        var radDestroyed, radCreated;
+
+        before(function () {
+            radDestroyed = htmlRadio.initialize($('#radDestroyed'));
+            radCreated = htmlRadio.initialize($('#radCreated'));
+            subject = rxSelect.initialize($('#selTargetCreated'));
+        });
+
+        describe('when created', function () {
+            before(function () {
+                radCreated.select();
+            });
+
+            it('should be present', function () {
+                expect(subject.isPresent()).to.eventually.be.true;
+            });
+        });
+
+        describe('when destroyed', function () {
+            before(function () {
+                radDestroyed.select();
+            });
+
+            it('should not be present', function () {
+                expect(subject.isPresent()).to.eventually.be.false;
+            });
+        });
+    });
+});

--- a/src/rxSelect/rxSelect.exercise.js
+++ b/src/rxSelect/rxSelect.exercise.js
@@ -1,0 +1,51 @@
+var _ = require('lodash');
+var rxSelect = require('./rxSelect.page').rxSelect;
+
+/**
+ * @description rxSelect exercises
+ * @exports encore.exercise.rxSelect
+ * @param {Object} [options=] - Test options. Used to build valid tests.
+ * @param {String} [options.cssSelector=] - Fallback selector string to initialize widget with.
+ * @param {Boolean} [options.disabled=false] - Determines if the select is disabled
+ * @param {Boolean} [options.visible=true] - Determines if the select is visible
+ * @param {Boolean} [options.valid=true] - Determines if the select is valid
+ */
+exports.rxSelect = function (options) {
+    if (options === undefined) {
+        options = {};
+    }
+
+    options = _.defaults(options, {
+        disabled: false,
+        visible: true,
+        valid: true
+    });
+
+    return function () {
+        var component;
+
+        before(function () {
+            if (options.cssSelector === undefined) {
+                component = rxSelect.main;
+            } else {
+                component = rxSelect.initialize($(options.cssSelector));
+            }
+        });
+
+        it('should be present', function () {
+            expect(component.isPresent()).to.eventually.be.true;
+        });
+
+        it('should ' + (options.visible ? 'be' : 'not be') + ' visible', function () {
+            expect(component.isDisplayed()).to.eventually.eq(options.visible);
+        });
+
+        it('should ' + (options.disabled ? 'be' : 'not be') + ' disabled', function () {
+            expect(component.isDisabled()).to.eventually.eq(options.disabled);
+        });
+
+        it('should ' + (options.valid ? 'be' : 'not be') + ' valid', function () {
+            expect(component.isValid()).to.eventually.eq(options.valid);
+        });
+    };
+};

--- a/src/rxSelect/rxSelect.js
+++ b/src/rxSelect/rxSelect.js
@@ -1,0 +1,49 @@
+angular.module('encore.ui.rxSelect', [])
+/**
+ *
+ * @ngdoc directive
+ * @name encore.ui.rxForm:rxSelect
+ * @restrict A
+ * @param {Boolean} [ngDisabled=""] - Angular expression that evaluates to a Boolean
+ * @description This directive is to apply styling to native `<select>` elements
+ */
+.directive('rxSelect', function () {
+    return {
+        restrict: 'A',
+        scope: {
+            ngDisabled: '=?'
+        },
+        link: function (scope, element, attrs) {
+            var disabledClass = 'rx-disabled';
+            var wrapper = angular.element('<div class="rxSelect"></div>');
+            var fakeSelect = '<div class="fake-select">' +
+                    '<div class="select-trigger">' +
+                        '<i class="fa fa-fw fa-caret-down"></i>' +
+                    '</div>' +
+                '</div>';
+
+            element.wrap(wrapper);
+            element.after(fakeSelect);
+
+            // apply/remove disabled class so we have the ability to
+            // apply a CSS selector for purposes of style sibling elements
+            if (attrs.disabled) {
+                wrapper.addClass(disabledClass);
+            }
+            if (_.has(attrs, 'ngDisabled')) {
+                scope.$watch('ngDisabled', function (newVal) {
+                    if (newVal === true) {
+                        wrapper.addClass(disabledClass);
+                    } else {
+                        wrapper.removeClass(disabledClass);
+                    }
+                });
+            }
+
+            // remove stylistic markup when element is destroyed
+            element.on('$destroy', function () {
+                wrapper[0].remove();
+            });
+        }
+    };
+});

--- a/src/rxSelect/rxSelect.less
+++ b/src/rxSelect/rxSelect.less
@@ -1,0 +1,107 @@
+/*
+ * rxSelect
+ */
+.rxSelect {
+  .box-sizing(border-box);
+  display: block;
+  overflow: hidden;
+  position: relative;
+  color: @rxSelect-color;
+  background: @rxSelect-background;
+  .border-radius(@rxSelect-border-radius);
+
+  // Element should be resizable via wrapper alone
+  min-width: @rxSelect-min-width;
+  min-height: @rxSelect-min-height;
+
+  &.rx-disabled {
+    color: @inputColorDisabled;
+    background: @inputBackgroundDisabled;
+  }
+
+  // position elements in wrapper
+  select,
+  .fake-select {
+    .box-sizing(border-box);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  select {
+    z-index: 0;
+    padding: 5px;
+    cursor: pointer;
+
+    // reset native styling
+    border: none !important;
+    outline: none !important;
+    background: transparent;
+    &:-moz-focusring {
+      // FF uses text color to draw ring. Make it transparent
+      color: transparent;
+      // However, we still need to display our select <option> text
+      text-shadow: 0 0 0 @rxSelect-color;
+    }
+
+    & + .fake-select {
+      border-color: @inputBorderColor;
+      border-width: 1px;
+    }
+
+    &.ng-invalid + .fake-select {
+      border-color: @rxSelect-border-color-invalid;
+      border-width: 2px;
+
+      .select-trigger {
+        color: @rxSelect-trigger-color-invalid;
+      }
+    }
+
+    &[disabled] {
+      cursor: not-allowed ;
+
+      & + .fake-select {
+        border-color: @rxSelect-border-color-disabled;
+        border-width: 1px;
+
+        .select-trigger {
+          background: @rxSelect-background-disabled;
+          border-left-width: 0px;
+          border-left-color: @rxSelect-color-disabled;
+          color: @rxSelect-trigger-color-disabled;
+        }
+      }
+    }//[disabled]
+  }//select
+
+  .fake-select {
+    z-index: 10;
+    border: @rxSelect-border-width solid @rxSelect-border-color;
+    overflow: hidden;
+    .border-radius(@rxSelect-border-radius);
+    .flexbox();
+    .justify-content(flex-end);
+    .flex-flow(row nowrap);
+
+    // This allow pointer events to pass THROUGH to the
+    // native <select> element
+    pointer-events: none !important;
+
+    // Custom trigger button will cover native <select> button
+    .select-trigger {
+      .box-sizing(border-box);
+      width: @rxSelect-trigger-width;
+      background: @rxSelect-trigger-background;
+      color: @rxSelect-trigger-color;
+
+      // perfectly center the trigger icon
+      .flexbox();
+      .align-items(center);
+      .justify-content(center);
+    }//.select-trigger
+  }//.fake-select
+}//.rxSelect
+

--- a/src/rxSelect/rxSelect.page.js
+++ b/src/rxSelect/rxSelect.page.js
@@ -1,0 +1,374 @@
+/*jshint node:true*/
+var _ = require('lodash');
+var Page = require('astrolabe').Page;
+
+/**
+ * @namespace
+ */
+var htmlSelectOption = {
+    /**
+     * @returns {string} The text inside of an `<option>` element
+     */
+    label: {
+        get: function () {
+            return this.rootElement.getText();
+        }
+    },
+
+    /**
+     * @returns {string} The "value" attribute for an `<option>` element
+     */
+    value: {
+        get: function () {
+            return this.rootElement.getAttribute('value');
+        }
+    },
+
+    /**
+     * @function
+     * @description
+     *   Select an `<option>` element within a `<select>`
+     *
+     *   Equivalent to `browser.actions().mouseDown(elem).mouseUp().perform();`.
+     *   This function should be used when dealing with odd or unusual behavior while interacting with click events
+     *   that don't seem to work right. Either the element does not appear to respond to a normal `.click()` call, or
+     *   the element is responding to more than one click event. This typically happens more often in Firefox than
+     *   in other browsers. See {@link rxForm.dropdown.option.select} for an example of a function that will
+     *   slow click an element to achieve consistent behavior.
+     *
+     * @returns {undefined}
+     */
+    select: {
+        value: function () {
+            browser.actions().mouseDown(this.rootElement).mouseUp().perform();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the `<option>` is currently selected
+     */
+    isSelected: {
+        value: function () {
+            return this.rootElement.isSelected();
+        }
+    }
+};//htmlSelectOption
+
+/**
+ * @namespace
+ */
+var htmlSelect = {
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the `<select>` element is disabled
+     */
+    isDisabled: {
+        value: function () {
+            return this.rootElement.getAttribute('disabled').then(function (disabled) {
+                return (disabled ? true : false);
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether the `<select>` element is currently displayed
+     */
+    isDisplayed: {
+        value: function () {
+            return this.rootElement.isDisplayed();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the `<select>` element exists on the page
+     */
+    isPresent: {
+        value: function () {
+            return this.rootElement.isPresent();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether the `<select>` element is valid
+     */
+    isValid: {
+        value: function () {
+            return this.rootElement.getAttribute('class').then(function (classes) {
+                return _.contains(classes.split(' '), 'ng-valid');
+            });
+        }
+    },
+
+    /* ========================================
+     * OPTIONS
+     * ======================================== */
+
+    /**
+     * @function
+     * @param {String} optionText
+     *   Partial or total string to match the display value of the desired `<option>` element
+     * @returns {Page} Page object representing an option
+     */
+    option: {
+        value: function (optionText) {
+            var optionElement = this.findOption(optionText);
+            return exports.htmlSelectOption.initialize(optionElement);
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Page[]} List of Page objects for each `<option>` element in the dropdown
+     */
+    options: {
+        get: function () {
+            return this.optionElements.map(function (optionElement) {
+                return exports.htmlSelectOption.initialize(optionElement);
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Integer} The number of `<option>` elements in the dropdown
+     */
+    optionCount: {
+        value: function () {
+            return this.optionElements.count();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {WebElement[]} List of all `<option>` elements in the dropdown
+     */
+    optionElements: {
+        get: function () {
+            return this.rootElement.$$('option');
+        }
+    },
+
+    /**
+     * @function
+     * @param {String} optionText
+     *   Partial or total string to match the display value of the desired `<option>` element
+     * @returns {Boolean} Whether or not the option exists
+     */
+    optionExists: {
+        value: function (optionText) {
+            return this.findOption(optionText).isPresent();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {String[]} List of visible text for each `<option>` element in the dropdown
+     */
+    optionLabels: {
+        get: function () {
+            return this.options.map(function (option) {
+                return option.label;
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {String[]} List of values for each `<option>` element in the dropdown
+     */
+    optionValues: {
+        get: function () {
+            return this.options.map(function (option) {
+                return option.value;
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Page[]} List of Page objects for each selected `<option>` element in the dropdown
+     */
+    selectedOptions: {
+        get: function () {
+            return this.selectedOptionElements.map(function (optionElement) {
+                return exports.htmlSelectOption.initialize(optionElement);
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Integer} The number of selected `<option>` elements in the dropdown
+     */
+    selectedOptionCount: {
+        value: function () {
+            return this.selectedOptionElements.count();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {WebElement[]} List of all selected `<option>` elements in the dropdown.
+     */
+    selectedOptionElements: {
+        get: function () {
+            return this.rootElement.$$('option:checked');
+        }
+    },
+
+    /**
+     * @function
+     * @param {String} optionText
+     *   Partial or total string to match the display value of the desired `<option>` element.
+     * @returns {WebElement}
+     */
+    findOption: {
+        value: function (optionText) {
+            return this.rootElement.element(by.cssContainingText('option', optionText));
+        }
+    },
+
+    /**
+     * @function
+     * @param {String} optionText
+     *   Partial or total string to match the display value of the desired `<option>` element.
+     * @example
+     * ```js
+     * var dropdown = encore.htmlSelect.initialize($('#country-select'));
+     * dropdown.selectOption('United States');
+     * ```
+     */
+    selectOption: {
+        value: function (optionText) {
+            return this.option(optionText).select();
+        }
+    }
+};//htmlSelect
+
+/**
+ * @namespace
+ * @extends htmlSelect
+ * @description Type of htmlSelect that includes functionality required to interact with additional markup.
+ */
+var rxSelect = {
+    eleWrapper: {
+        get: function () {
+            return this.rootElement.element(by.xpath('..'));
+        }
+    },
+
+    eleFakeSelect: {
+        get: function () {
+            return this.eleWrapper.$('.fake-select');
+        }
+    },
+
+    /**
+     * @function
+     * @override
+     * @returns {Boolean} Whether or not the wrapper has expected disabled class name
+     */
+    isDisabled: {
+        value: function () {
+            return this.eleWrapper.getAttribute('class').then(function (classes) {
+                return _.contains(classes.split(' '), 'rx-disabled');
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @override
+     * @returns {Boolean} Whether the styled element is currently displayed.
+     */
+    isDisplayed: {
+        value: function () {
+            return this.rootElement.isDisplayed() && this.eleFakeSelect.isDisplayed();
+        }
+    },
+
+    /**
+     * @function
+     * @override
+     * @returns {Boolean} Whether or not the styled element exists on the page
+     */
+    isPresent: {
+        value: function () {
+            return this.eleFakeSelect.isPresent();
+        }
+    }
+};
+rxSelect = _.assign(htmlSelect, rxSelect);
+
+/**
+ * @exports encore.htmlSelectOption
+ */
+exports.htmlSelectOption = {
+    /**
+     * @function
+     * @param {WebElement} selectOption - WebElement to be transformed into an htmlSelectOption page object
+     * @returns {htmlSelectOption} Page object representing an `<option>` element.
+     */
+    initialize: function (selectOptionElement) {
+        htmlSelectOption.rootElement = {
+            get: function () { return selectOptionElement; }
+        };
+        return Page.create(htmlSelectOption);
+    }
+};
+
+/**
+ * @exports encore.htmlSelect
+ */
+exports.htmlSelect = {
+    /**
+     * @function
+     * @param {WebElement} selectElement - WebElement to be transformed into an htmlSelect page object
+     * @returns {htmlSelect} Page object representing a `<select>` element
+     */
+    initialize: function (selectElement) {
+        htmlSelect.rootElement = {
+            get: function () { return selectElement; }
+        };
+        return Page.create(htmlSelect);
+    },
+
+    /**
+     * @returns {htmlSelect} Page object representing the _first_ `<select>` element found on the page
+     */
+    main: (function () {
+        htmlSelect.rootElement = {
+            get: function () { return $('select')[0]; }
+        };
+    })()
+};
+
+/**
+ * @exports encore.rxSelect
+ */
+exports.rxSelect = {
+    /**
+     * @function
+     * @param {WebElement} rxSelectElement - WebElement to be transformed into an rxSelect page object
+     * @returns {rxSelect} Page object representing a `<select rx-select>` element.
+     */
+    initialize: function (rxSelectElement) {
+        rxSelect.rootElement = {
+            get: function () { return rxSelectElement; }
+        };
+        return Page.create(rxSelect);
+    },
+
+    /**
+     * @returns {rxSelect} Page object representing the _first_ `<select rx-select>` element found on the page
+     */
+    main: (function () {
+        rxSelect.rootElement = {
+            get: function () { return $('select[rx-select]')[0]; }
+        };
+    })()
+};

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -188,3 +188,23 @@
 @rxCheckbox-background-color-selected: #4881c0;
 @rxCheckbox-border-color: #ccc;
 @rxCheckbox-border-color-selected: @rxCheckbox-background-color-selected;
+
+/*
+ * rxSelect
+ */
+@rxSelect-min-width: @inputWidth;
+@rxSelect-min-height: 26px;
+@rxSelect-color: @inputColor;
+@rxSelect-background: #fff;
+@rxSelect-trigger-background: #fff;
+@rxSelect-color-disabled: @inputColorDisabled;
+@rxSelect-background-disabled: @inputBackgroundDisabled;
+@rxSelect-border-color: @inputBorderColor;
+@rxSelect-border-color-invalid: @inputBorderColorInvalid;
+@rxSelect-border-color-disabled: @inputBorderColor;
+@rxSelect-border-radius: @inputBorderRadius;
+@rxSelect-border-width: 1px;
+@rxSelect-trigger-width: @rxSelect-min-height;
+@rxSelect-trigger-color: #aaa;
+@rxSelect-trigger-color-invalid: @inputBorderColorInvalid;
+@rxSelect-trigger-color-disabled: @rxSelect-trigger-color;

--- a/wraith/configs/config.yaml
+++ b/wraith/configs/config.yaml
@@ -59,6 +59,7 @@ paths:
   rxPermission: "/#/component/rxPermission"
   rxRadio: "/#/component/rxRadio"
   rxSearchBox: "/#/component/rxSearchBox"
+  rxSelect: "/#/component/rxSelect"
   rxSelectFilter: "/#/component/rxSelectFilter"
   rxSession: "/#/component/rxSession"
   rxSessionStorage: "/#/component/rxSessionStorage"


### PR DESCRIPTION
Per necessity of rxForm rework, but this directive can stand alone for use elsewhere in the framework.

* `$destroy` support
* apply `rx-disabled` class to wrapper if disabled by either `disabled` or `ng-disabled`
* exercises added to test common functionality
* page objects exports `rxSelect`, `htmlSelectOption`, and `htmlSelect`
  * `htmlSelectOption` and `htmlSelect` provides page object support for
    non-styled elements
* rxCheckbox.page.js updated to export both `rxCheckbox` and `htmlCheckbox`
  * this is to provide page object support for non-styled checkboxes
* rxRadio.page.js updated to export both `rxRadio` and `htmlRadio`
  * this is to provide page object support for non-styled radios
* Lays groundwork for #884

Closes #896