### PR TITLE
fix(travis): Valid visual regression installs only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: node_js
 node_js:
 - '0.10'
 before_install:
-- sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
 - npm install -g grunt-cli bower
 install:
 - travis_retry npm install
-# keep tricky cairo dependencies for visual regression isolated to Travis builds only
-- travis_retry npm install snappit-mocha-protractor@0.0.6
 - bower install
 - ./node_modules/.bin/webdriver-manager update --standalone
 before_script:

--- a/utils/visual-regression/clone.sh
+++ b/utils/visual-regression/clone.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 [ "${TRAVIS_SECURE_ENV_VARS}" == "false" ] && exit 0;
 
+# keep tricky cairo dependencies for visual regression isolated to Travis builds only
+sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+travis_retry npm install snappit-mocha-protractor@0.0.6
+
 CLONE_URL="https://${ghToken}@github.com/rackerlabs/encore-ui-screenshots.git";
 git submodule add -f ${CLONE_URL} screenshots > /dev/null 2>&1;


### PR DESCRIPTION
Don't install visual regression tools, which take nearly 3 to 5 minutes,
if the tools aren't even going to be used.

By placing these steps inside of the `after_success` block, it prevents
these installs should the tests fail.

By placing these steps after a check for secure variables existing, it
prevents these installs for PRs that will never run the visual
regression tests in the first place, like from a fork.