### PR TITLE
fix(rxBulkSelect): only add bulk message to root table

### DIFF
--- a/src/rxBulkSelect/rxBulkSelect.js
+++ b/src/rxBulkSelect/rxBulkSelect.js
@@ -29,7 +29,7 @@ angular.module('encore.ui.rxBulkSelect', ['encore.ui.rxCheckbox'])
 
             // We add the `<tr rx-bulk-select-message>` row to the header here to save the devs
             // from having to do it themselves. 
-            var thead = elem.find('thead');
+            var thead = elem.find('thead').eq(0);
             var messageElem = angular.element(elemString);
             messageElem.attr('resource-name', attrs.resourceName || attrs.bulkSource.replace(/s$/, ''));
             thead.append(messageElem);

--- a/src/rxBulkSelect/rxBulkSelect.spec.js
+++ b/src/rxBulkSelect/rxBulkSelect.spec.js
@@ -14,10 +14,26 @@ describe('rxBulkSelect', function () {
                     '<th>Name</th>' +
                 '</tr>' +
             '</thead>' +
-            '<tbody>' +
-                '<tr ng-repeat="server in servers">' +
+            '<tbody ng-repeat="server in servers">' +
+                '<tr>' +
                     '<td rx-bulk-select-row row="server"></td>' +
                     '<td>{{ server.name }}</td>' +
+                '</tr>' +
+                '<tr>' +
+                    '<td colspan="2">' +
+                        '<table>' +
+                            '<thead>' +
+                                '<tr>' +
+                                    '<th>Title</th>' +
+                                '</tr>' +
+                            '</thead>' +
+                            '<tbody>' +
+                                '<tr>' +
+                                    '<td>Content</td>' +
+                                '</tr>' +
+                            '</tbody>' +
+                        '</table>' +
+                    '</td>' +
                 '</tr>' +
             '</tbody>' +
         '</table>';


### PR DESCRIPTION
The `rx-bulk-select-message` directive was being added to every `<thead>` in the table, which is fine until you need nested tables (like in the [docs](http://rackerlabs.github.io/encore-ui/#/styleguide/tables)).