### PR TITLE
fix(rxFloatingHeader): rxSearchBox and rxBulkSelect fixes

### DIFF
--- a/src/rxBulkSelect/rxBulkSelect.js
+++ b/src/rxBulkSelect/rxBulkSelect.js
@@ -320,13 +320,16 @@ angular.module('encore.ui.rxBulkSelect', ['encore.ui.rxCheckbox'])
  *       </rx-batch-actions>
  *   </th>
  */
-.directive('rxBatchActions', function () {
+.directive('rxBatchActions', function (rxDOMHelper) {
     return {
         restrict: 'E',
-        require: '^rxBulkSelect',
+        require: ['^rxBulkSelect', '?^rxFloatingHeader'],
         templateUrl: 'templates/rxBatchActions.html',
         transclude: true,
-        link: function (scope, element, attrs, rxBulkSelectCtrl) {
+        link: function (scope, element, attrs, controllers) {
+
+            var rxBulkSelectCtrl = controllers[0],
+                rxFloatingHeaderCtrl = controllers[1];
 
             // We need to add the class onto the parent <tr>, so rxFloatingHeader can
             // easily identify this <tr>
@@ -345,6 +348,18 @@ angular.module('encore.ui.rxBulkSelect', ['encore.ui.rxCheckbox'])
                 }
             };
             rxBulkSelectCtrl.registerForNumSelected(numSelectedChange);
+
+            if (!_.isUndefined(rxFloatingHeaderCtrl)) {
+                // When rxBatchActions lives inside of an rxFloatingHeader enabled table,
+                // the element will be cloned by rxFloatingHeader. The issue is that a normal
+                // .clone() does not clone Angular bindings, and thus the cloned element doesn't
+                // have `ng-show="displayed"` on it. We can manually add `ng-hide` on startup, to
+                // ensure that class is present in the clone. After that, everything will work as expected.
+                if (!scope.displayed) {
+                    rxDOMHelper.find(element, '.batch-action-menu-container').addClass('ng-hide');
+                }
+                rxFloatingHeaderCtrl.update();
+            }
 
         }
     };

--- a/src/rxBulkSelect/rxBulkSelect.spec.js
+++ b/src/rxBulkSelect/rxBulkSelect.spec.js
@@ -37,6 +37,7 @@ describe('rxBulkSelect', function () {
     };
 
     beforeEach(function () {
+        module('encore.ui.rxMisc');
         module('encore.ui.rxBulkSelect', function ($provide) {
             $provide.value('rxBulkSelectUtils', rxBulkSelectUtils);
         });

--- a/src/rxFloatingHeader/docs/rxFloatingHeader.html
+++ b/src/rxFloatingHeader/docs/rxFloatingHeader.html
@@ -35,12 +35,12 @@
     <table rx-floating-header class="filter">
         <thead>
             <tr>
-                <td colspan="2">
+                <th colspan="2">
                     <rx-search-box
                         ng-model="searchText"
                         class="filter-box"
                         rx-placeholder="'Filter by any...'"></rx-search-box>
-                </td>
+                </th>
             </tr>
             <tr>
                 <th>Column One Header</th>

--- a/src/rxFloatingHeader/rxFloatingHeader.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.js
@@ -5,7 +5,7 @@
  * Turns a tableheader into a floating persistent header
  */
 angular.module('encore.ui.rxFloatingHeader', ['encore.ui.rxMisc'])
-.directive('rxFloatingHeader', function (rxDOMHelper) {
+.directive('rxFloatingHeader', function ($document, rxDOMHelper) {
     return {
         restrict: 'A',
         controller: function ($scope) {
@@ -185,7 +185,7 @@ angular.module('encore.ui.rxFloatingHeader', ['encore.ui.rxMisc'])
                         // we re-dock the header, otherwise the browser will scroll
                         // the screen back up ot the input
                         _.each(inputs, function (input) {
-                            if (rxDOMHelper.scrollTop() > rxDOMHelper.offset(input).top) {
+                            if ($document[0].activeElement === input[0]) {
                                 input[0].blur();
                             }
                         });

--- a/src/rxSearchBox/rxSearchBox.js
+++ b/src/rxSearchBox/rxSearchBox.js
@@ -2,7 +2,7 @@ angular.module('encore.ui.rxSearchBox', [])
 .directive('rxSearchBox', function () {
     return {
         restrict: 'E',
-        require: 'ngModel',
+        require: ['ngModel', '?^rxFloatingHeader'],
         templateUrl: 'templates/rxSearchBox.html',
         scope: {
             searchVal: '=ngModel',
@@ -24,6 +24,12 @@ angular.module('encore.ui.rxSearchBox', [])
             $scope.clearSearch = function () {
                 $scope.searchVal = '';
             };
+        },
+        link: function (scope, element, attrs, controllers) {
+            var rxFloatingHeaderCtrl = controllers[1];
+            if (!_.isUndefined(rxFloatingHeaderCtrl)) {
+                rxFloatingHeaderCtrl.update();
+            }
         }
     };
 });


### PR DESCRIPTION
Closes #1038
Closes #1047

`rxBulkSelect` and `rxSearchBox` have their templates inserted _after_ the `rxFloatingHeader` `link` function runs. `rxFloatingHeader` needs to know about their content, so we now have them explicitly tell `rxFloatingHeader` to rerun once they're ready.