### PR TITLE
feat(FlexLayout): remove outer margins on layout-margin

### DIFF
--- a/src/layout/docs/responsiveLayout.html
+++ b/src/layout/docs/responsiveLayout.html
@@ -88,18 +88,20 @@
     <h2 class="title">Flex Order Attribute</h2>
 
     <div layout="row" layout-margin>
-      <div flex flex-order="3" class="flex-box dark-blue">
+      <div flex flex-order="3" class="flex-box dark-blue margin-left">
         [flex-order="3"]
       </div>
-      <div flex flex-order="2" class="flex-box light-blue">
+      <div flex flex-order="2" class="flex-box light-blue margin-right margin-left">
         [flex-order="2"]
       </div>
-      <div flex flex-order="1" class="flex-box dark-green">
+      <div flex flex-order="1" class="flex-box dark-green margin-right">
         [flex-order="1"]
       </div>
     </div>
 
     <p>Add the <code>flex-order</code> attribute to a layout child to set its position within the layout. Any value from 0-9 is accepted.</p>
+
+    <p>Note that the <code>flex-order</code> attribute is not compatible with the <code>layout-margin</code> attribute. This is because the CSS selector engine selects based on DOM markup order and the <code>layout-margin</code> attribute makes use of <code>:first-child</code> and <code>:last-child</code> to apply margins to only the inner elements in the container. As a work-around, <code>[flex-order].left-margin</code> and <code>[flex-order].right-margin</code> classes are availabe to manually add margins. The most likely use cases for these classes is for programatic ordering of children.</p>
 
     <table>
         <tr>
@@ -136,7 +138,7 @@
     <h2 class="title">Flex Offset Attribute</h2>
 
     <div layout="row">
-      <div flex offset="33" class="flex-box dark-blue">
+      <div flex flex-offset="33" class="flex-box dark-blue">
         [flex offset="33"]
       </div>
       <div flex class="flex-box light-blue">

--- a/src/layout/layout.less
+++ b/src/layout/layout.less
@@ -26,11 +26,6 @@
   padding: @layout-gutter-width / 2;
 }
 
-[layout-margin],
-[layout-margin] > [flex] {
-  margin: @layout-gutter-width / 2;
-}
-
 [layout-wrap] {
   .flex-wrap(wrap);
 }
@@ -60,8 +55,25 @@
 }
 
 
+// Vertical and horizontal margins, except on outside and on flex-ordered elements
+.layout-margin-for-name(@divisor, @suffix: null) {
+  .concat-selector('flex', @suffix);
+  [layout-margin] > [@{selector}]:not([flex-order])  {
+    margin: (@layout-gutter-width / @divisor);
+    &:first-child { margin-left: 0; }
+    &:last-child { margin-right: 0; }
+  }
+}
+
+
 .flex-order-for-name(@suffix: null) {
   .concat-selector('flex-order', @suffix);
+  [@{selector}].margin-right {
+    margin-right: @layout-gutter-width / 2;
+  }
+  [@{selector}].margin-left {
+    margin-left: @layout-gutter-width / 2;
+  }
   .loop (@i) when (@i < 10) {
     [@{selector}="@{i}"] { order: @i; }
     .loop (@i + 1);
@@ -190,6 +202,7 @@
 // Flex attributes for layout children
 // ------------------------------
 
+.layout-margin-for-name(2);
 .flex-properties-for-name();
 .layout-align-for-name();
 .flex-order-for-name();

--- a/src/layout/responsive.less
+++ b/src/layout/responsive.less
@@ -22,21 +22,13 @@
   padding: @layout-gutter-width / 1;
 }
 
-[layout-margin] > [flex-sm],
-[layout-margin] > [flex-lt-md]
-{
-  margin: @layout-gutter-width / 4;
-}
-[layout-margin] > [flex-gt-sm],
-[layout-margin] > [flex-md],
-[layout-margin] > [flex-lt-lg] {
-  margin: @layout-gutter-width / 2;
-}
-[layout-margin] > [flex-gt-md],
-[layout-margin] > [flex-lg]
-{
-  margin: @layout-gutter-width / 1;
-}
+.layout-margin-for-name(4, sm);
+.layout-margin-for-name(4, lt-md);
+.layout-margin-for-name(2, gt-sm);
+.layout-margin-for-name(2, md);
+.layout-margin-for-name(2, lt-lg);
+.layout-margin-for-name(1, gt-md);
+.layout-margin-for-name(1, lg);
 
 
 /**


### PR DESCRIPTION
Using layout-margin produces margins around all edges of the child elements by default. For keeping a consistent visual look in our framework and considering that the layout module is intended to replace the Pure Grid system, the outer margins on outer child elements should be removed. This will mean that layout-margin will no longer be compatible with flex-order, as css selectors currently work based on DOM order, (ie, depending on the flex-order, the first and last child selector may not represent the outer elements).