### PR TITLE
docs(styles): fast follow update to <code> styles

### DIFF
--- a/demo/assets/demo.less
+++ b/demo/assets/demo.less
@@ -146,23 +146,33 @@ table.component-attributes {
   }
 }
 
-pre, code {
-    color: #404040;
-    background-color: #D0D0D0;
-    border: 1px solid #BABABA;
-    border-radius: 2px;
+.component-description,
+.component-demo {
+  pre,
+  code {
+      color: #404040;
+      background-color: #D0D0D0;
+      border: 1px solid #BABABA;
+      border-radius: 2px;
+  }
+
+  code {
+      padding: 0 2px;
+      margin: 0 1px;
+  }
+
+  pre {
+      padding: 10px;
+
+      code {
+          border: none;
+          padding: 0;
+          margin: 0;
+          border-radius: 0;
+      }
+  }
 }
 
-pre {
-    padding: 10px;
-}
-
-code {
-    padding: 2px 4px;
-}
-
-pre code {
-    padding: 0;
-    border: 0;
-    border-radius: 0;
+p {
+    line-height: 1.5;
 }

--- a/demo/assets/generated_demo.css
+++ b/demo/assets/generated_demo.css
@@ -105,21 +105,31 @@ table.component-attributes th,
 table.component-attributes td {
   vertical-align: top;
 }
-pre,
-code {
+.component-description pre,
+.component-demo pre,
+.component-description code,
+.component-demo code {
   color: #404040;
   background-color: #D0D0D0;
   border: 1px solid #BABABA;
   border-radius: 2px;
 }
-pre {
+.component-description code,
+.component-demo code {
+  padding: 0 2px;
+  margin: 0 1px;
+}
+.component-description pre,
+.component-demo pre {
   padding: 10px;
 }
-code {
-  padding: 2px 4px;
-}
-pre code {
+.component-description pre code,
+.component-demo pre code {
+  border: none;
   padding: 0;
-  border: 0;
+  margin: 0;
   border-radius: 0;
+}
+p {
+  line-height: 1.5;
 }


### PR DESCRIPTION
While I realize that these styles will probably be out of date once design is finished with their work, but in the mean time, this is a fix to make documentation more legible.

### Before
![screen shot 2015-06-23 at 3 43 40 pm](https://cloud.githubusercontent.com/assets/545605/8316898/716eb87a-19bf-11e5-8d70-83d0290468fe.png)

### After
![screen shot 2015-06-23 at 3 44 10 pm](https://cloud.githubusercontent.com/assets/545605/8316906/7745485e-19bf-11e5-8048-5f7132051b13.png)
