### PR TITLE
fix(visualRegression): Correct branch names

### DIFF
--- a/grunt-tasks/options/shell.js
+++ b/grunt-tasks/options/shell.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
         screenshotsPush: {
             command: ['[ ${ghToken} -n ] && exit 0;',
                       '[ ${TRAVIS_BRANCH} = "false" ] && exit 0;',
-                      'ENCORE_SHA=`git rev-parse HEAD | cut -c-7`;',
+                      'ENCORE_SHA=`echo $TRAVIS_COMMIT_RANGE | cut -c44-51`',
                       'BRANCH=SHA-$ENCORE_SHA;',
                       'cd screenshots; git checkout -b $BRANCH;',
                       'git config user.email "comeatmebro@users.noreply.github.com";',


### PR DESCRIPTION
The idea is to have visual regression branch names match the SHA of the
commit that Travis just got done building. I thought it made sense to
grab this commit SHA directly from git itself, but it appears that
Travis only clones a portion of the repository or something. It reports
back different SHAs for the commits than what's in github.

From now on, grab the SHA from the range of commits that Travis sees
from github, which is located in a special Travis environment variable.