### PR TITLE
Add in keyMapping function to rxAutoSave

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "postinstall": "grunt hooks"
   },
   "dependencies": {
-    "normalize.css": "^3.0.2"
+    "normalize.css": "^3.0.2",
+    "karma-sinon-chai": "^0.3.0"
   },
   "devDependencies": {
     "astrolabe": "~0.3.6",

--- a/src/rxMisc/README.md
+++ b/src/rxMisc/README.md
@@ -204,3 +204,18 @@ If you wish to use a different storage backend (`SessionStorage`, for instance),
 `storageBackend` requires that you pass it an object which has `getObject(key)` and `setObject(key, val)` methods. `LocalStorage` and `SessionStorage` are both provided by EncoreUI, and support this interface.
 
 You can use your own custom backends as well, as long as it supports `getObject(key)` and `setObject(key, val)`.
+
+### Custom Storage Key Values
+Sometimes, it may be necessary to change how a key is formed for the specified `storageBackend`. As previously stated, these are calculated by prepending `'rxAutoSave::'` before the url. You can override this by passing in a `keyShaping` function to the options object.
+
+An example one would be as follows:
+
+```
+    var autosave = rxAutoSave($scope, 'formData', {
+        keyShaping: function (key) {
+            return key.replace('?cache=false', '');
+        }
+    });
+```
+
+The above example could be used to have the current url ignore any caching flags passed in. The `keyShaping` function will receive the default calculated key (`rxAutoSave::` + $location.url()). By default, `keyShaping` just returns the original calculated key.

--- a/src/rxMisc/rxMisc.js
+++ b/src/rxMisc/rxMisc.js
@@ -186,8 +186,11 @@ angular.module('encore.ui.rxMisc', ['debounce', 'encore.ui.rxSessionStorage'])
     // @param [storageBackend] - Optional, defaults to LocalStorage. If you pass in a storage object,
     //                           it must support both getObject(key) and setObject(key, val), matching
     //                           the operations of LocalStorage and SessionStorage
-    var StorageAPI = function (watchVar, storageBackend) {
-        this.key = 'rxAutoSave::' + $location.url();
+    // @param [keyShaping] - Optional, defaults to just returning the originally defined key value.
+    //                       It gets passed the original value defined ('rxAutoSave::' + $location.url())
+    //                       and is expected to return the new key that you wish to have used.
+    var StorageAPI = function (watchVar, storageBackend, keyShaping) {
+        this.key = keyShaping('rxAutoSave::' + $location.url());
         this.watchVar = watchVar;
         this.storage = storageBackend ? storageBackend : LocalStorage;
     };
@@ -284,12 +287,13 @@ angular.module('encore.ui.rxMisc', ['debounce', 'encore.ui.rxSessionStorage'])
             clearOnSuccess: undefined,
             exclude: [],
             ttl: 172800,
+            keyShaping: _.identity,
             storageBackend: LocalStorage
         });
 
         opts.ttl = opts.ttl * 1000; // convert back to milliseconds
         
-        var api = new StorageAPI(watchVar, opts.storageBackend);
+        var api = new StorageAPI(watchVar, opts.storageBackend, opts.keyShaping);
 
         var updateExpiryTime = function () {
             if (opts.ttl > 0) {

--- a/src/rxMisc/rxMisc.spec.js
+++ b/src/rxMisc/rxMisc.spec.js
@@ -336,6 +336,34 @@ describe('rxAutoSave', function () {
         expect(scope.formA.foo, 'stored data for this url').to.equal('bar');
     });
 
+    it('should allow key manipulation for stored values on URLs', function () {
+        // store a value on the default URL
+        scope.formA.foo = 'bar';
+        flush();
+
+        var oldUrl = url;
+
+        var opts = {
+            keyShaping: function (key) {
+                return key.replace('invalid', '');
+            }
+        };
+
+        // Navigate to a new URL with the same form structure
+        url = oldUrl + 'invalid';
+        initializeScope();
+        a = rxAutoSave(scope, 'formA', opts);
+        scope.$digest();
+        expect(scope.formA.foo, 'stored data for this url').to.equal('bar');
+
+        // Navigate back to the original URL
+        url = oldUrl;
+        initializeScope();
+        a = rxAutoSave(scope, 'formA', opts);
+        scope.$digest();
+        expect(scope.formA.foo, 'stored data for this url').to.equal('bar');
+    });
+
     it('should let you add a clear promise via clearOnSuccess()', function () {
         // have rxAutoSave store 'bar'
         scope.formA.foo = 'bar';


### PR DESCRIPTION
So I was using `rxAutoSave` and figured out that I needed to change how the keys are stored in localstorage, so I had to completely overwrite the storage method.

Thought that was a bit overkill and thought this would be a more "elegant" solution