### PR TITLE
fix(rxRadio): fix broken styles

### DIFF
--- a/src/rxRadio/docs/rxRadio.html
+++ b/src/rxRadio/docs/rxRadio.html
@@ -45,6 +45,7 @@
              ng-model="radCreateDestroy" />
       <label for="radDestroy">Destroyed</label>
     </span>
+    &nbsp;
     <span>
       <input rx-radio
              id="radCreated"

--- a/src/rxRadio/rxRadio.less
+++ b/src/rxRadio/rxRadio.less
@@ -5,7 +5,7 @@
   display: inline-block;
   width: @rxRadio-size;
   height: @rxRadio-size;
-  background-color: @rxRadio-background-color;
+  background-color: transparent;
   position: relative;
 
   input[type="radio"],
@@ -27,10 +27,10 @@
     height: 100%;
     .border-radius(100%);
     overflow: hidden;
-    border: 1px solid @inputBorderColor;
+    border: @rxRadio-border-width solid @inputBorderColor;
+    background-color: @rxRadio-background-color;
 
     // perfect center alignment for tick
-    // TODO: use MIXINS
     .flexbox();
     .flex-flow(row nowrap);
     .align-items(center);
@@ -38,9 +38,10 @@
 
     .tick {
       .flex(0 0 auto);
-      .border-radius(100%);
-      width: 60%;
-      height: 60%;
+      .box-sizing(border-box);
+      .border-radius(@rxRadio-tick-border-radius);
+      width: @rxRadio-tick-size;
+      height: @rxRadio-tick-size;
       background-color: transparent;
     }
   }//.fake-radio
@@ -81,11 +82,12 @@
     &.ng-invalid {
       // enabled unchecked error
       & + .fake-radio {
-        border: 2px solid @rxRadio-color-error;
+        border: @rxRadio-border-width-invalid solid @rxRadio-color-error;
 
         .tick {
-          width: 70%;
-          height: 70%;
+          .border-radius(@rxRadio-tick-border-radius-invalid);
+          width: @rxRadio-tick-size-invalid;
+          height: @rxRadio-tick-size-invalid;
         }
       }
 

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -166,7 +166,16 @@
 @rxRadio-color-selected: #4881c0;
 @rxRadio-color-disabled: @inputBackgroundDisabled;
 @rxRadio-color-error: @inputBackgroundError;
-@rxRadio-tick-size: @rxRadio-size - 4px;
+@rxRadio-border-width: 1px;
+@rxRadio-border-width-invalid: 2px;
+@rxRadio-tick-margin: 3px;
+@rxRadio-tick-margin-invalid: (@rxRadio-tick-margin - (@rxRadio-border-width-invalid - @rxRadio-border-width));
+/* Size and radius must be calculated. Percentages are not consistent across browsers. */
+@rxRadio-tick-size: (@rxRadio-size - (2 * @rxRadio-border-width) - (2 * @rxRadio-tick-margin));
+@rxRadio-tick-size-invalid: (@rxRadio-size - (2 * @rxRadio-border-width-invalid) - (2 * @rxRadio-tick-margin-invalid));
+@rxRadio-tick-border-radius: (@rxRadio-tick-size / 2);
+@rxRadio-tick-border-radius-invalid: (@rxRadio-tick-size-invalid / 2);
+
 
 /*
  * rxCheckbox


### PR DESCRIPTION
(Noticed this while playing around with `rxFormOptionTable`.)

*Before - Notice the white corners on the gray and green backgrounds*
![screen shot 2015-05-18 at 1 09 00 pm](https://cloud.githubusercontent.com/assets/545605/7686999/ae0c166e-fd5f-11e4-9755-4cbd9c833776.png)

*After - no more white corners*
![screen shot 2015-05-18 at 1 09 31 pm](https://cloud.githubusercontent.com/assets/545605/7687015/c2c5fd54-fd5f-11e4-84b3-6e050c2f10c5.png)
