### PR TITLE
feat(rxApp): Add LDAP filtering in the nav

### DIFF
--- a/src/rxApp/templates/rxAppNavItem.html
+++ b/src/rxApp/templates/rxAppNavItem.html
@@ -1,4 +1,4 @@
-<li class="rx-app-nav-item" ng-show="isVisible(item.visibility)"
+<li class="rx-app-nav-item" ng-show="isVisible(item.visibility, item.roles)"
 ng-class="{'has-children': item.children.length > 0, active: item.active, 'rx-app-key-{{ item.key }}': item.key }">
     <a href="{{ item.url }}" class="item-link" ng-click="toggleNav($event, item.href)">{{item.linkText}}</a>
     <div class="item-content" ng-show="item.active && (item.directive || item.children)">

--- a/src/rxPermission/README.md
+++ b/src/rxPermission/README.md
@@ -1,3 +1,21 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-Service and directive for mananging permissions in EncoreUI
+Service and directive for mananging permissions in EncoreUI.
+
+A factory `Permission` is provided, for working with roles, and a directive `rxPermission` for excluding DOM content based on roles.
+
+# `Permission`
+
+`Permission` exposes three methods.
+
+## `getRoles()`
+This method takes no arguments, and returns all the roles tied to the user, in the exact format available in their Session token.
+
+## `hasRole(roles)`
+Given an array of roles (strings), this method returns `true` if the user has at least one of those roles, and `false` otherwise.
+
+## `hasAllRoles(roles)`
+Given an array of roles (strings), this method returns `true` if the user has _all_ of the roles, and `false` otherwise.
+
+# `rxPermission`
+This directive can be used to hide or show content based on whether or not the user has the specified role. See the demo below for an example.

--- a/src/rxPermission/rxPermission.spec.js
+++ b/src/rxPermission/rxPermission.spec.js
@@ -100,5 +100,20 @@ describe('rxPermission', function () {
             expect(session.getToken).to.be.called;
         });
 
+        it('Permission service: should accept array of roles', function () {
+            expect(permission.hasRole(['Customer', 'Invalid Role'])).to.be.true;
+            expect(permission.hasRole(['Custom', 'Er Role', 'Today'])).to.be.false;
+            expect(permission.hasRole(['Test', 'Er Role', 'Today'])).to.be.true;
+            expect(session.getToken).to.be.called;
+
+        });
+
+        it('Permission service: should validate if user has all roles', function () {
+            expect(permission.hasAllRoles(['Customer', 'Invalid Role'])).to.be.false;
+            expect(permission.hasAllRoles(['Customer', 'Test'])).to.be.true;
+            expect(permission.hasAllRoles(['Customer', 'Test', 'Today'])).to.be.false;
+            expect(session.getToken).to.be.called;
+        });
+
     });
 });


### PR DESCRIPTION
Closes #958

This adds the ability to filter individual items in the nav
by requiring certain LDAP roles. If a logged-in user doesn't
have the necessary roles, then the item won't appear in the nav
for them.

Note: Before we can really start to use this, all Encore products will have to be running whatever version of the framework incorporates this change. Otherwise all nav items will be displayed when the user is in a non-updated product.

Note that I haven't explicitly documented how to add these roles to the nav. I don't know yet where the right place is for that. Likely better to increase documentation in the encore-ui-nav repo.