### PR TITLE
fix(rxSelectFilter): correctly render preselected options

### DIFF
--- a/src/rxSelectFilter/rxSelectFilter.js
+++ b/src/rxSelectFilter/rxSelectFilter.js
@@ -118,6 +118,14 @@ angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
             this.addOption = function (option) {
                 if (option !== 'all') {
                     this.options = _.union(this.options, [option]);
+                    this.render();
+                }
+            };
+            this.removeOption = function (option) {
+                if (option !== 'all') {
+                    this.options = _.without(this.options, option);
+                    this.unselect(option);
+                    this.render();
                 }
             };
 
@@ -170,25 +178,27 @@ angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
             var ngModelCtrl = controllers[1];
 
             ngModelCtrl.$render = function () {
-                scope.preview = (function () {
-                    function getLabel (option) {
-                        var optionElement = rxDOMHelper.find(element, '[value="' + option + '"]');
-                        return optionElement.text().trim();
-                    }
+                scope.$evalAsync(function () {
+                    scope.preview = (function () {
+                        function getLabel (option) {
+                            var optionElement = rxDOMHelper.find(element, '[value="' + option + '"]');
+                            return optionElement.text().trim();
+                        }
 
-                    if (_.isEmpty(scope.selected)) {
-                        return 'None';
-                    } else if (scope.selected.length === 1) {
-                        return getLabel(scope.selected[0]) || scope.selected[0];
-                    } else if (scope.selected.length === selectCtrl.options.length - 1) {
-                        var option = _.first(_.difference(selectCtrl.options, scope.selected));
-                        return 'All except ' + getLabel(option) || scope.selected[0];
-                    } else if (scope.selected.length === selectCtrl.options.length) {
-                        return 'All Selected';
-                    } else {
-                        return scope.selected.length + ' Selected';
-                    }
-                })();
+                        if (_.isEmpty(scope.selected)) {
+                            return 'None';
+                        } else if (scope.selected.length === 1) {
+                            return getLabel(scope.selected[0]) || scope.selected[0];
+                        } else if (scope.selected.length === selectCtrl.options.length - 1) {
+                            var option = _.first(_.difference(selectCtrl.options, scope.selected));
+                            return 'All except ' + getLabel(option) || scope.selected[0];
+                        } else if (scope.selected.length === selectCtrl.options.length) {
+                            return 'All Selected';
+                        } else {
+                            return scope.selected.length + ' Selected';
+                        }
+                    })();
+                });
             };
 
             selectCtrl.ngModelCtrl = ngModelCtrl;
@@ -235,7 +245,9 @@ angular.module('encore.ui.rxSelectFilter', ['encore.ui.rxMisc'])
 
             selectCtrl.addOption(scope.value);
 
-            selectCtrl.render();
+            scope.$on('$destroy', function () {
+                selectCtrl.removeOption(scope.value);
+            });
         }
     };
 });

--- a/src/rxSelectFilter/rxSelectFilter.spec.js
+++ b/src/rxSelectFilter/rxSelectFilter.spec.js
@@ -30,11 +30,18 @@ describe('rxMultiSelect', function () {
         };
     });
 
+    it('renders the preview text properly with preselected options', function () {
+        scope.types = _.without(scope.options, 'E');
+        var el = createDirective(optionsTemplate);
+        var isolateScope = el.isolateScope();
+        expect(isolateScope.preview).to.equal('All except E');
+    });
+
     [transcludedTemplate, optionsTemplate].forEach(function (template, i) {
 
         describe(i === 0 ? 'without options attribute' : 'with options attribute', function () {
             var isolateScope, el;
-           
+
             beforeEach(function () {
                 el = createDirective(template);
                 isolateScope = el.isolateScope();
@@ -68,7 +75,9 @@ describe('rxMultiSelect', function () {
                     expect(scope.types).to.eql([]);
                 });
 
-                it('tracks its options (except "all")', function () {
+                it('adds options (except "all") and renders', function () {
+                    ctrl.render = sinon.stub();
+
                     expect(ctrl.options).to.eql(['A', 'B', 'C', 'D', 'E']);
 
                     ctrl.addOption('F');
@@ -76,6 +85,30 @@ describe('rxMultiSelect', function () {
 
                     ctrl.addOption('all');
                     expect(ctrl.options).to.eql(['A', 'B', 'C', 'D', 'E', 'F']);
+
+                    expect(ctrl.render).to.have.been.calledOnce;
+                });
+
+                it('removes options (except "all") and renders', function () {
+                    var reducedOptions = ['A', 'B', 'C', 'D'];
+                    var options = reducedOptions.concat('E');
+                    scope.types = options;
+                    scope.$digest();
+                    ctrl.render = sinon.stub();
+
+                    expect(ctrl.options).to.eql(options);
+
+                    ctrl.removeOption('E');
+                    scope.$digest();
+                    expect(ctrl.options).to.eql(reducedOptions);
+                    expect(scope.types).to.eql(reducedOptions);
+
+                    ctrl.removeOption('all');
+                    scope.$digest();
+                    expect(ctrl.options).to.eql(reducedOptions);
+                    expect(scope.types).to.eql(reducedOptions);
+
+                    expect(ctrl.render).to.have.been.calledOnce;
                 });
 
                 it('selects and unselects a single option', function () {
@@ -158,6 +191,13 @@ describe('rxMultiSelect', function () {
                     ctrl.select('C');
                     scope.$digest();
                     expect(isolateScope.preview).to.equal('3 Selected');
+                });
+
+                it('rerenders when the model is changed outside the controller', function () {
+                    var label = el[0].querySelector('rx-select-option[value="A"]').textContent.trim();
+                    scope.types = ['A'];
+                    scope.$digest();
+                    expect(isolateScope.preview).to.equal(label);
                 });
 
             });


### PR DESCRIPTION
Fixex #984 
The preview text requires that the DOM has been updated, as it uses an option's label in some cases.  Also, the component internally tracks the list of available options, and this list is used in the preview text logic.  However, items weren't being removed if the option element was removed.