### PR TITLE
fix(componentTemplate): update to .controller() syntax

### DIFF
--- a/grunt-tasks/component-template/root/docs/component.js
+++ b/grunt-tasks/component-template/root/docs/component.js
@@ -1,6 +1,6 @@
 /*jshint unused:false*/
-
-// This file is used to help build the 'demo' documentation page and should be updated with example code
-function {%= name %}Ctrl ($scope) {
-
-}
+angular.module('demoApp')
+.controller('{%= name %}Ctrl', function ($scope) {
+    // This controller is used to help build the 'demo' documentation page
+    // and should be updated with example code
+});


### PR DESCRIPTION
Update component template to use the `.controller('myController', function ($scope) {...})` syntax. This is for angular 1.3+ support of new components.