### PR TITLE
docs(tables): Add proper styling for delete X pattern.

### DIFF
--- a/demo/styleguide/tables.html
+++ b/demo/styleguide/tables.html
@@ -55,6 +55,7 @@
     <div class="component-description clear">
         <ul class="list">
             <li><span class="msg-info">ENCORE-SPECIFIC:</span> For data tables involving objects that only require deleting (Examples: tables related to LBaaS connection nodes and Support Service user tables) there's a design pattern that replaces the cog with an X.</li>
+            <li>Add the <code>delete-x</code> class to the icon element to automatically apply the red hover style.  This should always be done when using this design pattern</li>
             <li>View <a href="https://github.com/rackerlabs/supportservice-ui/search?utf8=%E2%9C%93&q=times">these set of tables used in Support Services</a> for examples.</li>
         </ul>
     </div>

--- a/demo/styleguide/tables/delete.html
+++ b/demo/styleguide/tables/delete.html
@@ -10,7 +10,7 @@
         <tr>
             <td>Patrick Deuley</td>
             <td>Design Chaplain</td>
-            <td><i class="fa fa-times"></i></td>
+            <td><i class="fa fa-times delete-x"></i></td>
         </tr>
     </tbody>
 </table>

--- a/src/rxApp/common.less
+++ b/src/rxApp/common.less
@@ -101,6 +101,10 @@ table {
             .chevron-mixin(-1);
         }
     }
+    .fa-times.delete-x:hover {
+        color: @warnRedHover;
+        cursor: pointer;
+    }
 }
 
 .expanded-container {


### PR DESCRIPTION
Fixes #930 
![screen shot 2015-06-30 at 1 27 17 pm](https://cloud.githubusercontent.com/assets/5414922/8438493/c34a7b36-1f2b-11e5-8eaf-87b6df0d2bf2.png)
To clarify the screenshot, my mouse is hovering the x, but it isn't visible.  The x is not red unless hovered.