### PR TITLE
fix(rxSelect) main methods do not return

### DIFF
--- a/src/rxSelect/rxSelect.page.js
+++ b/src/rxSelect/rxSelect.page.js
@@ -304,6 +304,7 @@ exports.htmlSelect = {
         htmlSelect.rootElement = {
             get: function () { return $('select')[0]; }
         };
+        return Page.create(htmlSelect);
     })(),
 
     /**
@@ -347,6 +348,7 @@ exports.rxSelect = {
         rxSelect.rootElement = {
             get: function () { return $('select[rx-select]')[0]; }
         };
+        return Page.create(rxSelect);
     })(),
 
     /**


### PR DESCRIPTION
Fix rxSelect.main to return an rxSelect object.
Fix htmlSelect.main to return an htmlselect object.