### PR TITLE
feat(rxApp): EN-1912 default to an accounts admin user

### DIFF
--- a/src/rxApp/rxApp.js
+++ b/src/rxApp/rxApp.js
@@ -438,6 +438,19 @@ angular.module('encore.ui.rxApp', ['encore.ui.rxAppRoutes', 'encore.ui.rxEnviron
         link: function (scope) {
             scope.isCloudProduct = false;
 
+            // This function is attached to the scope for the sole purpose of making
+            // it easier to test this functionality. A reorganization of this and/or 
+            // the tests is needed in order to pull this off the scope.
+            scope.switchToAdmin = function () {
+                // If the user in the params is not the admin swtich to the admin
+                // this causes the $route.current.params.user to become the admin user
+                var adminUser = _.first(_.where(scope.users, { admin: true }));
+                if (adminUser && ($route.current.params.user !== adminUser.username)){
+                    scope.currentUser = adminUser.username;
+                    scope.switchUser(adminUser.username);
+                }
+            };
+
             var checkCloud = function () {
                 encoreRoutes.isActiveByKey('accountLvlTools').then(function (isAccounts) {
                     if (isAccounts) {
@@ -458,6 +471,8 @@ angular.module('encore.ui.rxApp', ['encore.ui.rxAppRoutes', 'encore.ui.rxEnviron
             var loadUsers = function () {
                 var success = function (account) {
                     scope.users = account.users;
+                    scope.switchToAdmin();
+
                     scope.currentUser = $route.current.params.user;
                     if (!scope.currentUser) {
                         // We're not in Cloud, but instead in Billing, or Events, or

--- a/src/rxApp/rxApp.spec.js
+++ b/src/rxApp/rxApp.spec.js
@@ -1007,6 +1007,7 @@ describe('rxAccountUsers', function () {
 
             $location.url('http://server/cloud/');
             $route.current = {};
+            $route.current.originalPath = $location.url();
             $route.current.params = {
                 accountNumber: 323676,
                 user: 'hub_cap'
@@ -1014,8 +1015,8 @@ describe('rxAccountUsers', function () {
 
             scope.currentUser = 'hub_cap';
             scope.users = [
-                { username: 'testaccountuser' },
-                { username: 'hub_cap' }
+                { username: 'testaccountuser', admin: true },
+                { username: 'hub_cap', admin: false }
             ];
 
             var accountUsersHtml = $templateCache.get('templates/rxAccountUsers.html');
@@ -1024,6 +1025,11 @@ describe('rxAccountUsers', function () {
 
         userSelect = helpers.createDirective(angular.element(validTemplate), compile, scope);
         users = userSelect.find('option');
+    });
+
+    it('should switch to the admin account', function () {
+        scope.switchToAdmin();
+        expect(scope.currentUser).to.equal('testaccountuser');
     });
 
     it('should have two account users', function () {


### PR DESCRIPTION
When a user searches for an account they will, by default, have the admin user for that account selected.  They can then select a different user if they choose.

JIRA: https://jira.rax.io/browse/EN-1912