### PR TITLE
chore(travis): Use Firefox 35.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
 - '0.10'
+addons:
+  firefox: "35.0"
 before_install:
 - npm install -g grunt-cli bower
 install:


### PR DESCRIPTION
There are intermittent failures in Travis end to end test runs. This is attempting to fix that.

This at least narrows it down a little bit, since we're all using Firefox 35.0 locally.

I've found that Selenium server is at 2.46 in both places, so it shouldn't be that. Protractor is latest in both places. This appears to be the only obvious place to start for now.

I'm going to keep running this PR over and over for the next few days (?).

### Test Runs

| Run Number | Result |
|------|-------|
| 1 | Pass |
| 2 | Pass |
| 3 | Pass |
| 4 | Pass |
| 5 | Pass |
| 6 | Pass |
| 7 | [Fail](https://github.com/rackerlabs/encore-ui/pull/1092#issuecomment-119558643) |
| 8 | Pass |
| 9 | Pass |
| 10 | Pass |
| 11 | Pass |
| 12 | Pass |
| 13 | Pass |
| 14 | Pass |
| 15 | Pass |
| 16 | Pass |
| 17 | Pass |
| 18 | Pass |
| 19 | Pass |
| 20 | Pass |
| 21 | Pass |
| 22 | Pass |
| 23 | Pass |
| 24 | Pass |