### PR TITLE
DOCS: normalize relative links

### DIFF
--- a/demo/styleguide/basics.html
+++ b/demo/styleguide/basics.html
@@ -7,7 +7,7 @@
         <li>This section of the Demo site focuses mainly on markup, CSS and design patterns. If you're curious about Encore-specific angular.js directives, find the "All Components" section in the left hand navigation.</li>
         <li>If you're a Rackspace team outside of Encore and need help setting up an new project from an engineering perspective, go to this <a href="https://github.com/rackerlabs/encore-ui/blob/master/guides/using-encoreui.md">Using EncoreUI In Your Own Project</a> guide in the EncoreUI repository.
         <ul class="list">
-            <li>For the most part, RackSpace developer teams will be creating mark-up using the <a href="http://rackerlabs.github.io/encore-ui/#/component/rxApp">rxPage subdirective of rxApp</a> as a container.</li>
+            <li>For the most part, RackSpace developer teams will be creating mark-up using the <a href="#/component/rxApp">rxPage subdirective of rxApp</a> as a container.</li>
             <li><a href="https://github.com/rackerlabs/encore-ui/blob/master/src/rxApp/templates/rxPage.html">rxPage's template code</a> contains a breadcrumb component, an attribute to pre-fill titles and subtitles and a rxNotification container so you can send page-level communication errors and validation messages in a standardized way. Check the angular.js code for controllers within Cloud Encore for implementation examples.</li>
         </ul>
         </li>
@@ -134,7 +134,7 @@
 
     <div class="component-description clear">
         <ul class="list">
-            <li>The <a href="http://rackerlabs.github.io/encore-ui/#/component/metadata">EncoreUI metadata component</a> is a list of terms with their associated descriptions. This is used throughout Encore to show metadata, especially on an individual object such as a server or a CBS volume.</li>
+            <li>The <a href="#/component/metadata">EncoreUI metadata component</a> is a list of terms with their associated descriptions. This is used throughout Encore to show metadata, especially on an individual object such as a server or a CBS volume.</li>
             <li><span class="msg-info">ENCORE-SPECIFIC:</span> This is an ideal solution if you have anywhere from 5-10 definitions. (See a Server Details page or Image Details page under Accounts -&gt; Cloud for an example.) Anything more - or anything displaying visual or image content - and you may want to consider a different design pattern. (See the "Non-Data based Tables" section in the Table page for more information.)</li>
         </ul>
     </div>

--- a/demo/styleguide/buttons.html
+++ b/demo/styleguide/buttons.html
@@ -2,7 +2,7 @@
 
 <h3 class="title clear">Basics</h3>
 
-<p>While buttons in EncoreUI can be marked up multiple ways: through <code>button</code>, <code>input type="button"</code> or <a href="http://rackerlabs.github.io/encore-ui/#/component/rxButton">the rxButton direcitve</a>, which adds dynamic actions to loading indicators and messages - they should be styled using the <code>.button</code> class.</p>
+<p>While buttons in EncoreUI can be marked up multiple ways: through <code>button</code>, <code>input type="button"</code> or <a href="#/component/rxButton">the rxButton directive</a>, which adds dynamic actions to loading indicators and messages - they should be styled using the <code>.button</code> class.</p>
 
 
     <h3 class="title clear">Customizing Buttons</h3>

--- a/demo/styleguide/forms.html
+++ b/demo/styleguide/forms.html
@@ -4,7 +4,7 @@
     <div class="component-description">
       <ul class="list">
         <li>Many of the <code>rxForm</code> directives are designed for layout and positioning. However, there are some that are for stylistic purposes.</li>
-        <li>See <a href="/ngdocs/index.html#/api/rxForm">rxForm API Documentation</a> for a more comprehensive list of available directives.</li>
+        <li>See <a href="ngdocs/index.html#/api/rxForm">rxForm API Documentation</a> for a more comprehensive list of available directives.</li>
       </ul>
     </div>
 
@@ -36,8 +36,8 @@
                   <ul>
                     <li>This allows developers/designers to style the label based on the state of the control.</li>
                     <li>
-                      See <a href="/#/component/rxCheckbox">rxCheckbox</a>, <a href="/#/component/rxRadio">rxRadio</a>,
-                      and <a href="/#/component/rxForm">rxForm</a> for markup examples.
+                      See <a href="#/component/rxCheckbox">rxCheckbox</a>, <a href="#/component/rxRadio">rxRadio</a>,
+                      and <a href="#/component/rxForm">rxForm</a> for markup examples.
                     </li>
                   </ul>
                 </li>
@@ -49,7 +49,7 @@
           In contrast to its predecessor (rxFormItem), rxField and children provide the flexibility to create form field inputs that make use
           of one or more controls.
           <ul>
-            <li>See "Advanced Controls" in <a href="/#/component/rxForm">rxForm</a> demo for examples.</li>
+            <li>See "Advanced Controls" in <a href="#/component/rxForm">rxForm</a> demo for examples.</li>
           </ul>
         </li>
       </ul>
@@ -58,7 +58,7 @@
     <h3 class="title">Error Messages</h3>
     <div class="component-description">
       <ul>
-        <li>Inline Error messages should make use of the <a href="/ngdocs/index.html#/api/rxForm.directive:rxInlineError">rxInlineError</a> directive.</li>
+        <li>Inline Error messages should make use of the <a href="ngdocs/index.html#/api/rxForm.directive:rxInlineError">rxInlineError</a> directive.</li>
         <li>This directive is styled with bold, red text and is not constrained by DOM hierarchy, so you may place it wherever it is necessary.</li>
       </ul>
     </div>
@@ -66,7 +66,7 @@
     <h3 class="title">Help Text</h3>
     <div class="component-description">
       <ul>
-        <li>Help text should make use of the <a href="/ngdocs/index.html#/api/rxForm.directive:rxHelpText">rxHelpText</a> directive.</li>
+        <li>Help text should make use of the <a href="ngdocs/index.html#/api/rxForm.directive:rxHelpText">rxHelpText</a> directive.</li>
         <li>This directive is styled in a slightly smaller, italicized font and is not constrained by DOM hierarchy, so you may place it wherever it is necessary.</li>
       </ul>
     </div>
@@ -93,15 +93,15 @@
     <h3 class="title clear">Selects</h3>
     <div class="component-description">
       <ul>
-        <li>For single item selection, please use the <a href="/#/component/rxSelect">rxSelect</a> component.</li>
-        <li>For multi-item selection, please use the rxMultiSelect element defined in the <a href="/#/component/rxSelectFilter">rxSelectFilter</a> component.</li>
+        <li>For single item selection, please use the <a href="#/component/rxSelect">rxSelect</a> component.</li>
+        <li>For multi-item selection, please use the rxMultiSelect element defined in the <a href="#/component/rxSelectFilter">rxSelectFilter</a> component.</li>
       </ul>
     </div>
 
     <h3 class="title clear">Checkboxes</h3>
     <div class="component-description">
       <ul>
-        <li>Please use the <a href="/#/component/rxCheckbox">rxCheckbox</a> component for checkbox controls.</li>
+        <li>Please use the <a href="#/component/rxCheckbox">rxCheckbox</a> component for checkbox controls.</li>
         <li>
           If you intend to use a label element, place it <strong>immediately after the rxCheckbox</strong>
           so that CSS rules may style the label when the control is disabled.
@@ -113,7 +113,7 @@
     <h3 class="title clear">Toggle Switches</h3>
     <div class="component-description">
       <ul>
-        <li>Please use the <a href="/#/component/rxToggleSwitch">rxToggleSwitch</a> component for toggle switch controls.</li>
+        <li>Please use the <a href="#/component/rxToggleSwitch">rxToggleSwitch</a> component for toggle switch controls.</li>
         <li>
           If you intend to use a label element, place it <strong>immediately after the rxToggleSwitch</strong>
           so that CSS rules may style the label when the control is disabled.
@@ -131,7 +131,7 @@
     <h3 class="title clear">Radios</h3>
     <div class="component-description">
       <ul>
-        <li>Please use the <a href="/#/component/rxRadio">rxRadio</a> component for radio controls.</li>
+        <li>Please use the <a href="#/component/rxRadio">rxRadio</a> component for radio controls.</li>
         <li>
           If you intend to use a label element, place it <strong>immediately after the rxRadio</strong>
           so that CSS rules may style the label when the control is disabled.

--- a/demo/styleguide/layouts.html
+++ b/demo/styleguide/layouts.html
@@ -24,11 +24,11 @@
         <p>Note that the purpose of these layouts are to show design patterns and source markup rather than functionality, so as a result we have not included any angular.js components. As a result, the page may not function the way you expect.</p>
 
         <ul class="list">
-        	<li><a href="#/styleguide/layouts/1">Layout #1</a>: two metadata element in two columns, an action menu with three datatables. (<a href="https://github.com/rackerlabs/encore-ui/tree/master/demo/styleguide/layout-1.html">markup</a>) Uses <a href="http://rackerlabs.github.io/encore-ui/#/component/rxApp">rxPage</a>, grids, metadata and basic table components.</li>
+            <li><a href="#/styleguide/layouts/1">Layout #1</a>: two metadata element in two columns, an action menu with three datatables. (<a href="https://github.com/rackerlabs/encore-ui/tree/master/demo/styleguide/layout-1.html">markup</a>) Uses <a href="#/component/rxApp">rxPage</a>, grids, metadata and basic table components.</li>
 
-        	<li><a href="#/styleguide/layouts/2">Layout #2</a>: Multiple-column data table. (<a href="https://github.com/rackerlabs/encore-ui/tree/master/demo/styleguide/layout-2.html">markup</a>) Uses <a href="http://rackerlabs.github.io/encore-ui/#/component/rxApp">rxPage</a>, <a href="http://rackerlabs.github.io/encore-ui/#/component/rxActionMenu">rxActionMenu</a>, parts of <a href="http://rackerlabs.github.io/encore-ui/#/component/rxPaginate">rxPaginate</a> and <a href="http://rackerlabs.github.io/encore-ui/#/component/rxModalAction">rxModalAction</a></li>
+            <li><a href="#/styleguide/layouts/2">Layout #2</a>: Multiple-column data table. (<a href="https://github.com/rackerlabs/encore-ui/tree/master/demo/styleguide/layout-2.html">markup</a>) Uses <a href="#/component/rxApp">rxPage</a>, <a href="#/component/rxActionMenu">rxActionMenu</a>, parts of <a href="#/component/rxPaginate">rxPaginate</a> and <a href="#/component/rxModalAction">rxModalAction</a></li>
 
-        	<li><a href="#/styleguide/layouts/3">Layout #3</a>: create form that is page wide (rather than a modal) (<a href="https://github.com/rackerlabs/encore-ui/tree/master/demo/styleguide/layout-3.html">markup</a>). Uses <a href="http://rackerlabs.github.io/encore-ui/#/component/rxApp">rxPage</a> and sub-directives related to rxForm: <a href="http://rackerlabs.github.io/encore-ui/#/component/rxForm">rxFormItem, rxFormFieldset and parts of rxFormOptionTable</a>.</li>
+            <li><a href="#/styleguide/layouts/3">Layout #3</a>: create form that is page wide (rather than a modal) (<a href="https://github.com/rackerlabs/encore-ui/tree/master/demo/styleguide/layout-3.html">markup</a>). Uses <a href="#/component/rxApp">rxPage</a> and sub-directives related to <a href="#/component/rxForm">rxForm</a>.</li>
         </ul>
 
 

--- a/demo/styleguide/modals.html
+++ b/demo/styleguide/modals.html
@@ -3,7 +3,7 @@
 <h3 class="title clear">Basic Usage</h3>
 
 <ul class="list">
-    <li><a href="http://rackerlabs.github.io/encore-ui/#/component/rxModalAction">See the rxModalAction directive</a> for implementation and examples.</li>
+    <li><a href="#/component/rxModalAction">See the rxModalAction directive</a> for implementation and examples.</li>
 </ul>
 
 <h2 class="title lg" id="designpatterns">Design Patterns within Encore</h2>
@@ -16,7 +16,7 @@
                 <li>For Encore, we use modals for confirmation messaging. For notification messages we use rxNotification, the static subdirective of rxNotify. See the example below which uses <code>type="error"</code>. Note that <code>type="error"</code> can be replaced with the appropriate message response style.</li>
                 <li><span class="msg-warn">HEADS UP:</span> We also have used modals to edit content in lieu of having an edit view. This design pattern is not ideal and an Edit View will need to be considered as a pattern in future iterations.</li>
             </ul>
-        </li>    
+        </li>
         <li>Using the rxModalForm subdirective will automatically provide you with a title, subtitle, submit and cancel text. You may use rxForm elements within rxModalForm.</li>
         <li>For real world examples, take a look at the <a href="https://github.com/rackerlabs/encore-cloud-ui/blob/master/app/views/servers/templates/server-actions.html">ng-template blocks triggered from server action links</a> under Encore Cloud.</li>
         <li>If you need to deviate from the title / footer pattern at all, you'll need to take a look at the <a href="https://github.com/rackerlabs/encore-ui/blob/master/src/rxModalAction/templates/rxModalActionForm.html">rxModalForm directive template markup</a> and build upon that.</li>
@@ -28,7 +28,7 @@
 <h2 class="title lg" id="roadmap">UI Roadmap / Possible Future-work</h2>
 
 <ul class="list">
-    <li>Create a design pattern to document modal titles and subtitles.</li> 
+    <li>Create a design pattern to document modal titles and subtitles.</li>
     <li>Solidify copy and design language for action and cancel buttons within modals.</li>
 </ul>
 

--- a/demo/styleguide/tables.html
+++ b/demo/styleguide/tables.html
@@ -15,7 +15,7 @@
     <h3 class="title">Cog Menus via rxActionMenu</h3>
     <div class="component-description clear">
         <ul class="list">
-            <li><a href="http://rackerlabs.github.io/encore-ui/#/component/rxActionMenu">See the rxActionMenu directive</a> for implementation and examples.</li>
+            <li><a href="#/component/rxActionMenu">See the rxActionMenu directive</a> for implementation and examples.</li>
             <li><span class="msg-info">ENCORE-SPECIFIC:</span> In Encore, we usually use cogs if there are actionable items for every row. As an example, most main table listings show cog menus with actionable items, such as <a href="https://github.com/rackerlabs/encore-cloud-ui/blob/master/app/views/servers/Servers.html#L135-L146">Cloud Server pages showing FirstGen/NextGen actions</a> or <a href="https://github.com/rackerlabs/encore-cloud-ui/blob/master/app/views/cbs/Volumes.html#L115-L145">Cloud Block Storage Volumes</a>.</li>
             <li>For general advice as to what icons and colors to use, consult <a href="#/styleguide/buttons">the section on icons and colors</a>.
             <li>There may be cases where an action is not available on a particular row. In this case, those particular links were disabled using the <code>.disabled</code> class rather than not having them appear at all.</li>
@@ -28,7 +28,7 @@
     <h3 class="title">Table Footer Pagination via rxPaginate</h3>
     <div class="component-description clear">
         <ul class="list">
-            <li><a href="http://rackerlabs.github.io/encore-ui/#/component/rxPaginate">See the rxPaginate directive</a> for implementation and examples.</li>
+            <li><a href="#/component/rxPaginate">See the rxPaginate directive</a> for implementation and examples.</li>
             <li><span class="msg-info">ENCORE-SPECIFIC:</span> The pagination is visible in this example to show how mark-up will be implemented. Generally, the pagination directive does not display if there is only one page of data available. We use angular.js to make sure this doesn't display.</li>
             <li><span class="msg-warn">HEADS UP:</span> It's a known issue that the footer wraps into a second line if the table is 50% of the screen. In cases like those, we've used the <code>display:none</code> CSS property for elements to hide all elements not directly related to pagination. See the <a href="https://github.com/rackerlabs/supportservice-ui/blob/master/app/styles/table.less#L40-L50">LESS of narrow tables used in Support Services</a> for an example of this. Note that this has not been implemented in EncoreUI yet.</li>
         </ul>
@@ -71,7 +71,7 @@
 
     <h3 class="title">Status columns</h3>
     <ul>
-        <li><span class="msg-info">ENCORE-SPECIFIC:</span> We provide a standardized mechanism for color coding of status columns, via <a href="http://rackerlabs.github.io/encore-ui/#/component/rxStatusColumn">rxStatusColumn</a>. Ticket Queues has their own styling that predates this, and can be seen in <a href="https://github.com/rackerlabs/encore-tq-ui/blob/master/app/styles/tickets.less">their tickets.less file.</a> For consistency, new projects should use <code>rxStatusColumn</code>. If it doesn't satisfy your needs, please let us know and we'll see what we can do.</li>
+        <li><span class="msg-info">ENCORE-SPECIFIC:</span> We provide a standardized mechanism for color coding of status columns, via <a href="#/component/rxStatusColumn">rxStatusColumn</a>. Ticket Queues has their own styling that predates this, and can be seen in <a href="https://github.com/rackerlabs/encore-tq-ui/blob/master/app/styles/tickets.less">their tickets.less file.</a> For consistency, new projects should use <code>rxStatusColumn</code>. If it doesn't satisfy your needs, please let us know and we'll see what we can do.</li>
     </ul>
 
     <h3 class="title">Filters</h3>
@@ -84,7 +84,7 @@
               <li>Billing (Filtering by billing data and transactional status)</li>
           </ul>
           </li>
-          <li>With the addition of <a href="http://rackerlabs.github.io/encore-ui/#/component/rxFloatingHeader">rxFloatingHeader</a> to the framework, we now have a standard way of adding table filters. In short, we add a new <code>&lt;tr&gt;</code> into the <code>&lt;thead&gt;</code> of the table. <code>rxFloatingHeader</code> will take care of the styling, by adding the appropriate classes on its own (namely <a href="https://github.com/rackerlabs/encore-ui/blob/master/src/rxFloatingHeader/rxFloatingHeader.less#L12"><code>th.filter-header</code></a>)</li>
+          <li>With the addition of <a href="#/component/rxFloatingHeader">rxFloatingHeader</a> to the framework, we now have a standard way of adding table filters. In short, we add a new <code>&lt;tr&gt;</code> into the <code>&lt;thead&gt;</code> of the table. <code>rxFloatingHeader</code> will take care of the styling, by adding the appropriate classes on its own (namely <a href="https://github.com/rackerlabs/encore-ui/blob/master/src/rxFloatingHeader/rxFloatingHeader.less#L12"><code>th.filter-header</code></a>)</li>
       </ul>
     </div>
     <rx-styleguide code-url="styleguide/tables/with-filtering.html"></rx-styleguide>

--- a/src/rxApp/README.md
+++ b/src/rxApp/README.md
@@ -98,7 +98,7 @@ This will create a new status tag called `"gamma"`, which you can pass to `rx-pa
 
 And the title will appear with a `Hello World!` tag beside it, styled the same way as our `"alpha"` status tag is styled. You can also define your own CSS style in your application and use those instead, passing it as the `class` value to `addStatus()`.
 
-All the tags are accessible inside of [rxBreadcrumbs](./#/component/rxBreadcrumbs) as well. Any breadcrumb that was created with `useStatusTag: true` will automatically receive the same status tag as you passed to `<rx-page>`.
+All the tags are accessible inside of [rxBreadcrumbs](#/component/rxBreadcrumbs) as well. Any breadcrumb that was created with `useStatusTag: true` will automatically receive the same status tag as you passed to `<rx-page>`.
 
 ### .page-actions
 
@@ -143,7 +143,7 @@ Each section specified in this array is required to have a `title` attribute, i.
 navJSON = [
     {
         "title": "Section 1"
-    }, { 
+    }, {
         "title": "Section 2"
     }
 ]
@@ -157,7 +157,7 @@ navJSON = [
     {
         "title": "Section 1",
         "type": "highlight"
-    }, { 
+    }, {
         "title": "Section 2"
     }
 ]
@@ -187,7 +187,7 @@ navJSON = [
                 "linkText": "About"
             },
         ]
-    }, { 
+    }, {
         "title": "Section 2",
         "children": [
             {
@@ -293,7 +293,7 @@ If an item doesn't have an `href` attribute, it's probably because it has child 
                         "href": "/people/sue",
                         "linkText": "Sue"
                     }
-        
+
                 ]
             }
         ]
@@ -319,14 +319,14 @@ This expression would be evaluated, checking if the user is currently viewing th
 
 *Note*: Using an expression for environment checking use has somewhat tailed off. We now have different JSON files for each environment, so checking the current environment is not necessary.
 
-Another technique for visibility is to use a predefined set of visibility functions that exist in the framework. These include `rxPathParams` and `rxHideIfUkAccount`. 
+Another technique for visibility is to use a predefined set of visibility functions that exist in the framework. These include `rxPathParams` and `rxHideIfUkAccount`.
 
 To use these, you pass an array to `visibility`, with the first argument being the name of the function to use (as a string), and the second argument as an optional object describing the parameters to pass to the function.
 
 For instance, `rxPathParams` is used to check if a particular parameter is present in the current route. The syntax is as follows:
 
 ```
-"visibility": ["rxPathParams", { "param": "accountNumber" }], 
+"visibility": ["rxPathParams", { "param": "accountNumber" }],
 ```
 
 This means "only show this item if `accountNumber` is present in the current route.
@@ -363,7 +363,7 @@ The `childHeader` attribute is used to specify an HTML header to be placed above
                         "href": "/people/sue",
                         "linkText": "Sue"
                     }
-        
+
                 ]
             }
         ]
@@ -405,7 +405,7 @@ In addition to the `visibility` criteria described above, you can also restrict 
                         "linkText": "Sue",
                         "roles": { "any": ["role1", "role2", "role3"] }
                     }
-        
+
                 ]
             }
         ]

--- a/src/rxBreadcrumbs/README.md
+++ b/src/rxBreadcrumbs/README.md
@@ -7,7 +7,7 @@ with the `rxBreadcrumbsSvc.setHome()` method. It takes the new path as the first
 second argument. If you don't pass the second argument, it will reuse whatever name is already there (i.e. `'Home'`).
 The breadcrumb name can contain HTML (ie. `'<strong>Home</strong>'`).
 
-The argument `status` is also an optional argument to breadcrumbs. This leverages the tags defined in [rxApp](./#/component/rxApp) to display status tags directly inside of breadcrumbs. The demo shows the use of the custom `"demo"` tag.
+The argument `status` is also an optional argument to breadcrumbs. This leverages the tags defined in [rxApp](#/component/rxApp) to display status tags directly inside of breadcrumbs. The demo shows the use of the custom `"demo"` tag.
 
 A final optional argument is the boolean `usePageStatusTag`, which defaults to `false`. If you set it to `true`, then the breadcrumb will use whatever
 status tag was passed to page, i.e.:

--- a/src/rxButton/README.md
+++ b/src/rxButton/README.md
@@ -1,6 +1,6 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-[API Documentation](/ngdocs/index.html#/api/rxButton.directive:rxButton)
+[API Documentation](ngdocs/index.html#/api/rxButton.directive:rxButton)
 
 Provides styling for various types of buttons. See the .less file for examples.
 

--- a/src/rxCharacterCount/README.md
+++ b/src/rxCharacterCount/README.md
@@ -1,6 +1,6 @@
 [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges)
 
-[API Documenation](/ngdocs/index.html#/api/rxCharacterCount.directive:rxCharacterCount)
+[API Documenation](ngdocs/index.html#/api/rxCharacterCount.directive:rxCharacterCount)
 
 This provides an attribute directive intended for adding to `<textarea>` elements. Place the `rx-character-count` attribute into your `<textarea>`, and a new
 `<div>` will be added directly underneath it. This directive requires that you're using `ng-model` with your `<textarea>`

--- a/src/rxCheckbox/README.md
+++ b/src/rxCheckbox/README.md
@@ -1,6 +1,6 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-[API Documentation](/ngdocs/index.html#/api/rxCheckbox.directive:rxCheckbox)
+[API Documentation](ngdocs/index.html#/api/rxCheckbox.directive:rxCheckbox)
 
 rxCheckbox is an **attribute directive** that wraps a native checkbox element in markup required for styling purposes.
 To use the directive, you can replace `type="checkbox"` with `rx-checkbox`. The directive is smart enough to set the correct input type.

--- a/src/rxForm/README.md
+++ b/src/rxForm/README.md
@@ -1,6 +1,6 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-[API Documentation](/ngdocs/index.html#/api/rxForm)
+[API Documentation](ngdocs/index.html#/api/rxForm)
 
 The rxForm component is a set of directives used to create forms throughout
 Encore.  These directives provide a common HTML layout and style for all form
@@ -24,35 +24,35 @@ If you do not nest these elements properly, Angular will throw an error (this is
 
 These directives must be nested in the following hierarchy (*parens denote how many items can be nested within its parent*):
 
-* [rxForm](/ngdocs/index.html#/api/rxForm.directive:rxForm)
-  * [rxFormSection](/ngdocs/index.html#/api/rxForm.directive:rxFormSection) (0..N)
-    * [rxField](/ngdocs/index.html#/api/rxForm.directive:rxField) (0..N)
-      * [rxFieldName](/ngdocs/index.html#/api/rxForm.directive:rxFieldName) (0..1)
-      * [rxFieldContent](/ngdocs/index.html#/api/rxForm.directive:rxFieldContent) (0..1)
-        * [rxInput](/ngdocs/index.html#/api/rxForm.directive:rxInput) (0..N)
-          * [rxPrefix](/ngdocs/index.html#/api/rxForm.directive:rxPrefix) (0..1)
-          * [rxSuffix](/ngdocs/index.html#/api/rxForm.directive:rxSuffix) (0..1)
+* [rxForm](ngdocs/index.html#/api/rxForm.directive:rxForm)
+  * [rxFormSection](ngdocs/index.html#/api/rxForm.directive:rxFormSection) (0..N)
+    * [rxField](ngdocs/index.html#/api/rxForm.directive:rxField) (0..N)
+      * [rxFieldName](ngdocs/index.html#/api/rxForm.directive:rxFieldName) (0..1)
+      * [rxFieldContent](ngdocs/index.html#/api/rxForm.directive:rxFieldContent) (0..1)
+        * [rxInput](ngdocs/index.html#/api/rxForm.directive:rxInput) (0..N)
+          * [rxPrefix](ngdocs/index.html#/api/rxForm.directive:rxPrefix) (0..1)
+          * [rxSuffix](ngdocs/index.html#/api/rxForm.directive:rxSuffix) (0..1)
 
 ## Free-Range
 These directives are not limited to their placement and can be used anywhere:
 
-* [rxHelpText](/ngdocs/index.html#/api/rxForm.directive:rxHelpText)
+* [rxHelpText](ngdocs/index.html#/api/rxForm.directive:rxHelpText)
   * Designed to style form control help text.
-* [rxInlineError](/ngdocs/index.html#/api/rxForm.directive:rxInlineError)
+* [rxInlineError](ngdocs/index.html#/api/rxForm.directive:rxInlineError)
   * Designed to style form control error messages.
 
 ## Compatible Components
 These components work well with rxForm.
 
-* [rxButton](/#/component/rxButton)
-* [rxCharacterCount](/#/component/rxCharacterCount)
-* [rxCheckbox](/#/component/rxCheckbox)
-* [rxMultiSelect](/#/component/rxSelectFilter) *(defined in `rxSelectFilter`)*
-* [rxOptionTable](/#/component/rxOptionTable)
-* [rxRadio](/#/component/rxRadio)
-* [rxSelect](/#/component/rxSelect)
-* [rxToggleSwitch](/#/component/rxToggleSwitch)
-* [typeahead](/#/component/typeahead)
+* [rxButton](#/component/rxButton)
+* [rxCharacterCount](#/component/rxCharacterCount)
+* [rxCheckbox](#/component/rxCheckbox)
+* [rxMultiSelect](#/component/rxSelectFilter) *(defined in `rxSelectFilter`)*
+* [rxOptionTable](#/component/rxOptionTable)
+* [rxRadio](#/component/rxRadio)
+* [rxSelect](#/component/rxSelect)
+* [rxToggleSwitch](#/component/rxToggleSwitch)
+* [typeahead](#/component/typeahead)
 
 
 # Layout
@@ -82,7 +82,7 @@ attribute for rxFieldName.  When the value evaluates to true, an asterisk will
 display to the left of the field name.  You can see an example of this with the
 "Required Textare" field name in the demo.
 
-See [rxFieldName](/ngdocs/index.html#/api/rxForm.directive:rxFieldName)
+See [rxFieldName](ngdocs/index.html#/api/rxForm.directive:rxFieldName)
 API Documentation for more information.
 
 ## Custom Validators
@@ -109,7 +109,7 @@ release of the EncoreUI framework.** They are still functional, but **WILL displ
 a warning in the javascript console** to let you know you should upgrade your code.
 
 ### **rxFormOptionTable**
-Please use [`rxOptionTable`](/#/component/rxOptionTable) as a stand-in replacement.
+Please use [`rxOptionTable`](#/component/rxOptionTable) as a stand-in replacement.
 
 ### **rxFormItem**
 See "Before & After" below

--- a/src/rxMisc/README.md
+++ b/src/rxMisc/README.md
@@ -1,6 +1,6 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-A module for shared functionality across framework components.  See [API Documentation](/ngdocs/index.html#/api/rxMisc).
+A module for shared functionality across framework components.  See [API Documentation](ngdocs/index.html#/api/rxMisc).
 
 
 ## rxDOMHelper
@@ -8,7 +8,7 @@ A small set of functions to provide some functionality that isn't present in Ang
 
 
 ## titleize
-See [titleize API Documentation](/ngdocs/index.html#/api/rxMisc.filter:titleize)
+See [titleize API Documentation](ngdocs/index.html#/api/rxMisc.filter:titleize)
 
 A filter that converts a string to title case, stripping out underscores and capitalizing words.  For example,
 ```
@@ -18,7 +18,7 @@ renders the string "A Simple String".
 
 
 ## rxAutoSave
-See [rxAutoSave API Documentation](/ngdocs/index.html#/api/rxMisc.service:rxAutoSave)
+See [rxAutoSave API Documentation](ngdocs/index.html#/api/rxMisc.service:rxAutoSave)
 
 `rxAutoSave` provides a way to store values in a form for later. For instance, if a user is entering values into a form, then accidentally navigate to a new page, we likely want the values to be present again when they click the "Back" button in their browser. By correctly setting up an `rxAutoSave` instance for the form, this can happen automatically. By default, all saved values will be cleared after two days.
 

--- a/src/rxOptionTable/README.md
+++ b/src/rxOptionTable/README.md
@@ -1,5 +1,5 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-[API Documentation](/ngdocs/index.html#/api/rxOptionTable.directive:rxOptionTable)
+[API Documentation](ngdocs/index.html#/api/rxOptionTable.directive:rxOptionTable)
 
 Given a data object and an additional optional object for column labels, `rxOptionTable` creates a series of radio or checkbox buttons.

--- a/src/rxRadio/README.md
+++ b/src/rxRadio/README.md
@@ -1,6 +1,6 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-[API Documentation](/ngdocs/index.html#/api/rxRadio.directive:rxRadio)
+[API Documentation](ngdocs/index.html#/api/rxRadio.directive:rxRadio)
 
 rxRadio is an **attribute directive** that wraps a native radio element in markup required for styling purposes.
 To use the directive, you can replace `type="radio"` with `rx-radio`. The directive is smart enough to set

--- a/src/rxSelect/README.md
+++ b/src/rxSelect/README.md
@@ -1,6 +1,6 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-[API Documentation](/ngdocs/index.html#/api/rxSelect.directive:rxSelect)
+[API Documentation](ngdocs/index.html#/api/rxSelect.directive:rxSelect)
 
 The rxSelect component is an **attribute directive** that wraps native select elements in markup required for styling.
 

--- a/src/rxStatus/README.md
+++ b/src/rxStatus/README.md
@@ -2,7 +2,7 @@
 
 # Description
 
-This service is provided as a compliment to [`rxNotify` rxNotify service](http://rackerlabs.github.io/encore-ui/#/component/rxNotify).  It abstracts out some of the raw functionality provided by rxNotify to make the addition and removal of single messages easier.
+This service is provided as a compliment to [`rxNotify` rxNotify service](#/component/rxNotify).  It abstracts out some of the raw functionality provided by rxNotify to make the addition and removal of single messages easier.
 
 # Usage
 
@@ -41,7 +41,7 @@ results in a call to rxNotify as such:
             }
         );
 
-Note: For `success` and `error` messages, the `repeat` attribute is set to false. Messages of `success` will also automatically timeout after 5 seconds. Both of these defaults were design decisions made at this level for usability and consistency across all Encore products. 
+Note: For `success` and `error` messages, the `repeat` attribute is set to false. Messages of `success` will also automatically timeout after 5 seconds. Both of these defaults were design decisions made at this level for usability and consistency across all Encore products.
 
 Each of the wrapper functions to the different rxNotify message types support receiving an `options:{}` parameter that can override defaults for the respective wrapper. For example, instead of showing a success message on next route change, it can be shown immediately:
 

--- a/src/rxToggleSwitch/README.md
+++ b/src/rxToggleSwitch/README.md
@@ -1,6 +1,6 @@
 [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges)
 
-[API Documenation](/ngdocs/index.html#/api/rxToggleSwitch.directive:rxToggleSwitch)
+[API Documentation](ngdocs/index.html#/api/rxToggleSwitch.directive:rxToggleSwitch)
 
 A simple boolean toggle switch.
 


### PR DESCRIPTION
* Use correct relative link URLs:
  * removing leading forward slash
* Normalized relative links:
  * modified `rackerlabs.github.io` links to use relative paths, where necessary

This needs to be added ASAP or the new rxForm documentation links (as well as a few others) will be 9 kinds of broken.