### PR TITLE
style(styleguide): Fix metadata styles for expanded table

### DIFF
--- a/demo/styleguide/tables/nested-metadata.html
+++ b/demo/styleguide/tables/nested-metadata.html
@@ -19,7 +19,7 @@
               <div class="expanded-content">
                 <div class="metadata">
                   <dl ng-repeat="(attr, val) in person.pets[0]">
-                    <dt>{{ attr | rxCapitalize }}</dt>
+                    <dt>{{ attr | rxCapitalize }}:</dt>
                     <dd>{{ val }}</dd>
                   </dl>
                 </div>

--- a/src/rxApp/common.less
+++ b/src/rxApp/common.less
@@ -133,6 +133,9 @@ table {
     .expanded-content {
         background-color: @white;
         margin-top: 3px;
+        .metadata {
+            padding: 5px 10px;
+        }
     }
 }
 


### PR DESCRIPTION
Closes #804. Brings metadata styles up to date for the expanded table row view, and adds padding. 

This also addresses part of https://jira.rax.io/browse/UXENCORE-356.

Before:
![screen shot 2015-05-26 at 1 30 30 pm](https://cloud.githubusercontent.com/assets/1529366/7820094/bc1c915a-03ab-11e5-9dac-2e9327f70d38.png)

After:
![screen shot 2015-05-26 at 1 30 12 pm](https://cloud.githubusercontent.com/assets/1529366/7820100/c1462998-03ab-11e5-82e9-87b6ae41ae6c.png)
