### PR TITLE
docs(rxButton): Improve usage documentation.

### DIFF
--- a/src/rxButton/README.md
+++ b/src/rxButton/README.md
@@ -2,8 +2,16 @@
 
 [API Documentation](ngdocs/index.html#/api/rxButton.directive:rxButton)
 
-Provides styling for various types of buttons. See the .less file for examples.
+An **element directive** used to create buttons with a dynamically-displayed loading indicator. This is used as a replacement for `<button>` elements in scenarios where the button has multiple states.
 
-## rxButton directive
+## Usage
 
-This directive is used to allow dynamic showing/hiding of a spinner/loading indicator.
+The state of the button is controlled via the `toggle` attribute, which disables the button and replaces the `default-msg` with the `toggle-msg` as the button's text.  There are no defaults for these messages, so they must be defined if the toggle behavior is desired.  While the button is in the toggled state, it is also disabled (no matter what the value of `disable` is.
+
+The button does not modify the variable passed to `toggle`; it should be modified in the handler provided to `ng-click`.  Usually, the handler will set the variable to `true` immediately, and then to `false` once the the process (e.g. an API call) is complete.
+
+To disable the button, use the `disable` attribute instead of the normal `ng-disabled` - the behavior is the same.
+
+## Styling
+
+There are several styles of buttons available, and they are documented in the [styleguide](#/styleguide/buttons).  Any classes that need to be added to the button should be passed to the `classes` attribute.

--- a/src/rxButton/docs/rxButton.html
+++ b/src/rxButton/docs/rxButton.html
@@ -7,9 +7,6 @@
 </div>
 
 <h3 class="title">Using the <code>disable</code> attribute<h3>
-<p>
-Normally the <code>ng-disabled</code> property of an <code>rxButton</code> is controlled by <code>toggle</code>. You can use the optional <code>disable</code> attribute to pass an expression that <code>rxButton</code> should use for <code>ng-disabled</code>. Note that we set <code>classes="positive"</code> on the "Login" button to provide it with some styling.
-</p>
 <div ng-controller="rxButtonCtrl">
     <rx-button default-msg="Toggle enabled/disabled of 'Login'"
         rx-toggle="status.disable">

--- a/src/rxButton/rxButton.js
+++ b/src/rxButton/rxButton.js
@@ -13,6 +13,7 @@ angular.module('encore.ui.rxButton', [])
 * @param {String} defaultMsg Text to be displayed by default an no operation is in progress.
 * @param {Boolean=} [toggle=false] When true, the button will display the loading text.
 * @param {Boolean=} [disable=false] When true, the button will be disabled.
+* @param {String=} [classes=""] The class names to be applied to the button.
 */
 .directive('rxButton', function () {
     return {


### PR DESCRIPTION
This is a pretty old component that has almost no documentation.
![screen shot 2015-07-08 at 1 02 42 pm](https://cloud.githubusercontent.com/assets/5414922/8578002/ad314a2c-2571-11e5-9e60-b834a7bac87f.png)
