### PR TITLE
fix(fontawesome): stop bundling FontAwesome

### DIFF
--- a/grunt-tasks/build.js
+++ b/grunt-tasks/build.js
@@ -2,7 +2,7 @@ module.exports = function (grunt) {
     grunt.registerTask('build', 'Create build files', function () {
         grunt.task.run(['clean:build', 'modules', 'concat:dist', 'concat:distTpls', 'concat:tmpLess',
             'concat:tmpLessResp', 'less:encore', 'less:encoreResp', 'less:styleguide', 'copy:demoreadme',
-            'copy:demohtml', 'copy:demoassets', 'copy:demopolyfills', 'imagemin', 'copy:font',
+            'copy:demohtml', 'copy:demoassets', 'copy:demopolyfills', 'imagemin',
             'jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs']);
     });
 };

--- a/grunt-tasks/options/copy.js
+++ b/grunt-tasks/options/copy.js
@@ -59,16 +59,7 @@ module.exports = {
                 content = content.replace(/\(\.\/(.*?)\)/g, '(' + githubPath + ')');
                 return markdown(content);
             }
-
         }
-    },
-    font: {
-        files: [{
-            expand: true,
-            src: ['*'],
-            cwd: 'build/bower_components/font-awesome/fonts',
-            dest: '<%= config.font %>'
-        }]
     },
     coverage: {
         files: [{

--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -2,7 +2,6 @@ module.exports = {
     app: 'src',
     build: 'build',
     dist: '<%= config.build %>/dist', // used for js/css files pushed to CDN/bower
-    font: '<%= config.dist %>/font',
     docs: 'build', // used for demo, coverage, jsdocs files to go to gh-pages (same a 'build' folder, but a
                    // different variable in case they're later changed)
     exportableStyles: '<%= config.app %>/styles',

--- a/src/rxApp/common.less
+++ b/src/rxApp/common.less
@@ -1,5 +1,3 @@
-@import (less) 'demo/bower_components/font-awesome/less/font-awesome.less';
-@fa-font-path: 'font';
 @import 'vars';
 @import (inline) 'normalize.css';
 


### PR DESCRIPTION
1. **bower**: Because `font-awesome` is already a bower dependency, it will be installed automatically as a sibling bower dependency within the target app (i.e. no need to bundle).
2. **demo**: `demo/index.html` is already including the font-awesome CSS (configured via `grunt wiredep`).
3. Likely related to #774 