### PR TITLE
feat(rxSelectFilter): Leverage new rxCheckbox and rxSelect components

### DIFF
--- a/src/rxSelect/rxSelect.js
+++ b/src/rxSelect/rxSelect.js
@@ -27,7 +27,7 @@ angular.module('encore.ui.rxSelect', [])
 
             // apply/remove disabled class so we have the ability to
             // apply a CSS selector for purposes of style sibling elements
-            if (attrs.disabled) {
+            if (_.has(attrs, 'disabled')) {
                 wrapper.addClass(disabledClass);
             }
             if (_.has(attrs, 'ngDisabled')) {

--- a/src/rxSelect/rxSelect.less
+++ b/src/rxSelect/rxSelect.less
@@ -4,7 +4,6 @@
 .rxSelect {
   .box-sizing(border-box);
   display: block;
-  overflow: hidden;
   position: relative;
   color: @rxSelect-color;
   background: @rxSelect-background;
@@ -12,7 +11,7 @@
 
   // Element should be resizable via wrapper alone
   min-width: @rxSelect-min-width;
-  min-height: @rxSelect-min-height;
+  height: @rxSelect-height;
 
   &.rx-disabled {
     color: @inputColorDisabled;
@@ -21,6 +20,7 @@
 
   // position elements in wrapper
   select,
+  rx-multi-select,
   .fake-select {
     .box-sizing(border-box);
     position: absolute;
@@ -30,9 +30,9 @@
     height: 100%;
   }
 
-  select {
+  select,
+  rx-multi-select {
     z-index: 0;
-    padding: 5px;
     cursor: pointer;
 
     // reset native styling

--- a/src/rxSelectFilter/README.md
+++ b/src/rxSelectFilter/README.md
@@ -165,4 +165,4 @@ Merely calls the `applyTo()` method of a `SelectFilter` instance to an input arr
 
 Remember to adhere to the Null Pattern for [tables](#/styleguide/tables) in Encore UI.  When there are no results to populate the table, the table content should say "No [x] were found."  However, if the table is empty because of the applied filters, the message should instead say "No results match those criteria."  This has been included in the demo below for an example implemtation.
 
-The developer is reponsible for ensuring that the multi-select input is wide enough to show the preview text. Especially for the "All except [x]" case, the text could wrap if the proper width is not set.  To facilitate this, a class is provided that adds a '-filter' suffix to the filtered property.  See the demo markup for an example.
+The developer is reponsible for ensuring that the multi-select input is wide enough to show the preview text. Especially for the "All except [x]" case, the text could clip if the proper width is not set.  To facilitate this, a class is provided that adds a '-filter' suffix to the filtered property.  See the demo markup for an example.

--- a/src/rxSelectFilter/docs/rxSelectFilter.html
+++ b/src/rxSelectFilter/docs/rxSelectFilter.html
@@ -1,15 +1,23 @@
 <!-- Sample HTML goes here as a live example of how the component can be used -->
 <div ng-controller="rxSelectFilterCtrl">
     <h3 class="title">rxMultiSelect Input</h3>
-    <rx-form-item label="Classification">
+    <p class="multi-select-container">
+        <span class="field-label">Classification:</span>
         <rx-multi-select ng-model="data.classification" id="classification">
             <rx-select-option value="A">Type A</rx-select-option>
             <rx-select-option value="B">Type B</rx-select-option>
             <rx-select-option value="C">Type C</rx-select-option>
             <rx-select-option value="D">Type D</rx-select-option>
         </rx-multi-select>
-    </rx-form-item>
+    </p>
     <span>Model value: [{{ data.classification.join(', ') }}]</span>
+
+    <p class="multi-select-container">
+        <span class="field-label">Disabled:</span>
+        <rx-multi-select ng-model="data.other" disabled>
+            <rx-select-option value="Not allowed"></rx-select-option>
+        </rx-multi-select>
+    </p>
 
     <h3 class="title">Filtered Table</h3>
     <table class="table-striped">
@@ -39,7 +47,15 @@
     </table>
 </div>
 <style>
-    .status-filter .rx-multi-select {
+    .multi-select-container {
+        width: 200px;
+    }
+
+    .account-filter .rxSelect {
+        width: 150px;
+    }
+
+    .status-filter .rxSelect {
         width: 180px;
     }
 </style>

--- a/src/rxSelectFilter/rxSelectFilter.exercise.js
+++ b/src/rxSelectFilter/rxSelectFilter.exercise.js
@@ -44,7 +44,7 @@ exports.rxMultiSelect = function (options) {
         });
 
         it('selects no options', function () {
-            component.unselect(['Select All']);
+            component.deselect(['Select All']);
             expect(component.selectedOptions).to.eventually.be.empty;
             expect(component.preview).to.eventually.equal('None');
         });
@@ -71,8 +71,8 @@ exports.rxMultiSelect = function (options) {
             expect(component.preview).to.eventually.equal('All Selected');
         });
 
-        it('unselects all options', function () {
-            component.unselect(['Select All']);
+        it('deselects all options', function () {
+            component.deselect(['Select All']);
             expect(component.selectedOptions).to.eventually.be.empty;
             expect(component.preview).to.eventually.equal('None');
         });

--- a/src/rxSelectFilter/rxSelectFilter.js
+++ b/src/rxSelectFilter/rxSelectFilter.js
@@ -1,4 +1,4 @@
-angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
+angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc', 'encore.ui.rxSelect'])
 /**
  * @ngdoc filter
  * @name encore.ui.rxSelectFilter:Apply
@@ -99,7 +99,7 @@ angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
  * @param {string} ng-model The scope property that stores the value of the input
  * @param {Array} [options] A list of the options for the dropdown
  */
-.directive('rxMultiSelect', function ($document, rxDOMHelper) {
+.directive('rxMultiSelect', function ($document, rxDOMHelper, rxSelectDirective) {
     return {
         restrict: 'E',
         templateUrl: 'templates/rxMultiSelect.html',
@@ -142,10 +142,12 @@ angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
             };
         },
         link: function (scope, element, attrs, controllers) {
-            var selectElement = rxDOMHelper.find(element, '.rx-multi-select')[0];
+            rxSelectDirective[0].link.apply(this, arguments);
+
+            var previewElement = rxDOMHelper.find(element, '.preview')[0];
 
             var documentClickHandler = function (event) {
-                if (event.target !== selectElement) {
+                if (event.target !== previewElement) {
                     scope.listDisplayed = false;
                     scope.$apply();
                 }
@@ -159,7 +161,7 @@ angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
             scope.listDisplayed = false;
 
             scope.toggleDisplay = function (event) {
-                if (event.target === selectElement) {
+                if (event.target === previewElement) {
                     scope.listDisplayed = !scope.listDisplayed;
                 } else {
                     event.stopPropagation();

--- a/src/rxSelectFilter/rxSelectFilter.less
+++ b/src/rxSelectFilter/rxSelectFilter.less
@@ -1,11 +1,17 @@
 /*
  * rxSelectFilter
  */
-@import 'vars';
-
 .rx-select-filter {
+    .rxSelect {
+        display: inline-block;
+    }
+
     .select-wrapper:not(:first-child) {
         padding-left: 20px;
+    }
+
+    .rxSelect, .field-label {
+        vertical-align: middle;
     }
 
     .field-label {
@@ -13,23 +19,24 @@
     }
 }
 
-.rx-multi-select {
+rx-multi-select {
 
-    color: @inputColor;
-    border: 1px solid @inputBorderColor;
-    padding: 3px;
-    width: 150px;
-    position: relative;
-    font-size: 1.2em;
+    z-index: auto !important;
 
-    &:hover {
-        cursor:pointer;
+    &[disabled] .preview {
+        pointer-events: none;
+    }
+
+    .preview {
+        padding: 5px;
+        overflow: hidden;
+        white-space: nowrap;
     }
 
     ul {
+        z-index: 100;
         position: absolute;
-        top: ~"calc(-1px)";
-        z-index: 1;
+        top: -1px;
         left: -1px;
         width: 100%;
         border: 1px solid @inputBorderColor;
@@ -47,12 +54,18 @@
 
     label {
         display: block;
-        padding: 2px 10px;
+        padding: 4px 6px;
 
         &:hover {
             background: @optionHighlightBg;
             color: @white;
             cursor: pointer;
         }
+    }
+
+    .rxCheckbox {
+        width: @appFontSize;
+        height: @appFontSize;
+        vertical-align: middle;
     }
 }

--- a/src/rxSelectFilter/rxSelectFilter.page.js
+++ b/src/rxSelectFilter/rxSelectFilter.page.js
@@ -1,10 +1,11 @@
 /*jshint node:true*/
 var Page = require('astrolabe').Page;
 var _ = require('lodash');
+var rxCheckbox = require('../rxCheckbox/rxCheckbox.page').rxCheckbox;
 
 var selectOptionFromElement = function (optionElement) {
 
-    return Page.create({
+    return Object.create(rxCheckbox.initialize(optionElement.$('input')), {
 
         /**
          * @memberof rxMultiSelect.option
@@ -17,55 +18,12 @@ var selectOptionFromElement = function (optionElement) {
         },
 
         /**
-           Selects the option in the dropdown.
-           @memberof rxMultiSelect.option
-           @function
-           @returns {undefined}
-         */
-        select: {
-            value: function () {
-                return this.isSelected().then(function (selected) {
-                    if (!selected) {
-                        optionElement.$('input').click();
-                    }
-                });
-            }
-        },
-
-        /**
-           Unselects the option in the dropdown.
-           @memberof rxMultiSelect.option
-           @function
-           @returns {undefined}
-         */
-        unselect: {
-            value: function () {
-                return this.isSelected().then(function (selected) {
-                    if (selected) {
-                        optionElement.$('input').click();
-                    }
-                });
-            }
-        },
-
-        /**
            @memberof rxMultiSelect.option
            @returns {string} The value bound to the option.
          */
         value: {
             get: function () {
                 return optionElement.getAttribute('value');
-            }
-        },
-
-        /**
-           @memberof rxMultiSelect.option
-           @function
-           @returns {Boolean} Whether or not the option is currently selected.
-         */
-        isSelected: {
-            value: function () {
-                return optionElement.$('input').isSelected();
             }
         }
 
@@ -76,6 +34,12 @@ var selectOptionFromElement = function (optionElement) {
  * @namespace
  */
 var rxMultiSelect = {
+
+    lblPreview: {
+        get: function () {
+            return this.rootElement.$('.preview');
+        }
+    },
 
     /**
        Close the menu
@@ -88,7 +52,7 @@ var rxMultiSelect = {
             var self = this;
             this.isOpen().then(function (isOpen) {
                 if (isOpen) {
-                    self.rootElement.$('.rx-multi-select').click();
+                    self.lblPreview.click();
                 }
             });
         }
@@ -105,7 +69,7 @@ var rxMultiSelect = {
             var self = this;
             this.isOpen().then(function (isOpen) {
                 if (!isOpen) {
-                    self.rootElement.$('.rx-multi-select').click();
+                    self.lblPreview.click();
                 }
             });
         }
@@ -128,10 +92,7 @@ var rxMultiSelect = {
      */
     preview: {
         get: function () {
-            // getText() will include the text of the options as well as the preview
-            return this.rootElement.getText().then(function (text) {
-                return text.split('\n')[0];
-            });
+            return this.lblPreview.getText();
         }
     },
 
@@ -214,15 +175,15 @@ var rxMultiSelect = {
     /**
        @memberof rxMultiSelect
        @function
-       @param {string[]} optionTexts - Array of partial or total strings matching the desired options to unselect.
+       @param {string[]} optionTexts - Array of partial or total strings matching the desired options to deselect.
        @returns {undefined}
      */
-    unselect: {
+    deselect: {
         value: function (optionTexts) {
             var self = this;
             this.openMenu();
             optionTexts.forEach(function (optionText) {
-                self.option(optionText).unselect();
+                self.option(optionText).deselect();
             });
         }
     }
@@ -279,7 +240,7 @@ var rxSelectFilter = {
        @function
        @param {Object} filterData - Key-value pairs of the rxMultiSelects' labels and their options to select.
                                     The value is an object, where the keys are the options and the values indicate
-                                    if the option should be selected or unselected.
+                                    if the option should be selected or deselected.
        @returns {undefined}
        @example
        ```js
@@ -300,7 +261,7 @@ var rxSelectFilter = {
                     if (shouldSelect) {
                         multiSelect.select([option]);
                     } else {
-                        multiSelect.unselect([option]);
+                        multiSelect.deselect([option]);
                     }
                 });
                 multiSelect.closeMenu();

--- a/src/rxSelectFilter/rxSelectFilter.spec.js
+++ b/src/rxSelectFilter/rxSelectFilter.spec.js
@@ -45,15 +45,16 @@ describe('rxMultiSelect', function () {
             });
 
             it('toggles the visibility of the menu when clicked', function () {
-                el.children().click();
+                var previewElement = angular.element(el[0].querySelector('.preview'));
+                previewElement.click();
                 expect(isolateScope.listDisplayed).to.be.true;
 
-                el.children().click();
+                previewElement.click();
                 expect(isolateScope.listDisplayed).to.be.false;
             });
 
             it('does not toggle the visibility of the menu when a child element is clicked', function () {
-                el.children().children().click();
+                angular.element(el[0].querySelector('rx-select-option')).click();
                 expect(isolateScope.listDisplayed).to.be.false;
             });
 

--- a/src/rxSelectFilter/templates/rxMultiSelect.html
+++ b/src/rxSelectFilter/templates/rxMultiSelect.html
@@ -1,5 +1,5 @@
-<div class="rx-multi-select field-select" ng-click="toggleDisplay($event)">
-    {{ preview }}
+<div ng-click="toggleDisplay($event)">
+    <div class="preview">{{ preview }}</div>
     <ul ng-show="listDisplayed">
         <rx-select-option value="all">Select All</rx-select-option>
         <rx-select-option value="{{option}}" ng-repeat="option in options"></rx-select-option>

--- a/src/rxSelectFilter/templates/rxSelectOption.html
+++ b/src/rxSelectFilter/templates/rxSelectOption.html
@@ -1,6 +1,6 @@
 <li class="rx-select-option">
     <label>
-        <input type="checkbox" ng-model="isSelected" ng-click="toggle()" />
+        <input rx-checkbox ng-model="isSelected" ng-click="toggle()" />
         <span ng-if="!transclusion">{{value | titleize}}</span>
         <span ng-transclude></span>
     </label>

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -192,8 +192,8 @@
 /*
  * rxSelect
  */
-@rxSelect-min-width: @inputWidth;
-@rxSelect-min-height: 26px;
+@rxSelect-min-width: 60px;
+@rxSelect-height: 26px;
 @rxSelect-color: @inputColor;
 @rxSelect-background: #fff;
 @rxSelect-trigger-background: #fff;
@@ -204,7 +204,7 @@
 @rxSelect-border-color-disabled: @inputBorderColor;
 @rxSelect-border-radius: @inputBorderRadius;
 @rxSelect-border-width: 1px;
-@rxSelect-trigger-width: @rxSelect-min-height;
+@rxSelect-trigger-width: @rxSelect-height;
 @rxSelect-trigger-color: #aaa;
 @rxSelect-trigger-color-invalid: @inputBorderColorInvalid;
 @rxSelect-trigger-color-disabled: @rxSelect-trigger-color;


### PR DESCRIPTION
Fixes #990 
Now, this input looks the same as `rx-select` and can be disabled.  Also, preview text (e.g. "2 Selected") that exceeds the width of the control will now be clipped instead of wrapping to a new line.
![screen shot 2015-06-02 at 9 31 39 am](https://cloud.githubusercontent.com/assets/5414922/7938301/6d5265b8-090a-11e5-9613-42fb8bcca83a.png)
![screen shot 2015-06-02 at 9 31 26 am](https://cloud.githubusercontent.com/assets/5414922/7938300/6c46374e-090a-11e5-9019-84cb02d15367.png)