### PR TITLE
style(demo): Add visual styles for code blocks

### DIFF
--- a/demo/assets/demo.less
+++ b/demo/assets/demo.less
@@ -145,3 +145,24 @@ table.component-attributes {
     vertical-align: top;
   }
 }
+
+pre, code {
+    color: #404040;
+    background-color: #D0D0D0;
+    border: 1px solid #BABABA;
+    border-radius: 2px;
+}
+
+pre {
+    padding: 10px;
+}
+
+code {
+    padding: 2px 4px;
+}
+
+pre code {
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+}


### PR DESCRIPTION
Closes #940.

### Current style
![screen shot 2015-06-19 at 2 35 05 pm](https://cloud.githubusercontent.com/assets/1529366/8261527/e33c8112-1690-11e5-9200-e6351faa2801.png)

### New Style (this PR)
![screen shot 2015-06-19 at 2 34 17 pm](https://cloud.githubusercontent.com/assets/1529366/8261539/f18194c4-1690-11e5-9581-4beabe8cb3a8.png)

### New Style applied on non-white background
We'll be tweaking documentation styles, so code blocks will appear on the grey Encore background in most contexts -- more details and mock-ups coming, just posting a screen shot here as a rough example.
![screen shot 2015-06-19 at 2 34 44 pm](https://cloud.githubusercontent.com/assets/1529366/8261550/00498962-1691-11e5-8e1d-ef9aacdfc53b.png)

@ElementE Can you review and let me know if these colors look good to you? I figure we'll likely revisit when we do more detailed color work/standardization in the future.