### PR TITLE
fix(rxFormElements): Work around for removing parent elements

### DIFF
--- a/src/rxCheckbox/rxCheckbox.js
+++ b/src/rxCheckbox/rxCheckbox.js
@@ -37,9 +37,13 @@ angular.module('encore.ui.rxCheckbox', [])
                     });
                 }
 
+                var removeParent = function () {
+                    parent.remove();
+                };
+
                 // remove stylistic markup when element is destroyed
                 element.on('$destroy', function () {
-                    parent[0].remove();
+                    scope.$evalAsync(removeParent);
                 });
             };
         }//compile

--- a/src/rxRadio/rxRadio.js
+++ b/src/rxRadio/rxRadio.js
@@ -37,9 +37,13 @@ angular.module('encore.ui.rxRadio', [])
                     });
                 }
 
+                var removeParent = function () {
+                    parent.remove();
+                };
+
                 // remove stylistic markup when element is destroyed
                 element.on('$destroy', function () {
-                    parent[0].remove();
+                    scope.$evalAsync(removeParent);
                 });
             };
         }//compile

--- a/src/rxSelect/rxSelect.js
+++ b/src/rxSelect/rxSelect.js
@@ -42,9 +42,13 @@ angular.module('encore.ui.rxSelect', [])
                 });
             }
 
+            var removeParent = function () {
+                parent.remove();
+            };
+
             // remove stylistic markup when element is destroyed
             element.on('$destroy', function () {
-                parent[0].remove();
+                scope.$evalAsync(removeParent);
             });
         }
     };


### PR DESCRIPTION
Found an issue where essentially we have `rxFormOptionTable` in tabs, and as you switch tabs, the table gets destroyed thanks to an `ng-if` things in the browser/unit-tests seem ok.   

But with the inclusion of the new `rx-radio` `rx-checkbox` elements  

```bash
TypeError: 'undefined' is not a function (evaluating 'parent[0].remove()')
            at /Users/fred7307/Workspace/encore-tq-ui/app/bower_components/encore-ui/encore-ui-tpls.js:2067
```
Essentially my finding was that `parent` DOMElement in PhantomJS seems to have no `remove` function (in fact none of the DOMElements do), however the `jqlite` wrapper does.  Not sure if this was just an uncaught or overseen issue.

The reason for the `$evalSync` was due to if we call `parent.remove()` within the `element.$destroy` event, then an infinite loop of `$destroy` events ends up happening.  :shrug:

