### PR TITLE
fix(e2e): Use published version for testing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -37,6 +37,7 @@
         "demoPage": true,
         "describe": false,
         "element": false,
+        "encore": true,
         "expect": true,
         "exports": false,
         "helpers": true,

--- a/demo/styleguide/layout-3.html
+++ b/demo/styleguide/layout-3.html
@@ -3,82 +3,82 @@
 <form class="rx-form clear">
   <div class="form-area">
     <rx-form-item label="Server Name">
-        <input type="text" id="serverName" required>
+	<input type="text" id="serverName" required>
     </rx-form-item>
 
     <rx-form-item label="Text area">
-        <textarea rows="10" cols="50"></textarea>
+	<textarea rows="10" cols="50"></textarea>
     </rx-form-item>
 
     <rx-form-item label="Region">
-        <span class="field-select">
-            <select
-                name="region"
-                id="region">
-                <option>ORD</option>
-                <option>DFW</option>
-                <option>IAD</option>
-            </select>
-        </span>
+	<span class="field-select">
+	    <select
+		name="region"
+		id="region">
+		<option>ORD</option>
+		<option>DFW</option>
+		<option>IAD</option>
+	    </select>
+	</span>
     </rx-form-item>
 
     <rx-form-item label="Monthly Cost" prefix="$" suffix="million">
-        <input type="number" ng-model="volume.cost" />
+	<input type="number" ng-model="volume.cost" />
     </rx-form-item>
   </div>
 <tabset class="clearfix clear tab-area">
     <tab heading="Tab 1">
-    <!-- Using the controller from the rxForm docs .js file -->
-        <div ng-controller="rxFormDemoCtrl">
-            <rx-form-fieldset legend="Option Table (radio w/full-width class)">
-                <rx-form-option-table
-                    data="optionTableData"
-                    columns="optionTableColumns"
-                    type="radio"
-                    model="volume.data"
-                    field-id="optionTable"
-                    selected="0"
-                    class="full-width"
-                    ></rx-form-option-table>
-            </rx-form-fieldset>
-        </div>
+    <!-- Using the controller from the rxOptionTable docs.js file -->
+	<div ng-controller="rxOptionTableCtrl">
+	    <rx-form-fieldset legend="Option Table (radio w/full-width class)">
+		<rx-form-option-table
+		    data="optionTableData"
+		    columns="optionTableColumns"
+		    type="radio"
+		    model="volume.data"
+		    field-id="optionTable"
+		    selected="0"
+		    class="full-width"
+		    ></rx-form-option-table>
+	    </rx-form-fieldset>
+	</div>
     </tab>
     <tab heading="Tab 2">
 <table class="table-striped">
     <thead>
-        <tr>
-            <th>Column 1</th>
-            <th>Column 2</th>
-            <th>Column 3</th>
-            <th>Column 4</th>
-        </tr>
+	<tr>
+	    <th>Column 1</th>
+	    <th>Column 2</th>
+	    <th>Column 3</th>
+	    <th>Column 4</th>
+	</tr>
     </thead>
     <tbody>
-        <tr>
-            <td>Lorem ipsum</td>
-            <td>1aa2bfa9-de8d-42f7-9f6d-e6437855b36e</td>
-            <td>Lorem ipsum dolor sit amet</td>
-            <td>1234567890</td>
-        </tr>
-        <tr>
-            <td>Lorem ipsum</td>
-            <td>1aa2bfa9-de8d-42f7-9f6d-e6437855b36e</td>
-            <td>Lorem ipsum dolor sit amet</td>
-            <td>1234567890</td>
-        </tr>
+	<tr>
+	    <td>Lorem ipsum</td>
+	    <td>1aa2bfa9-de8d-42f7-9f6d-e6437855b36e</td>
+	    <td>Lorem ipsum dolor sit amet</td>
+	    <td>1234567890</td>
+	</tr>
+	<tr>
+	    <td>Lorem ipsum</td>
+	    <td>1aa2bfa9-de8d-42f7-9f6d-e6437855b36e</td>
+	    <td>Lorem ipsum dolor sit amet</td>
+	    <td>1234567890</td>
+	</tr>
     </tbody>
 </table>
     </tab>
 </tabset>
 
     <div class="form-actions">
-        <button class="button submit" type="submit">
-            Submit Form
-        </button>
+	<button class="button submit" type="submit">
+	    Submit Form
+	</button>
 
-        <button class="button cancel" type="submit">
-            Cancel
-        </button>
+	<button class="button cancel" type="submit">
+	    Cancel
+	</button>
     </div>
 
 </form>

--- a/grunt-tasks/build.js
+++ b/grunt-tasks/build.js
@@ -1,8 +1,8 @@
 module.exports = function (grunt) {
     grunt.registerTask('build', 'Create build files', function () {
         grunt.task.run(['clean:build', 'modules', 'concat:dist', 'concat:distTpls', 'concat:tmpLess',
-            'concat:tmpLessResp', 'less:encore', 'less:encoreResp', 'less:styleguide', 'copy:demoreadme',
-            'copy:demohtml', 'copy:demoassets', 'copy:demopolyfills', 'imagemin',
-            'jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs']);
+                        'concat:tmpLessResp', 'less:encore', 'less:encoreResp', 'less:styleguide', 'copy:demoreadme',
+                        'copy:demohtml', 'copy:demoassets', 'copy:demopolyfills', 'imagemin', 'concat:rxPageObjects',
+                        'concat:rxPageObjectsExercises', 'jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs']);
     });
 };

--- a/grunt-tasks/component-template/root/docs/component.midway.js
+++ b/grunt-tasks/component-template/root/docs/component.midway.js
@@ -1,5 +1,4 @@
-var {%= name %}Page = require('../{%= name %}.page').{%=name %};
-var exercise = require('../{%= name %}.exercise');
+var {%= name %}Page = encore.{%=name %};
 
 describe('{%= name %}', function () {
     var {%= name %};
@@ -13,6 +12,6 @@ describe('{%= name %}', function () {
         expect({%= name %}.isDisplayed()).to.eventually.be.true;
     });
 
-    describe('exercises', exercise.{%= name %}());
+    describe('exercises', encore.exercise.{%= name %}());
 
 });

--- a/grunt-tasks/options/watch.js
+++ b/grunt-tasks/options/watch.js
@@ -30,8 +30,9 @@ module.exports = {
         files: ['src/**/docs/*.html', 'src/**/*.md', 'demo/**/*', '!demo/bower_components/**/*'],
         tasks: ['build']
     },
-    rxPageObjectsDocs: {
+    rxPageObjects: {
         files: ['src/**/*.page.js', 'src/**/*.exercise.js'],
-        tasks: ['jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs']
+        tasks: ['concat:rxPageObjects', 'concat:rxPageObjectsExercises',
+                'jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs']
     }
 };

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -27,12 +27,7 @@ var config = {
     onPrepare: function () {
         expect = require('chai').use(require('chai-as-promised')).expect;
         demoPage = require('./utils/demo.page.js');
-        browser.driver.manage().window().setSize(1366, 768); // laptop
-        screenshot = require('snappit-mocha-protractor');
-        screenshot.configure({
-            defaultResolutions: [[768, 1024], [1024, 768], // tablet
-                                 [320, 568], [568, 320]]  // phone
-        });
+        encore = require('./utils/rx-page-objects/index');
     },
 
     // Options to be passed to mocha

--- a/src/rxAccountInfo/docs/rxAccountInfo.midway.js
+++ b/src/rxAccountInfo/docs/rxAccountInfo.midway.js
@@ -1,5 +1,5 @@
-var rxAccountInfoPage = require('../rxAccountInfo.page').rxAccountInfo;
-var notifications = require('../../rxNotify/rxNotify.page').rxNotify;
+var rxAccountInfoPage = encore.rxAccountInfo;
+var notifications = encore.rxNotify;
 var expect = require('chai').use(require('chai-as-promised')).expect;
 
 describe('rxAccountInfo', function () {

--- a/src/rxActionMenu/docs/rxActionMenu.midway.js
+++ b/src/rxActionMenu/docs/rxActionMenu.midway.js
@@ -1,8 +1,8 @@
 var Page = require('astrolabe').Page;
 
-var actionMenu = require('../rxActionMenu.page').rxActionMenu;
-var rxForm = require('../../rxForm/rxForm.page').rxForm;
-var notifications = require('../../rxNotify/rxNotify.page').rxNotify;
+var actionMenu = encore.rxActionMenu;
+var rxForm = encore.rxForm;
+var notifications = encore.rxNotify;
 
 describe('rxActionMenu', function () {
     var globalDismiss, localDismiss, customActions;

--- a/src/rxActionMenu/rxActionMenu.page.js
+++ b/src/rxActionMenu/rxActionMenu.page.js
@@ -21,8 +21,7 @@ var action = function (actionElement) {
             */
             value: function (customFunctionality) {
                 actionElement.$('.modal-link').click();
-                var rxModal = exports.rxModalAction || require('../rxModalAction/rxModalAction.page').rxModalAction;
-                return rxModal.initialize(customFunctionality);
+                return exports.rxModalAction.initialize(customFunctionality);
             }
         },
 

--- a/src/rxAge/docs/rxAge.midway.js
+++ b/src/rxAge/docs/rxAge.midway.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var moment = require('moment');
 
-var rxAge = require('../rxAge.page').rxAge;
+var rxAge = encore.rxAge;
 
 describe('rxAge', function () {
     var momentsTable, isoString;

--- a/src/rxApp/docs/rxApp.midway.js
+++ b/src/rxApp/docs/rxApp.midway.js
@@ -1,5 +1,5 @@
-var rxAppPage = require('../rxApp.page').rxApp;
-var rxPage = require('../rxApp.page').rxPage;
+var rxAppPage = encore.rxApp;
+var rxPage = encore.rxPage;
 
 describe('rxApp', function () {
     var rxAppCustom, rxAppStandard;

--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
@@ -1,4 +1,4 @@
-var rxBreadcrumbs = require('../rxBreadcrumbs.page').rxBreadcrumbs;
+var rxBreadcrumbs = encore.rxBreadcrumbs;
 
 describe('rxBreadcrumbs', function () {
     var breadcrumbs;

--- a/src/rxBulkSelect/docs/rxBulkSelect.midway.js
+++ b/src/rxBulkSelect/docs/rxBulkSelect.midway.js
@@ -1,11 +1,9 @@
-var exercise = require('../rxBulkSelect.exercise');
-
 describe('rxBulkSelect', function () {
 
     before(function () {
         demoPage.go('#/component/rxBulkSelect');
     });
 
-    describe('exercises', exercise.rxBulkSelect());
+    describe('exercises', encore.exercise.rxBulkSelect());
 
 });

--- a/src/rxBulkSelect/rxBulkSelect.page.js
+++ b/src/rxBulkSelect/rxBulkSelect.page.js
@@ -1,13 +1,12 @@
 /*jshint node:true*/
 var _ = require('lodash');
 var Page = require('astrolabe').Page;
-var rxCheckbox = require('../rxCheckbox/rxCheckbox.page').rxCheckbox;
 
 /**
    @namespace
  */
 var rxBulkSelectDefaultRowFn = function (rowElement) {
-    return rxCheckbox.initialize(rowElement.$('input[type="checkbox"]'));
+    return exports.rxCheckbox.initialize(rowElement.$('input[type="checkbox"]'));
 };
 
 var rxBulkSelect = {
@@ -32,7 +31,7 @@ var rxBulkSelect = {
 
     selectAllCheckbox: {
         get: function () {
-            return rxCheckbox.initialize(
+            return exports.rxCheckbox.initialize(
                 this.rootElement.$('[rx-bulk-select-header-check]').$('input[type="checkbox"]')
             );
         }

--- a/src/rxButton/docs/rxButton.midway.js
+++ b/src/rxButton/docs/rxButton.midway.js
@@ -1,4 +1,4 @@
-var rxButtonPage = require('../rxButton.page').rxButton;
+var rxButtonPage = encore.rxButton;
 
 describe('rxButton', function () {
     var rxButton;

--- a/src/rxCharacterCount/docs/rxCharacterCount.midway.js
+++ b/src/rxCharacterCount/docs/rxCharacterCount.midway.js
@@ -1,4 +1,3 @@
-var exercise = require('../rxCharacterCount.exercise');
 
 describe('rxCharacterCount', function () {
 
@@ -6,30 +5,30 @@ describe('rxCharacterCount', function () {
         demoPage.go('#/component/rxCharacterCount');
     });
 
-    describe('defaults', exercise.rxCharacterCount({
+    describe('defaults', encore.exercise.rxCharacterCount({
         cssSelector: '.demo-default-values'
     }));
 
-    describe('low max characters', exercise.rxCharacterCount({
+    describe('low max characters', encore.exercise.rxCharacterCount({
         cssSelector: '.demo-custom-max-characters',
         maxCharacters: 25
     }));
 
-    describe('high near limit level', exercise.rxCharacterCount({
+    describe('high near limit level', encore.exercise.rxCharacterCount({
         cssSelector: '.demo-custom-low-boundary',
         nearLimit: 250
     }));
 
-    describe('count insignificant whitespace', exercise.rxCharacterCount({
+    describe('count insignificant whitespace', encore.exercise.rxCharacterCount({
         cssSelector: '.demo-custom-do-not-trim',
         ignoreInsignificantWhitespace: false
     }));
 
-    describe('initial value', exercise.rxCharacterCount({
+    describe('initial value', encore.exercise.rxCharacterCount({
         cssSelector: '.demo-initial-value'
     }));
 
-    describe('with highlighting', exercise.rxCharacterCount({
+    describe('with highlighting', encore.exercise.rxCharacterCount({
         cssSelector: '.demo-highlighting',
         maxCharacters: 10,
         highlight: true

--- a/src/rxCheckbox/docs/rxCheckbox.midway.js
+++ b/src/rxCheckbox/docs/rxCheckbox.midway.js
@@ -1,89 +1,88 @@
-var rxCheckboxPage = require('../rxCheckbox.page').rxCheckbox;
-var exercise = require('../rxCheckbox.exercise');
+var rxCheckboxPage = encore.rxCheckbox;
 
 describe('rxCheckbox', function () {
     before(function () {
         demoPage.go('#/component/rxCheckbox');
     });
 
-    describe('(State) Valid Enabled Checked', exercise.rxCheckbox({
+    describe('(State) Valid Enabled Checked', encore.exercise.rxCheckbox({
         cssSelector: "#chkValidEnabledOne",
         disabled: false,
         selected: true,
         valid: true
     }));
 
-    describe('(State) Valid Enabled UnChecked', exercise.rxCheckbox({
+    describe('(State) Valid Enabled UnChecked', encore.exercise.rxCheckbox({
         cssSelector: "#chkValidEnabledTwo",
         disabled: false,
         selected: false,
         valid: true
     }));
 
-    describe('(State) Valid Ng-Disabled Checked', exercise.rxCheckbox({
+    describe('(State) Valid Ng-Disabled Checked', encore.exercise.rxCheckbox({
         cssSelector: "#chkValidNgDisabledOne",
         disabled: true,
         selected: true,
         valid: true
     }));
 
-    describe('(State) Valid Ng-Disabled Unchecked', exercise.rxCheckbox({
+    describe('(State) Valid Ng-Disabled Unchecked', encore.exercise.rxCheckbox({
         cssSelector: "#chkValidNgDisabledTwo",
         disabled: true,
         selected: false,
         valid: true
     }));
 
-    describe('(State) Valid Disabled Checked', exercise.rxCheckbox({
+    describe('(State) Valid Disabled Checked', encore.exercise.rxCheckbox({
         cssSelector: "#chkValidDisabledOne",
         disabled: true,
         selected: true,
         valid: true
     }));
 
-    describe('(State) Valid Disabled Unchecked', exercise.rxCheckbox({
+    describe('(State) Valid Disabled Unchecked', encore.exercise.rxCheckbox({
         cssSelector: "#chkValidDisabledTwo",
         disabled: true,
         selected: false,
         valid: true
     }));
 
-    describe('(State) Invalid Enabled Checked', exercise.rxCheckbox({
+    describe('(State) Invalid Enabled Checked', encore.exercise.rxCheckbox({
         cssSelector: "#chkInvalidEnabledOne",
         disabled: false,
         selected: true,
         valid: false
     }));
 
-    describe('(State) Invalid Enabled UnChecked', exercise.rxCheckbox({
+    describe('(State) Invalid Enabled UnChecked', encore.exercise.rxCheckbox({
         cssSelector: "#chkInvalidEnabledTwo",
         disabled: false,
         selected: false,
         valid: false
     }));
 
-    describe('(State) Invalid Ng-Disabled Checked', exercise.rxCheckbox({
+    describe('(State) Invalid Ng-Disabled Checked', encore.exercise.rxCheckbox({
         cssSelector: "#chkInvalidNgDisabledOne",
         disabled: true,
         selected: true,
         valid: false
     }));
 
-    describe('(State) Invalid Ng-Disabled Unchecked', exercise.rxCheckbox({
+    describe('(State) Invalid Ng-Disabled Unchecked', encore.exercise.rxCheckbox({
         cssSelector: "#chkInvalidNgDisabledTwo",
         disabled: true,
         selected: false,
         valid: false
     }));
 
-    describe('(State) Invalid Disabled Checked', exercise.rxCheckbox({
+    describe('(State) Invalid Disabled Checked', encore.exercise.rxCheckbox({
         cssSelector: "#chkInvalidDisabledOne",
         disabled: true,
         selected: true,
         valid: false
     }));
 
-    describe('(State) Invalid Disabled Unchecked', exercise.rxCheckbox({
+    describe('(State) Invalid Disabled Unchecked', encore.exercise.rxCheckbox({
         cssSelector: "#chkInvalidDisabledTwo",
         disabled: true,
         selected: false,

--- a/src/rxCollapse/docs/rxCollapse.midway.js
+++ b/src/rxCollapse/docs/rxCollapse.midway.js
@@ -1,4 +1,3 @@
-var exercise = require('../rxCollapse.exercise');
 
 describe('rxCollapse', function () {
     var rxCollapse;
@@ -7,6 +6,6 @@ describe('rxCollapse', function () {
         demoPage.go('#/component/rxCollapse');
     });
 
-    describe('exercises', exercise.rxCollapse());
+    describe('exercises', encore.exercise.rxCollapse());
 
 });

--- a/src/rxDiskSize/docs/rxDiskSize.midway.js
+++ b/src/rxDiskSize/docs/rxDiskSize.midway.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 
-var diskSize = require('../rxDiskSize.page').rxDiskSize;
+var diskSize = encore.rxDiskSize;
 
 describe('rxDiskSize', function () {
     var diskSizesTable;

--- a/src/rxEnvironment/docs/rxEnvironment.midway.js
+++ b/src/rxEnvironment/docs/rxEnvironment.midway.js
@@ -1,4 +1,4 @@
-var environment = require('../rxEnvironment.page').rxEnvironment;
+var environment = encore.rxEnvironment;
 
 describe('rxEnvironment', function () {
 

--- a/src/rxFeedback/docs/rxFeedback.midway.js
+++ b/src/rxFeedback/docs/rxFeedback.midway.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 
-var feedback = require('../rxFeedback.page').rxFeedback;
+var feedback = encore.rxFeedback;
 
 describe('rxFeedback', function () {
     var successfulFeedback, unsuccessfulFeedback;

--- a/src/rxFeedback/rxFeedback.page.js
+++ b/src/rxFeedback/rxFeedback.page.js
@@ -95,9 +95,8 @@ var rxFeedback = {
     confirmSuccess: {
         value: function (within, fn) {
             if (fn === undefined) {
-                var notifications = exports.rxNotify || require('../rxNotify/rxNotify.page').rxNotify;
                 fn = function () {
-                    return notifications.all.exists('feedback', 'success');
+                    return exports.rxNotify.all.exists('feedback', 'success');
                 };
             }
 
@@ -112,11 +111,10 @@ var rxFeedback = {
 exports.rxFeedback = {
 
     initialize: function (rxFeedbackElement) {
-        var modal = exports.rxModalAction || require('../rxModalAction/rxModalAction.page').rxModalAction;
         rxFeedback.eleFeedback = {
             get: function () { return rxFeedbackElement; }
         };
-        return modal.initialize(rxFeedback);
+        return exports.rxModalAction.initialize(rxFeedback);
     }
 
 };

--- a/src/rxFieldName/docs/rxFieldName.midway.js
+++ b/src/rxFieldName/docs/rxFieldName.midway.js
@@ -1,6 +1,5 @@
-var rxFieldNamePage = require('../rxFieldName.page').rxFieldName;
-var rxCheckboxPage = require('../../rxCheckbox/rxCheckbox.page').rxCheckbox;
-var exercise = require('../rxFieldName.exercise');
+var rxFieldNamePage = encore.rxFieldName;
+var rxCheckboxPage = encore.rxCheckbox;
 
 describe('rxFieldName', function () {
     var subject;
@@ -9,13 +8,13 @@ describe('rxFieldName', function () {
         demoPage.go('#/component/rxFieldName');
     });
 
-    describe('(State) Required', exercise.rxFieldName({
+    describe('(State) Required', encore.exercise.rxFieldName({
         cssSelector: '#eleFieldNameStateRequired',
         visible: true,
         required: true
     }));
 
-    describe('(State) Optional', exercise.rxFieldName({
+    describe('(State) Optional', encore.exercise.rxFieldName({
         cssSelector: '#eleFieldNameStateOptional',
         visible: true,
         required: false

--- a/src/rxFloatingHeader/docs/rxFloatingHeader.midway.js
+++ b/src/rxFloatingHeader/docs/rxFloatingHeader.midway.js
@@ -1,4 +1,4 @@
-var rxFloatingHeader = require('../rxFloatingHeader.page').rxFloatingHeader;
+var rxFloatingHeader = encore.rxFloatingHeader;
 
 describe('rxFloatingHeader', function () {
     var table, tr, middleRow, middleRowY, initialY;

--- a/src/rxForm/docs/rxForm.html
+++ b/src/rxForm/docs/rxForm.html
@@ -8,7 +8,22 @@
         <rx-form-item label="Plain textbox">
             <input type="text" id="txtPlain" />
         </rx-form-item>
-
+        <p>
+          <input rx-radio
+                 id="first-option"
+                 value="First Option"
+                 ng-model="options"
+                 ng-required="false" />
+          <label for="first-option">First Option</label>
+        </p>
+        <p>
+          <input rx-radio
+                 id="second-option"
+                 value="Second Option"
+                 ng-model="options"
+                 ng-required="false" />
+          <label for="second-option">Second Option</label>
+        </p>
         <rx-form-item label="Text area">
             <textarea rows="10" cols="50"></textarea>
         </rx-form-item>
@@ -56,62 +71,5 @@
                 </select>
             </span>
         </rx-form-item>
-
-        <hr>
-
-        <h3 class="title">rxOptionTable</h3>
-
-        <rx-form-fieldset legend="Option Table (radio w/full-width class)">
-            <rx-option-table
-                id="radioOptionTable"
-                data="optionTableData"
-                columns="optionTableColumns"
-                type="radio"
-                model="volume.data"
-                field-id="optionTable"
-                selected="0"
-                class="full-width"
-                disable-fn="disableOption(tableId, fieldId, rowId)"
-                ></rx-option-table>
-        </rx-form-fieldset>
-
-        <p>Bound Value: {{volume.data}}</p>
-
-        <rx-form-fieldset legend="Option Table (checkboxes)">
-            <rx-option-table
-                columns="optionTableColumns"
-                type="checkbox"
-                id="checkboxOptionTable"
-                model="volume.checked"
-                field-id="optionCheckboxTable"
-                data="optionTableCheckboxData"
-                required="true"
-                ></rx-option-table>
-        </rx-form-fieldset>
-
-        <p>Item 1 Value: {{volume.checked[0]}}</p>
-        <p>Item 2 Value: {{volume.checked[1]}}</p>
-
-        <rx-form-fieldset legend="Option Table (empty)">
-            <rx-option-table
-                columns="optionTableColumns"
-                type="checkbox"
-                id="emptyOptionTable"
-                model="volume.checked"
-                field-id="optionCheckboxTable"
-                data="optionTableEmptyData"
-                empty-message="You don't have any data!"
-                ></rx-option-table>
-        </rx-form-fieldset>
-
-        <div class="form-actions">
-            <button class="button submit" type="submit">
-                Submit Form
-            </button>
-
-            <button class="button cancel" type="submit">
-                Cancel
-            </button>
-        </div>
     </form>
 </div>

--- a/src/rxForm/docs/rxForm.js
+++ b/src/rxForm/docs/rxForm.js
@@ -54,8 +54,6 @@ angular.module('demoApp')
         checked: [true, 'unchecked'] //example with first checkbox automatically checked
     };
 
-    $scope.yesOptionDescription = '<b>This</b> is HTML that included in the JS';
-
     $scope.optionTableData = [
         {
             'id': 'option1_id',
@@ -87,38 +85,6 @@ angular.module('demoApp')
             }
         }
     ];
-
-    $scope.optionTableColumns = [
-        {
-            'label': 'Name',
-            'key': 'name',
-            'selectedLabel': '(Already saved data)'
-        }, {
-            'label': 'Static Content',
-            'key': 'Some <strong>Text &</strong> HTML'
-        }, {
-            'label': 'Expression 2',
-            'key': '{{ value * 100 | number:2 }}'
-        }, {
-            'label': 'Expression 3',
-            'key': '{{ obj.name | uppercase }}'
-        }, {
-            'label': 'Expression 4',
-            'key': '{{ value | currency }}'
-        }
-    ];
-
-    $scope.optionTableCheckboxData = [
-        {
-            'name': 'Item 1'
-        }, {
-            'name': 'Item 2',
-            'value': 'checked',
-            'falseValue': 'unchecked'
-        }
-    ];
-
-    $scope.optionTableEmptyData = [];
 
     $scope.compressedLayout = { value: false };
 

--- a/src/rxForm/docs/rxForm.midway.js
+++ b/src/rxForm/docs/rxForm.midway.js
@@ -1,10 +1,15 @@
 var _ = require('lodash');
 var Page = require('astrolabe').Page;
 
-var rxForm = require('../rxForm.page').rxForm;
-var htmlCheckbox = require('../../rxCheckbox/rxCheckbox.page').htmlCheckbox;
-var htmlSelect = require('../../rxSelect/rxSelect.page').htmlSelect;
-var rxOptionTable = require('../../rxOptionTable/rxOptionTable.page').rxOptionTable;
+var rxForm = encore.rxForm;
+var htmlCheckbox = encore.htmlCheckbox;
+var htmlSelect = encore.htmlSelect;
+var rxOptionTable = encore.rxOptionTable;
+
+// shortens the process of selecting form elements on the page object below
+var elementByLabel = function (label) {
+    return $('rx-form-item[label="' + label + '"]');
+};
 
 // an anonymous page object to prove that form filling works
 var formPageObject = Page.create({

--- a/src/rxForm/docs/rxForm.midway.js
+++ b/src/rxForm/docs/rxForm.midway.js
@@ -1,11 +1,6 @@
 var _ = require('lodash');
 var Page = require('astrolabe').Page;
 
-var rxForm = encore.rxForm;
-var htmlCheckbox = encore.htmlCheckbox;
-var htmlSelect = encore.htmlSelect;
-var rxOptionTable = encore.rxOptionTable;
-
 // shortens the process of selecting form elements on the page object below
 var elementByLabel = function (label) {
     return $('rx-form-item[label="' + label + '"]');
@@ -15,37 +10,31 @@ var elementByLabel = function (label) {
 var formPageObject = Page.create({
     form: {
         set: function (formData) {
-            rxForm.fill(this, formData);
+            encore.rxForm.form.fill(this, formData);
         }
     },
 
-    plainTextbox: rxForm.textField.generateAccessor($('#txtPlain')),
+    plainTextbox: encore.rxForm.textField.generateAccessor($('#txtPlain')),
 
-    requireName: htmlCheckbox.generateAccessor($('#chkNameRequired')),
+    requireName: encore.rxForm.checkbox.generateAccessor($('#chkNameRequired')),
 
-    volumeTypeSelect: {
+    options: {
         get: function () {
             return Page.create({
-                type: htmlSelect.generateAccessor($('#selVolumeType'))
+                first: encore.rxForm.radioButton.generateAccessor($('#first-option')),
+                second: encore.rxForm.radioButton.generateAccessor($('#second-option'))
             });
         }
     },
 
-    radioTableObject: {
+    volumeTypeSelect: {
         get: function () {
-            return rxOptionTable.initialize($('#radioOptionTable'));
+            return Page.create({
+                type: encore.rxForm.dropdown.generateAccessor($('#selVolumeType'))
+            });
         }
-    },
+    }
 
-    radioTable: rxOptionTable.generateAccessor($('#radioOptionTable')),
-
-    checkboxTableObject: {
-        get: function () {
-            return rxOptionTable.initialize($('#checkboxOptionTable'));
-        }
-    },
-
-    checkboxTable: rxOptionTable.generateAccessor($('#checkboxOptionTable'))
 });
 
 describe('rxForm', function () {
@@ -57,6 +46,10 @@ describe('rxForm', function () {
         var formData = {
             plainTextbox: 'This is a plain textbox',
             requireName: false,
+            options: {
+                first: true,
+                second: false
+            },
             volumeTypeSelect: {
                 type: 'PUNCHCARDS'
             },
@@ -76,16 +69,17 @@ describe('rxForm', function () {
             expect(formPageObject.requireName).to.eventually.be.false;
         });
 
+        it('should have selected the first radio option', function () {
+            expect(formPageObject.options.first).to.eventually.be.true;
+        });
+
+        it('should not have selected the second radio option', function () {
+            expect(formPageObject.options.second).to.eventually.be.false;
+        });
+
         it('should have selected the volume type', function () {
             expect(formPageObject.volumeTypeSelect.type.text).to.eventually.equal('PUNCHCARDS');
         });
 
-        it('should have selected the second row in the radio option table', function () {
-            expect(formPageObject.radioTable).to.eventually.eql([1]);
-        });
-
-        it('should have selected both rows in the checkbox option table', function () {
-            expect(formPageObject.checkboxTable).to.eventually.eql([0, 1]);
-        });
     });
 });

--- a/src/rxForm/rxForm.page.js
+++ b/src/rxForm/rxForm.page.js
@@ -1,11 +1,6 @@
 /*jshint node:true*/
 var _ = require('lodash');
 
-var rxMisc = require('../rxMisc/rxMisc.page').rxMisc;
-var htmlCheckbox = require('../rxCheckbox/rxCheckbox.page').htmlCheckbox;
-var htmlRadio = require('../rxRadio/rxRadio.page').htmlRadio;
-var htmlSelect = require('../rxSelect/rxSelect.page').htmlSelect;
-
 /**
  * @exports encore.rxForm
  */
@@ -106,44 +101,54 @@ exports.rxForm = {
 
     /**
      * @namespace
-     * @deprecated
      * @description
-     * **DEPRECATED** Please use `encore.htmlCheckbox` or `encore.rxCheckbox` instead.
-     * This item will be removed in a future release of the EncoreUI framework.
+     * **ALISED** Directly uses <a href="#encore.module_rxCheckbox">encore.rxCheckbox</a>.
      */
-    checkbox: htmlCheckbox,
+    checkbox: {
+        get main() { return exports.rxCheckbox.main; },
+        get initialize() { return exports.rxCheckbox.initialize; },
+        get generateAccessor() { return exports.rxCheckbox.generateAccessor; }
+    },
 
     /**
      * @namespace
-     * @deprecated
      * @description
-     * **DEPRECATED** Please use `encore.htmlRadio` or `encore.rxRadio` instead.
-     * This item will be removed in a future release of the EncoreUI framework.
+     * **ALISED** Directly uses <a href="#encore.module_rxRadio">encore.rxRadio</a>.
      */
-    radioButton: htmlRadio,
+    radioButton: {
+        get main() { return exports.rxRadio.main; },
+        get initialize() { return exports.rxRadio.initialize; },
+        get generateAccessor() { return exports.rxRadio.generateAccessor; }
+    },
 
     /**
      * @namespace
-     * @deprecated
      * @description
-     * **DEPRECATED** Please use `encore.htmlSelect` or `encore.rxSelect` instead.
-     * This item will be removed in a future release of the EncoreUI framework.
+     * **ALIASED** Directly uses <a href="#encore.module_rxSelect">encore.rxSelect</a>.
      */
-    dropdown: htmlSelect,
+    dropdown: {
+        get main() { return exports.rxSelect.main; },
+        get initialize() { return exports.rxSelect.initialize; },
+        get generateAccessor() { return exports.rxSelect.generateAccessor; }
+    },
 
     /**
      * @deprecated
      * @description
-     * **DEPRECATED**: Please use `rxMisc.currencyToPennies` instead.
+     * **ALISED**: Please use {@link rxMisc.currencyToPennies} instead.
      * This function will be removed in a future release of the EncoreUI framework.
      */
-    currencyToPennies: rxMisc.currencyToPennies,
+    currencyToPennies: function (currencyString) {
+        return exports.rxMisc.currencyToPennies(currencyString);
+    },
 
     /**
      * @deprecated
      * @description
-     * **DEPRECATED**: Please use `rxMisc.slowClick` instead.
+     * **ALIASED**: Please use {@link rxMisc.slowClick} instead.
      * This function will be removed in a future release of the EncoreUI framework.
      */
-    slowClick: rxMisc.slowClick
+    slowClick: function (elem) {
+        return exports.rxMisc.slowClick(elem);
+    }
 };

--- a/src/rxInfoPanel/docs/rxInfoPanel.midway.js
+++ b/src/rxInfoPanel/docs/rxInfoPanel.midway.js
@@ -1,4 +1,4 @@
-var rxInfoPanelPage = require('../rxInfoPanel.page').rxInfoPanel;
+var rxInfoPanelPage = encore.rxInfoPanel;
 var expect = require('chai').use(require('chai-as-promised')).expect;
 
 describe('rxInfoPanel', function () {

--- a/src/rxLogout/docs/rxLogout.midway.js
+++ b/src/rxLogout/docs/rxLogout.midway.js
@@ -1,4 +1,4 @@
-var rxLogoutPage = require('../rxLogout.page').rxLogout;
+var rxLogoutPage = encore.rxLogout;
 
 describe('rxLogout', function () {
     var rxLogout;

--- a/src/rxMisc/docs/rxMisc.midway.js
+++ b/src/rxMisc/docs/rxMisc.midway.js
@@ -1,9 +1,9 @@
 var _ = require('lodash');
 var Page = require('astrolabe').Page;
 
-var rxMisc = require('../rxMisc.page').rxMisc;
-var rxForm = require('../../rxForm/rxForm.page').rxForm;
-var rxNotify = require('../../rxNotify/rxNotify.page').rxNotify;
+var rxMisc = encore.rxMisc;
+var rxForm = encore.rxForm;
+var rxNotify = encore.rxNotify;
 
 // "wait" for autosave to clear -- function passed to `browser.wait`
 var forAutoSaveToClear = function () {

--- a/src/rxModalAction/docs/rxModalAction.midway.js
+++ b/src/rxModalAction/docs/rxModalAction.midway.js
@@ -1,5 +1,5 @@
-var modal = require('../rxModalAction.page').rxModalAction;
-var rxForm = require('../../rxForm/rxForm.page').rxForm;
+var modal = encore.rxModalAction;
+var rxForm = encore.rxForm;
 
 describe('rxModalAction', function () {
     var changePasswordModal, triggerModal;

--- a/src/rxNotify/docs/rxNotify.midway.js
+++ b/src/rxNotify/docs/rxNotify.midway.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 
-var notifications = require('../rxNotify.page').rxNotify;
+var notifications = encore.rxNotify;
 
 describe('rxNotify', function () {
 

--- a/src/rxOptionTable/docs/rxOptionTable.midway.js
+++ b/src/rxOptionTable/docs/rxOptionTable.midway.js
@@ -1,7 +1,6 @@
 var _ = require('lodash');
-var rxOptionTablePage = require('../rxOptionTable.page').rxOptionTable;
-var rxMisc = require('../../rxMisc/rxMisc.page').rxMisc;
-var exercise = require('../rxOptionTable.exercise');
+var rxOptionTablePage = encore.rxOptionTable;
+var rxMisc = encore.rxMisc;
 
 describe('rxOptionTable', function () {
     var component;
@@ -11,19 +10,19 @@ describe('rxOptionTable', function () {
     });
 
     describe('exercise', function () {
-        describe('radio table', exercise.rxOptionTable({
+        describe('radio table', encore.exercise.rxOptionTable({
             cssSelector: "#radioOptionTable",
             visible: true,
             empty: false
         }));
 
-        describe('checkbox table', exercise.rxOptionTable({
+        describe('checkbox table', encore.exercise.rxOptionTable({
             cssSelector: "#checkboxOptionTable",
             visible: true,
             empty: false
         }));
 
-        describe('empty table', exercise.rxOptionTable({
+        describe('empty table', encore.exercise.rxOptionTable({
             cssSelector: "#emptyOptionTable",
             visible: true,
             empty: true

--- a/src/rxOptionTable/rxOptionTable.page.js
+++ b/src/rxOptionTable/rxOptionTable.page.js
@@ -2,8 +2,6 @@
 var Page = require('astrolabe').Page;
 var _ = require('lodash');
 
-var rxCheckbox = require('../rxCheckbox/rxCheckbox.page').rxCheckbox;
-
 /**
  * @private
  * @description Shared function in both one row's `isSelected`, and `selections` getter.
@@ -83,7 +81,7 @@ var optionRowFromElement = function (eleOptionRow) {
         selectInput: {
             get: function () {
                 var inputElement = this.rootElement.$('input');
-                return rxCheckbox.initialize(inputElement);
+                return exports.rxCheckbox.initialize(inputElement);
             }
         },
 

--- a/src/rxPaginate/docs/rxPaginate.midway.js
+++ b/src/rxPaginate/docs/rxPaginate.midway.js
@@ -1,7 +1,6 @@
-var exercise = require('../rxPaginate.exercise.js');
-var rxSortableColumn = require('../../rxSortableColumn/rxSortableColumn.page').rxSortableColumn;
-var rxSelectFilter = require('../../rxSelectFilter/rxSelectFilter.page').rxSelectFilter;
-var rxSearchBox = require('../../rxSearchBox/rxSearchBox.page').rxSearchBox;
+var rxSortableColumn = encore.rxSortableColumn;
+var rxSelectFilter = encore.rxSelectFilter;
+var rxSearchBox = encore.rxSearchBox;
 var Page = require('astrolabe').Page;
 
 // rowFromElement and table are anonymous page objects to assist with table data
@@ -72,13 +71,13 @@ describe('rxPaginate', function () {
         demoPage.go('#/component/rxPaginate');
     });
 
-    describe('UI pagination exercises', exercise.rxPaginate({
+    describe('UI pagination exercises', encore.exercise.rxPaginate({
         pageSizes: [3, 50, 200, 350, 500],
         defaultPageSize: 3,
         cssSelector: '.demo-ui-pagination .rx-paginate'
     }));
 
-    describe('API pagination exercises', exercise.rxPaginate({
+    describe('API pagination exercises', encore.exercise.rxPaginate({
         pageSizes: [25, 50, 200, 350, 500],
         defaultPageSize: 25,
         pages: 30,

--- a/src/rxPermission/docs/rxPermission.midway.js
+++ b/src/rxPermission/docs/rxPermission.midway.js
@@ -1,4 +1,4 @@
-var rxPermissionPage = require('../rxPermission.page').rxPermission;
+var rxPermissionPage = encore.rxPermission;
 
 describe('rxPermission', function () {
 

--- a/src/rxRadio/docs/rxRadio.midway.js
+++ b/src/rxRadio/docs/rxRadio.midway.js
@@ -1,5 +1,4 @@
-var rxRadioPage = require('../rxRadio.page').rxRadio;
-var exercise = require('../rxRadio.exercise');
+var rxRadioPage = encore.rxRadio;
 
 describe('rxRadio', function () {
     var subject;
@@ -8,84 +7,84 @@ describe('rxRadio', function () {
         demoPage.go('#/component/rxRadio');
     });
 
-    describe('(State) Valid Enabled Selected', exercise.rxRadio({
+    describe('(State) Valid Enabled Selected', encore.exercise.rxRadio({
         cssSelector: '#radValidEnabledOne',
         disabled: false,
         selected: true,
         valid: true
     }));
 
-    describe('(State) Valid Enabled Unselected', exercise.rxRadio({
+    describe('(State) Valid Enabled Unselected', encore.exercise.rxRadio({
         cssSelector: '#radValidEnabledTwo',
         disabled: false,
         selected: false,
         valid: true
     }));
 
-    describe('(State) Valid Disabled Selected', exercise.rxRadio({
+    describe('(State) Valid Disabled Selected', encore.exercise.rxRadio({
         cssSelector: '#radValidDisabledOne',
         disabled: true,
         selected: true,
         valid: true
     }));
 
-    describe('(State) Valid Disabled Unselected', exercise.rxRadio({
+    describe('(State) Valid Disabled Unselected', encore.exercise.rxRadio({
         cssSelector: '#radValidDisabledTwo',
         disabled: true,
         selected: false,
         valid: true
     }));
 
-    describe('(State) Valid NG-Disabled Selected', exercise.rxRadio({
+    describe('(State) Valid NG-Disabled Selected', encore.exercise.rxRadio({
         cssSelector: '#radValidNgDisabledOne',
         disabled: true,
         selected: true,
         valid: true
     }));
 
-    describe('(State) Valid NG-Disabled Unselected', exercise.rxRadio({
+    describe('(State) Valid NG-Disabled Unselected', encore.exercise.rxRadio({
         cssSelector: '#radValidNgDisabledTwo',
         disabled: true,
         selected: false,
         valid: true
     }));
 
-    describe('(State) Invalid Enabled Selected', exercise.rxRadio({
+    describe('(State) Invalid Enabled Selected', encore.exercise.rxRadio({
         cssSelector: '#radInvalidEnabledOne',
         disabled: false,
         selected: true,
         valid: false
     }));
 
-    describe('(State) Invalid Enabled Unselected', exercise.rxRadio({
+    describe('(State) Invalid Enabled Unselected', encore.exercise.rxRadio({
         cssSelector: '#radInvalidEnabledTwo',
         disabled: false,
         selected: false,
         valid: false
     }));
 
-    describe('(State) Invalid Disabled Selected', exercise.rxRadio({
+    describe('(State) Invalid Disabled Selected', encore.exercise.rxRadio({
         cssSelector: '#radInvalidDisabledOne',
         disabled: true,
         selected: true,
         valid: false
     }));
 
-    describe('(State) Invalid Disabled Unselected', exercise.rxRadio({
+    describe('(State) Invalid Disabled Unselected', encore.exercise.rxRadio({
         cssSelector: '#radInvalidDisabledTwo',
         disabled: true,
         selected: false,
         valid: false
     }));
 
-    describe('(State) Invalid NG-Disabled Selected', exercise.rxRadio({
+    describe('(State) Invalid NG-Disabled Selected', encore.exercise.rxRadio({
         cssSelector: '#radInvalidNgDisabledOne',
         disabled: true,
         selected: true,
         valid: false
     }));
 
-    describe('(State) Invalid NG-Disabled Unselected', exercise.rxRadio({
+    describe('(State) Invalid NG-Disabled Unselected', encore.exercise.rxRadio({
         cssSelector: '#radInvalidNgDisabledTwo',
         disabled: true,
         selected: false,

--- a/src/rxRadio/rxRadio.page.js
+++ b/src/rxRadio/rxRadio.page.js
@@ -46,7 +46,7 @@ var htmlRadio = {
     select: {
         value: function () {
             var radio = this.rootElement;
-            return this.isSelected(). then(function (selected) {
+            return this.isSelected().then(function (selected) {
                 if (!selected) {
                     radio.click();
                 }
@@ -169,5 +169,25 @@ exports.rxRadio = {
             get: function () { return $('input[rx-radio]'); }
         };
         return Page.create(rxRadio);
-    })()
+    })(),
+
+    /**
+     * @function
+     * @description Generates a getter and a setter for an rxRadio element on your page.
+     * @param {WebElement} elem - The WebElement for the rxRadio.
+     * @returns {Object} A getter and a setter to be applied to a rxRadio page object.
+     */
+    generateAccessor: function (elem) {
+        return {
+            get: function () {
+                return exports.rxRadio.initialize(elem).isSelected();
+            },
+            // passing `false` to this will do nothing.
+            set: function (enable) {
+                if (enable) {
+                    exports.rxRadio.initialize(elem).select();
+                }
+            }
+        };
+    }
 };

--- a/src/rxSearchBox/docs/rxSearchBox.midway.js
+++ b/src/rxSearchBox/docs/rxSearchBox.midway.js
@@ -1,21 +1,20 @@
-var rxSearchBoxPage = require('../rxSearchBox.page').rxSearchBox;
-var exercise = require('../rxSearchBox.exercise');
+var rxSearchBoxPage = encore.rxSearchBox;
 
 describe('rxSearchBox', function () {
     before(function () {
         demoPage.go('#/component/rxSearchBox');
     });
 
-    describe('default rxSearchBox', exercise.rxSearchBox({
+    describe('default rxSearchBox', encore.exercise.rxSearchBox({
         cssSelector: '.default-search-box'
     }));
 
-    describe('disabled rxSearchBox', exercise.rxSearchBox({
+    describe('disabled rxSearchBox', encore.exercise.rxSearchBox({
         cssSelector: '.disabled-search-box',
         disabled: true
     }));
 
-    describe('custom, wide rxSearchBox', exercise.rxSearchBox({
+    describe('custom, wide rxSearchBox', encore.exercise.rxSearchBox({
         cssSelector: '.wide-search-box',
         placeholder: 'Filter by any...'
     }));

--- a/src/rxSelect/docs/rxSelect.midway.js
+++ b/src/rxSelect/docs/rxSelect.midway.js
@@ -1,8 +1,6 @@
-var rxSelect = require('../rxSelect.page').rxSelect;
-var htmlCheckbox = require('../../rxCheckbox/rxCheckbox.page').htmlCheckbox;
-var htmlRadio = require('../../rxRadio/rxRadio.page').htmlRadio;
-
-var exercise = require('../rxSelect.exercise');
+var rxSelect = encore.rxSelect;
+var htmlCheckbox = encore.htmlCheckbox;
+var htmlRadio = encore.htmlRadio;
 
 describe('rxSelect', function () {
     var subject;
@@ -11,42 +9,42 @@ describe('rxSelect', function () {
         demoPage.go('#/component/rxSelect');
     });
 
-    describe('(State) Valid Enabled', exercise.rxSelect({
+    describe('(State) Valid Enabled', encore.exercise.rxSelect({
         cssSelector: '#selValidEnabled',
         disabled: false,
         visible: true,
         valid: true
     }));
 
-    describe('(State) Valid NG-Disabled', exercise.rxSelect({
+    describe('(State) Valid NG-Disabled', encore.exercise.rxSelect({
         cssSelector: '#selValidNgDisabled',
         disabled: true,
         visible: true,
         valid: true
     }));
 
-    describe('(State) Valid Disabled', exercise.rxSelect({
+    describe('(State) Valid Disabled', encore.exercise.rxSelect({
         cssSelector: '#selValidDisabled',
         disabled: true,
         visible: true,
         valid: true
     }));
 
-    describe('(State) Invalid Enabled', exercise.rxSelect({
+    describe('(State) Invalid Enabled', encore.exercise.rxSelect({
         cssSelector: '#selInvalidEnabled',
         disabled: false,
         visible: true,
         valid: false
     }));
 
-    describe('(State) Invalid NG-Disabled', exercise.rxSelect({
+    describe('(State) Invalid NG-Disabled', encore.exercise.rxSelect({
         cssSelector: '#selInvalidNgDisabled',
         disabled: true,
         visible: true,
         valid: false
     }));
 
-    describe('(State) Invalid Disabled', exercise.rxSelect({
+    describe('(State) Invalid Disabled', encore.exercise.rxSelect({
         cssSelector: '#selInvalidDisabled',
         disabled: true,
         visible: true,

--- a/src/rxSelect/rxSelect.page.js
+++ b/src/rxSelect/rxSelect.page.js
@@ -1,7 +1,6 @@
 /*jshint node:true*/
 var _ = require('lodash');
 var Page = require('astrolabe').Page;
-var rxMisc = require('../rxMisc/rxMisc.page').rxMisc;
 
 /**
  * @namespace
@@ -32,7 +31,7 @@ var htmlSelectOption = {
      */
     select: {
         value: function () {
-            rxMisc.slowClick(this.rootElement);
+            exports.rxMisc.slowClick(this.rootElement);
         }
     },
 

--- a/src/rxSelectFilter/docs/rxSelectFilter.midway.js
+++ b/src/rxSelectFilter/docs/rxSelectFilter.midway.js
@@ -1,8 +1,7 @@
 var Page = require('astrolabe').Page;
 var _ = require('lodash');
-var rxMultiSelectPage = require('../rxSelectFilter.page').rxMultiSelect;
-var rxSelectFilterPage = require('../rxSelectFilter.page').rxSelectFilter;
-var exercise = require('../rxSelectFilter.exercise');
+var rxMultiSelectPage = encore.rxMultiSelect;
+var rxSelectFilterPage = encore.rxSelectFilter;
 
 describe('rxMultiSelect', function () {
 
@@ -10,7 +9,7 @@ describe('rxMultiSelect', function () {
         demoPage.go('#/component/rxSelectFilter');
     });
 
-    describe('exercises', exercise.rxMultiSelect({
+    describe('exercises', encore.exercise.rxMultiSelect({
         cssSelector: '#classification',
         inputs: ['Type A', 'Type B', 'Type C', 'Type D']
     }));

--- a/src/rxSelectFilter/rxSelectFilter.page.js
+++ b/src/rxSelectFilter/rxSelectFilter.page.js
@@ -1,11 +1,10 @@
 /*jshint node:true*/
 var Page = require('astrolabe').Page;
 var _ = require('lodash');
-var rxCheckbox = require('../rxCheckbox/rxCheckbox.page').rxCheckbox;
 
 var selectOptionFromElement = function (optionElement) {
 
-    return Object.create(rxCheckbox.initialize(optionElement.$('input')), {
+    return Object.create(exports.rxCheckbox.initialize(optionElement.$('input')), {
 
         /**
          * @memberof rxMultiSelect.option

--- a/src/rxSortableColumn/docs/rxSortableColumn.midway.js
+++ b/src/rxSortableColumn/docs/rxSortableColumn.midway.js
@@ -1,4 +1,4 @@
-var rxSortableColumn = require('../rxSortableColumn.page').rxSortableColumn;
+var rxSortableColumn = encore.rxSortableColumn;
 
 var column = function (columnName, repeaterString) {
     var columnElement = element(by.cssContainingText('rx-sortable-column', columnName));

--- a/src/rxSpinner/docs/rxSpinner.midway.js
+++ b/src/rxSpinner/docs/rxSpinner.midway.js
@@ -1,4 +1,4 @@
-var rxSpinnerPage = require('../rxSpinner.page').rxSpinner;
+var rxSpinnerPage = encore.rxSpinner;
 
 describe('rxSpinner', function () {
 

--- a/src/rxStatusColumn/docs/rxStatusColumn.midway.js
+++ b/src/rxStatusColumn/docs/rxStatusColumn.midway.js
@@ -1,8 +1,8 @@
 var _ = require('lodash');
 var Page = require('astrolabe').Page;
 
-var rxStatusColumn = require('../rxStatusColumn.page').rxStatusColumn;
-var rxSortableColumn = require('../../rxSortableColumn/rxSortableColumn.page').rxSortableColumn;
+var rxStatusColumn = encore.rxStatusColumn;
+var rxSortableColumn = encore.rxSortableColumn;
 
 // an anonymous page object to demonstrate table and cell creation
 var repeaterString = 'server in servers';

--- a/src/rxToggleSwitch/docs/rxToggleSwitch.midway.js
+++ b/src/rxToggleSwitch/docs/rxToggleSwitch.midway.js
@@ -1,4 +1,3 @@
-var exercise = require('../rxToggleSwitch.exercise');
 
 describe('rxToggleSwitch', function () {
     var rxToggleSwitch;
@@ -7,19 +6,19 @@ describe('rxToggleSwitch', function () {
         demoPage.go('#/component/rxToggleSwitch');
     });
 
-    describe('defaults', exercise.rxToggleSwitch({
+    describe('defaults', encore.exercise.rxToggleSwitch({
         cssSelector: '.demo-default-values'
     }));
 
-    describe('specific model values', exercise.rxToggleSwitch({
+    describe('specific model values', encore.exercise.rxToggleSwitch({
         cssSelector: '.demo-model-values'
     }));
 
-    describe('post hook', exercise.rxToggleSwitch({
+    describe('post hook', encore.exercise.rxToggleSwitch({
         cssSelector: '.demo-post-hook'
     }));
 
-    describe('disabled', exercise.rxToggleSwitch({
+    describe('disabled', encore.exercise.rxToggleSwitch({
         cssSelector: '.demo-disabled',
         disabled: true
     }));

--- a/src/tabs/docs/tabs.midway.js
+++ b/src/tabs/docs/tabs.midway.js
@@ -1,4 +1,4 @@
-var tabsPage = require('../tabs.page').tabs;
+var tabsPage = encore.tabs;
 
 describe('tabs', function () {
     var tabs;

--- a/src/typeahead/docs/typeahead.midway.js
+++ b/src/typeahead/docs/typeahead.midway.js
@@ -1,4 +1,4 @@
-var typeaheadPage = require('../typeahead.page').typeahead;
+var typeaheadPage = encore.typeahead;
 
 describe('typeahead', function () {
     var typeahead;


### PR DESCRIPTION
## What is this all about?!

When we develop new components, we do so in the `src` directory. It looks like this.

```
src/rxActionMenu
├── README.md
├── docs
│   ├── rxActionMenu.html
│   ├── rxActionMenu.js
│   └── rxActionMenu.midway.js
├── rxActionMenu.js
├── rxActionMenu.less
├── rxActionMenu.page.js
├── rxActionMenu.spec.js
└── templates
    └── rxActionMenu.html
```

So, should we need another component inside of the page objects to borrow functionality from (in this case `rxActionMenu` requires functionality from `rxModalAction`), we'd write something like this.

```js
var modal = require('../../rxModalAction/rxModalAction.page').rxModalAction;
```

This will work...in the framework. But once this gets published to npm, the end result looks something like this.

```
rx-page-objects/
├── API.md
├── README.md
├── exercise.js
├── index.js
└── package.json
```

There is no `src` directory. Every page object is concatenated into one large `index.js`. In this environment, you'd "borrow" another component's functionality like this.

```js
var modal = exports.rxModalAction;
```

Since it's in the same file, this works fine. So, in order to make both the framework end to end tests pass *and* have proper require statements work in the published page objects, we write this.

```js
var modal = exports.rxModalAction || require('../../rxModalAction/rxModalAction.page').rxModalAction;
```

Ugly! Error prone! Confusing!

This pull request looks to concatenate all page object files into a single `index.js` file every time a page object file is changed. Then, when end to end tests run in the framework, the large `index.js` file will be used instead of the entire `src` directory. Errors similar to the one above will be caught from now on. There should be no more bad rx-page-objects releases in the future around this type of error.

fix(rxBulkSelect): Require from exports

https://goo.gl/OEY6EE

This link explains how you must try to require from both exports (for
the rx-page-objects finished product) vs. using the page object under
src. If you don't do this users who download rx-page-objects will get
errors in their end to end tests from bad require statements.

https://github.com/rackerlabs/encore-ui/issues/1044 is related.

fix(rxSelectFilter): Require from exports

test(visualRegression): Remove from dev conf

Developers who create new components need to run end to end tests
against them. This requires that they remove the `snappit` stuff from
it, since it's been left out of all environments (except the PR builder)
on purpose.

It was originally left in there in case a developer should decide to add
a visual regression test inside of the existing end to end test suite,
but it really doesn't make much sense.

Closes #1041

fix(testing): Unify to a single style of imports

Closes #1044