### PR TITLE
fix(rxFeedback): Show url of current page.

### DIFF
--- a/src/rxFeedback/rxFeedback.js
+++ b/src/rxFeedback/rxFeedback.js
@@ -94,8 +94,11 @@ angular.module('encore.ui.rxFeedback', ['ngResource'])
             sendFeedback: '=?onSubmit'
         },
         link: function (scope) {
-            scope.currentUrl = $location.url();
             scope.feedbackTypes = feedbackTypes;
+
+            scope.setCurrentUrl = function (modalScope) {
+                modalScope.currentUrl = $location.url();
+            };
 
             var showSuccessMessage = function (response) {
                 var message = _.isString(response.message) ? response.message : 'Thanks for your feedback!';

--- a/src/rxFeedback/rxFeedback.spec.js
+++ b/src/rxFeedback/rxFeedback.spec.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 describe('rxFeedback', function () {
     var scope, compile, rootScope, el, feedbackSvc, apiUrl, httpMock,
-        notifySvcMock, screenshotSvcMock, elScope, sessionSvcMock;
+        notifySvcMock, screenshotSvcMock, elScope, sessionSvcMock, locationMock;
     var validTemplate = '<rx-feedback></rx-feedback>';
     var theScreenshot = 'the screenshot';
 
@@ -33,6 +33,10 @@ describe('rxFeedback', function () {
             getUserId: sinon.stub()
         };
 
+        locationMock = {
+            url: sinon.stub()
+        };
+
         // load module
         module('encore.ui.configs');
         module('encore.ui.rxFeedback');
@@ -44,10 +48,11 @@ describe('rxFeedback', function () {
             $provide.value('rxNotify', notifySvcMock);
             $provide.value('rxScreenshotSvc', screenshotSvcMock);
             $provide.value('Session', sessionSvcMock);
+            $provide.value('$location', locationMock);
         });
 
         // Inject in angular constructs
-        inject(function ($location, $rootScope, $compile, rxFeedbackSvc, $httpBackend, feedbackApi) {
+        inject(function ($rootScope, $compile, rxFeedbackSvc, $httpBackend, feedbackApi) {
             rootScope = $rootScope;
             scope = $rootScope.$new();
             compile = $compile;
@@ -62,6 +67,13 @@ describe('rxFeedback', function () {
         el = helpers.createDirective(validTemplate, compile, scope);
         elScope = el.isolateScope();
 
+    });
+
+    it('should set the current url of the page on the modal\'s scope', function () {
+        var modalScope = {};
+        locationMock.url.returns('/path');
+        elScope.setCurrentUrl(modalScope);
+        expect(modalScope.currentUrl).to.equal('/path');
     });
 
     it('should submit data to feedback api', function () {

--- a/src/rxFeedback/templates/rxFeedback.html
+++ b/src/rxFeedback/templates/rxFeedback.html
@@ -1,5 +1,6 @@
 <div class="rx-feedback">
     <rx-modal-action
+        pre-hook="setCurrentUrl(this)"
         post-hook="sendFeedback(fields)"
         template-url="templates/feedbackForm.html">
         Submit Feedback


### PR DESCRIPTION
`rxFeedback` is displaying whatever the url was at the application's bootstrap, which is not necessarily the url at the time the feedback is submitted.  This has no effect on the api call that is made.

To reproduce this bug, go to the home page for the docs, and then click to any other page.  Open up the feedback modal, and you'll see
![screen shot 2015-07-09 at 2 14 48 pm](https://cloud.githubusercontent.com/assets/5414922/8604540/e280f10e-2644-11e5-857b-c08802747190.png)

