### PR TITLE
fix(ng1dot3): modify for angular 1.3 support

### DIFF
--- a/src/rxCheckbox/rxCheckbox.js
+++ b/src/rxCheckbox/rxCheckbox.js
@@ -12,32 +12,34 @@ angular.module('encore.ui.rxCheckbox', [])
 
             return function (scope, element, attrs) {
                 var disabledClass = 'rx-disabled';
-                var wrapper = angular.element('<div class="rxCheckbox"></div>');
+                var wrapper = '<div class="rxCheckbox"></div>';
                 var fakeCheckbox = '<div class="fake-checkbox">' +
                         '<div class="tick fa fa-check"></div>' +
                     '</div>';
 
                 element.wrap(wrapper);
                 element.after(fakeCheckbox);
+                // must be defined AFTER the element is wrapped
+                var parent = element.parent();
 
                 // apply/remove disabled attribute so we can
                 // apply a CSS selector to style sibling elements
                 if (attrs.disabled) {
-                    wrapper.addClass(disabledClass);
+                    parent.addClass(disabledClass);
                 }
                 if (_.has(attrs, 'ngDisabled')) {
                     scope.$watch('ngDisabled', function (newVal) {
                         if (newVal === true) {
-                            wrapper.addClass(disabledClass);
+                            parent.addClass(disabledClass);
                         } else {
-                            wrapper.removeClass(disabledClass);
+                            parent.removeClass(disabledClass);
                         }
                     });
                 }
 
                 // remove stylistic markup when element is destroyed
                 element.on('$destroy', function () {
-                    wrapper[0].remove();
+                    parent[0].remove();
                 });
             };
         }//compile

--- a/src/rxRadio/rxRadio.js
+++ b/src/rxRadio/rxRadio.js
@@ -12,32 +12,34 @@ angular.module('encore.ui.rxRadio', [])
 
             return function (scope, element, attrs) {
                 var disabledClass = 'rx-disabled';
-                var wrapper = angular.element('<div class="rxRadio"></div>');
+                var wrapper = '<div class="rxRadio"></div>';
                 var fakeRadio = '<div class="fake-radio">' +
                         '<div class="tick"></div>' +
                     '</div>';
 
                 element.wrap(wrapper);
                 element.after(fakeRadio);
+                // must be defined AFTER the element is wrapped
+                var parent = element.parent();
 
                 // apply/remove disabled attribute so we can
                 // apply a CSS selector to style sibling elements
                 if (attrs.disabled) {
-                    wrapper.addClass(disabledClass);
+                    parent.addClass(disabledClass);
                 }
                 if (_.has(attrs, 'ngDisabled')) {
                     scope.$watch('ngDisabled', function (newVal) {
                         if (newVal === true) {
-                            wrapper.addClass(disabledClass);
+                            parent.addClass(disabledClass);
                         } else {
-                            wrapper.removeClass(disabledClass);
+                            parent.removeClass(disabledClass);
                         }
                     });
                 }
 
                 // remove stylistic markup when element is destroyed
                 element.on('$destroy', function () {
-                    wrapper[0].remove();
+                    parent[0].remove();
                 });
             };
         }//compile

--- a/src/rxSelect/rxSelect.js
+++ b/src/rxSelect/rxSelect.js
@@ -15,7 +15,7 @@ angular.module('encore.ui.rxSelect', [])
         },
         link: function (scope, element, attrs) {
             var disabledClass = 'rx-disabled';
-            var wrapper = angular.element('<div class="rxSelect"></div>');
+            var wrapper = '<div class="rxSelect"></div>';
             var fakeSelect = '<div class="fake-select">' +
                     '<div class="select-trigger">' +
                         '<i class="fa fa-fw fa-caret-down"></i>' +
@@ -24,25 +24,27 @@ angular.module('encore.ui.rxSelect', [])
 
             element.wrap(wrapper);
             element.after(fakeSelect);
+            // must be defined AFTER the element is wrapped
+            var parent = element.parent();
 
             // apply/remove disabled class so we have the ability to
             // apply a CSS selector for purposes of style sibling elements
             if (_.has(attrs, 'disabled')) {
-                wrapper.addClass(disabledClass);
+                parent.addClass(disabledClass);
             }
             if (_.has(attrs, 'ngDisabled')) {
                 scope.$watch('ngDisabled', function (newVal) {
                     if (newVal === true) {
-                        wrapper.addClass(disabledClass);
+                        parent.addClass(disabledClass);
                     } else {
-                        wrapper.removeClass(disabledClass);
+                        parent.removeClass(disabledClass);
                     }
                 });
             }
 
             // remove stylistic markup when element is destroyed
             element.on('$destroy', function () {
-                wrapper[0].remove();
+                parent[0].remove();
             });
         }
     };


### PR DESCRIPTION
This is to provide support for angular 1.3+

Though we're not entirely sure what caused the issue, it seems that the `wrapper` variable used to wrap the native form elements seems to be disconnected from the DOM in angular 1.3.0 and above.  The workaround is to use `element.parent()` instead of `wrapper`.