### PR TITLE
Rx form page object refactor

### DIFF
--- a/src/rxCheckbox/docs/rxCheckbox.html
+++ b/src/rxCheckbox/docs/rxCheckbox.html
@@ -36,10 +36,6 @@
            ng-if="!chkIsRemoved" />
   </p>
 
-  <!-- END DEMO CODE -->
-  <!-- END DEMO CODE -->
-  <!-- END DEMO CODE -->
-
   <h2 class="title">Checkbox States</h2>
   <table>
     <thead>
@@ -167,4 +163,35 @@
       </tr>
     </tbody>
   </table>
+
+    <h3 class="title">Plain HTML Checkboxes (for comparison)</h3>
+  <p>
+    <input type="checkbox"
+           id="plainHtmlNormal"
+           ng-required="true" />
+    <label for="plainHtmlNormal">A plain checkbox</label>
+  </p>
+  <p>
+    <input type="checkbox"
+           id="plainHtmlDisabled"
+           disabled />
+    <label for="plainHtmlDisabled">A plain checkbox (disabled)</label>
+  </p>
+  <p>
+    <input type="checkbox"
+           id="plainHtmlChecked"
+           checked />
+    <label for="plainHtmlChecked">A plain checkbox (checked)</label>
+  </p>
+  <p>
+    <input type="checkbox"
+           id="plainChkRemoveCheckbox"
+           ng-model="plainChkIsRemoved" />
+    <label for="plainChkRemoveCheckbox">Remove Following Checkbox:</label>
+
+    <input type="checkbox"
+           checked
+           id="plainChkRemoveable"
+           ng-if="!plainChkIsRemoved" />
+  </p>
 </div>

--- a/src/rxCheckbox/docs/rxCheckbox.midway.js
+++ b/src/rxCheckbox/docs/rxCheckbox.midway.js
@@ -89,6 +89,30 @@ describe('rxCheckbox', function () {
         valid: false
     }));
 
+    describe('plain HTML checkboxes', function () {
+        describe('Valid Enabled Unchecked', encore.exercise.rxCheckbox({
+            cssSelector: "#plainHtmlNormal",
+            disabled: false,
+            selected: false,
+            valid: false
+        }));
+
+        describe('Valid Disabled Unchecked', encore.exercise.rxCheckbox({
+            cssSelector: "#plainHtmlDisabled",
+            disabled: true,
+            selected: false,
+            valid: false
+        }));
+
+        describe('Valid Enabled Checked', encore.exercise.rxCheckbox({
+            cssSelector: "#plainHtmlChecked",
+            disabled: false,
+            selected: true,
+            valid: false
+        }));
+
+    });
+
     describe('Show/Hide Input', function () {
         var chkSure, chkReallySure;
 
@@ -129,6 +153,33 @@ describe('rxCheckbox', function () {
                     expect(chkReallySure.isDisplayed()).to.eventually.be.false;
                 });
             });
+        });
+
+        describe('plain HTML checkboxes', function () {
+            var willHide;
+            var willBeHidden;
+
+            before(function () {
+                willHide = encore.rxCheckbox.initialize($('#plainChkRemoveCheckbox'));
+                willBeHidden = encore.rxCheckbox.initialize($('#plainChkRemoveable'));
+            });
+
+            it('should show the checkbox by default', function () {
+                expect(willBeHidden.isDisplayed()).to.eventually.be.true;
+                expect(willBeHidden.isPresent()).to.eventually.be.true;
+            });
+
+            it('should remove the checkbox from the DOM', function () {
+                willHide.select();
+                expect(willBeHidden.isPresent()).to.eventually.be.false;
+            });
+
+            it('should put the checkbox back', function () {
+                willHide.deselect();
+                expect(willBeHidden.isDisplayed()).to.eventually.be.true;
+                expect(willBeHidden.isPresent()).to.eventually.be.true;
+            });
+
         });
     });
 

--- a/src/rxCheckbox/rxCheckbox.exercise.js
+++ b/src/rxCheckbox/rxCheckbox.exercise.js
@@ -34,12 +34,12 @@ exports.rxCheckbox = function (options) {
             }
         });
 
-        it('should be a checkbox type', function () {
-            expect(component.isCheckbox()).to.eventually.be.true;
-        });
-
         it('should be present', function () {
             expect(component.isPresent()).to.eventually.be.true;
+        });
+
+        it('should be a checkbox', function () {
+            expect(component.isCheckbox()).to.eventually.be.true;
         });
 
         it('should ' + (options.visible ? 'be' : 'not be') + ' visible', function () {
@@ -53,6 +53,32 @@ exports.rxCheckbox = function (options) {
         it('should ' + (options.selected ? 'be' : 'not be') + ' selected', function () {
             expect(component.isSelected()).to.eventually.eq(options.selected);
         });
+
+        if (options.disabled) {
+            it('should not respond to selecting and unselecting', function () {
+                component.isSelected().then(function (selected) {
+                    selected ? component.deselect() : component.select();
+                    expect(component.isSelected()).to.eventually.equal(selected);
+                    // even though it "doesn't respond to selecting and unselecting"
+                    // attempt to put it back anyway in case it did actually respond.
+                    // that way nobody accidentally submits a swapped checkbox after
+                    // running these exercises.
+                    selected ? component.select() : component.deselect();
+                    expect(component.isSelected()).to.eventually.equal(selected);
+                });
+            });
+        } else {
+            it('should respond to selecting and unselecting', function () {
+                component.isSelected().then(function (selected) {
+                    selected ? component.deselect() : component.select();
+                    expect(component.isSelected()).to.eventually.not.equal(selected);
+                    // exercises should never alter the state of a page.
+                    // always put it back when you're done.
+                    selected ? component.select() : component.deselect();
+                    expect(component.isSelected()).to.eventually.equal(selected);
+                });
+            });
+        }
 
         it('should ' + (options.valid ? 'be' : 'not be') + ' valid', function () {
             expect(component.isValid()).to.eventually.eq(options.valid);

--- a/src/rxCheckbox/rxCheckbox.page.js
+++ b/src/rxCheckbox/rxCheckbox.page.js
@@ -5,14 +5,74 @@ var Page = require('astrolabe').Page;
 /**
  * @namespace
  */
-var htmlCheckbox = {
+var rxCheckbox = {
+    eleWrapper: {
+        get: function () {
+            return this.rootElement.element(by.xpath('..'));
+        }
+    },
+
+    eleFakeCheckbox: {
+        get: function () {
+            return this.eleWrapper.$('.fake-checkbox');
+        }
+    },
+
+    /**
+       Useful for situations where input types might change in the future, ensuring that the expected one is being used.
+       @returns {Boolean} Whether or not the element in question is a checkbox.
+     */
+    isCheckbox: {
+        value: function () {
+            return this.rootElement.getAttribute('type').then(function (type) {
+                return type === 'checkbox';
+            });
+        }
+    },
+
     /**
      * @function
      * @returns {Boolean} Whether the checkbox is currently displayed.
      */
     isDisplayed: {
         value: function () {
-            return this.rootElement.isDisplayed();
+            var page = this;
+            return this.eleFakeCheckbox.isPresent().then(function (isFakeCheckbox) {
+                return isFakeCheckbox ? page.eleFakeCheckbox.isDisplayed() : page.rootElement.isDisplayed();
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the checkbox is disabled.
+     */
+    isDisabled: {
+        value: function () {
+            var page = this;
+            return this.eleFakeCheckbox.isPresent().then(function (isFakeCheckbox) {
+                if (isFakeCheckbox) {
+                    return page.eleWrapper.getAttribute('class').then(function (classes) {
+                        return _.contains(classes.split(' '), 'rx-disabled');
+                    });
+                }
+                return page.rootElement.getAttribute('disabled').then(function (disabled) {
+                    return (disabled ? true : false);
+                });
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether or not the checkbox is present on the page.
+     */
+    isPresent: {
+        value: function () {
+            var page = this;
+            return this.eleFakeCheckbox.isPresent().then(function (isFakeCheckbox) {
+                return isFakeCheckbox || page.rootElement.isPresent();
+            });
         }
     },
 
@@ -29,34 +89,12 @@ var htmlCheckbox = {
     },
 
     /**
-     * @function
-     * @returns {Boolean} Whether or not the checkbox is currently selected
+       @function
+       @returns {Boolean} Whether or not the checkbox is selected.
      */
     isSelected: {
         value: function () {
             return this.rootElement.isSelected();
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether or not the checkbox is disabled
-     */
-    isDisabled: {
-        value: function () {
-            return this.rootElement.getAttribute('disabled').then(function (disabled) {
-                return (disabled ? true : false);
-            });
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether or not the checkbox exists on the page
-     */
-    isPresent: {
-        value: function () {
-            return this.rootElement.isPresent();
         }
     },
 
@@ -79,7 +117,7 @@ var htmlCheckbox = {
      * @deprecated
      * @function
      * @description
-     * **DEPRECATED**: Use {@link htmlCheckbox.deselect} instead.
+     * **DEPRECATED**: Use {@link rxCheckbox.deselect} instead.
      * This function will be removed in a future release of the EncoreUI framework.
      * @returns {undefined}
      */
@@ -106,118 +144,6 @@ var htmlCheckbox = {
 };
 
 /**
- * @namespace
- * @extends htmlCheckbox
- */
-var rxCheckbox = {
-    eleWrapper: {
-        get: function () {
-            return this.rootElement.element(by.xpath('..'));
-        }
-    },
-
-    eleFakeCheckbox: {
-        get: function () {
-            return this.eleWrapper.$('.fake-checkbox');
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether root element is of type="checkbox"
-     */
-    isCheckbox: {
-        value: function () {
-            return this.rootElement.getAttribute('type').then(function (ilk) {
-                return ilk === 'checkbox';
-            });
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether the fake checkbox is currently displayed.
-     */
-    isDisplayed: {
-        value: function () {
-            return this.eleFakeCheckbox.isDisplayed();
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether or not the wrapper has expected disabled class name
-     */
-    isDisabled: {
-        value: function () {
-            return this.eleWrapper.getAttribute('class').then(function (classes) {
-                return _.contains(classes.split(' '), 'rx-disabled');
-            });
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether or not the styled element exists on the page
-     */
-    isPresent: {
-        value: function () {
-            return this.eleFakeCheckbox.isPresent();
-        }
-    }
-};
-rxCheckbox = _.assign(htmlCheckbox, rxCheckbox);
-
-/**
- * @exports encore.htmlCheckbox
- * @description Page object for interacting with plain old html checkboxes
- */
-exports.htmlCheckbox = {
-    /**
-     * @function
-     * @param {WebElement} checkboxElement
-     *   WebElement to be transformed into an htmlCheckbox page object.
-     * @returns {htmlCheckbox} Page object representing the checkbox object
-     */
-    initialize: function (checkboxElement) {
-        htmlCheckbox.rootElement = {
-            get: function () { return checkboxElement; }
-        };
-        return Page.create(htmlCheckbox);
-    },
-
-    /**
-     * @returns {htmlCheckbox}
-     *   Page object representing the _first_ `<input type="checkbox" />`
-     *   object found on the page.
-     */
-    main: (function () {
-        htmlCheckbox.rootElement = {
-            get: function () { return $('input[type="checkbox"]'); }
-        };
-        return Page.create(htmlCheckbox);
-    })(),
-
-    /**
-     * @function
-     * @description Generates a getter and a setter for a checkbox element.
-     * @param {WebElement} elem - The WebElement for the checkbox.
-     * @returns {Object} A getter and a setter to be applied to a checkbox in a page object.
-     */
-    generateAccessor: function (elem) {
-        return {
-            get: function () {
-                return exports.htmlCheckbox.initialize(elem).isSelected();
-            },
-            set: function (enable) {
-                var checkbox = exports.htmlCheckbox.initialize(elem);
-                enable ? checkbox.select() : checkbox.deselect();
-            }
-        };
-    }
-};
-
-/**
  * @exports encore.rxCheckbox
  * @description Page object for interacting with rxCheckbox elements
  */
@@ -235,7 +161,9 @@ exports.rxCheckbox = {
     },
 
     /**
-     * @returns {rxCheckbox} Page object representing the _first_ `<input rx-checkbox />` element found on the page
+       Don't use this if you're expecting a regular html checkbox on the page. This only checks for Encore
+       specific rxForm-style checkboxes.
+       @returns {rxCheckbox} Page object representing the _first_ `<input rx-checkbox />` element found on the page.
      */
     main: (function () {
         rxCheckbox.rootElement = {

--- a/src/rxCheckbox/rxCheckbox.page.js
+++ b/src/rxCheckbox/rxCheckbox.page.js
@@ -161,18 +161,6 @@ exports.rxCheckbox = {
     },
 
     /**
-       Don't use this if you're expecting a regular html checkbox on the page. This only checks for Encore
-       specific rxForm-style checkboxes.
-       @returns {rxCheckbox} Page object representing the _first_ `<input rx-checkbox />` element found on the page.
-     */
-    main: (function () {
-        rxCheckbox.rootElement = {
-            get: function () { return $('input[rx-checkbox]'); }
-        };
-        return Page.create(rxCheckbox);
-    })(),
-
-    /**
      * @function
      * @description Generates a getter and a setter for an rxCheckbox element on your page.
      * @param {WebElement} elem - The WebElement for the rxCheckbox.

--- a/src/rxForm/rxForm.page.js
+++ b/src/rxForm/rxForm.page.js
@@ -172,17 +172,7 @@ exports.rxForm = {
                 get: function () { return rxFieldNameElement; }
             };
             return Page.create(rxFieldName);
-        },
-
-        /**
-         * @returns {rxFieldName} Page object representing the _first_ rxFieldName object found on the page.
-         */
-        main: (function () {
-            rxFieldName.rootElement = {
-                get: function () { return $('rx-field-name')[0]; }
-            };
-            return Page.create(rxFieldName);
-        })()
+        }
     },
 
     /**
@@ -192,7 +182,6 @@ exports.rxForm = {
      * **ALIASED** Directly uses <a href="#encore.module_rxCheckbox">encore.rxCheckbox</a>.
      */
     checkbox: {
-        get main() { return exports.rxCheckbox.main; },
         get initialize() { return exports.rxCheckbox.initialize; },
         get generateAccessor() { return exports.rxCheckbox.generateAccessor; }
     },
@@ -203,7 +192,6 @@ exports.rxForm = {
      * **ALIASED** Directly uses <a href="#encore.module_rxRadio">encore.rxRadio</a>.
      */
     radioButton: {
-        get main() { return exports.rxRadio.main; },
         get initialize() { return exports.rxRadio.initialize; },
         get generateAccessor() { return exports.rxRadio.generateAccessor; }
     },
@@ -214,7 +202,6 @@ exports.rxForm = {
      * **ALIASED** Directly uses <a href="#encore.module_rxSelect">encore.rxSelect</a>.
      */
     dropdown: {
-        get main() { return exports.rxSelect.main; },
         get initialize() { return exports.rxSelect.initialize; },
         get generateAccessor() { return exports.rxSelect.generateAccessor; }
     },

--- a/src/rxRadio/docs/rxRadio.html
+++ b/src/rxRadio/docs/rxRadio.html
@@ -154,7 +154,7 @@
             <input rx-radio
                    id="radInvalidEnabledTwo"
                    value="2"
-                   ng-model="validEnabled"
+                   ng-model="invalidEnabled"
                    always-invalid />
             <label for="radInvalidEnabledTwo">Unselected</label>
           </p>
@@ -206,4 +206,41 @@
       </tr>
     </tbody>
   </table>
+
+  <h3 class="title">Plain HTML Radios (for comparison)</h3>
+  <p>
+    <input type="radio"
+           id="plainHtmlNormal"
+           ng-model="plainHtmlRadio"
+           value="plain"
+           ng-required="true" />
+    <label for="plainHtmlNormal">A plain radio</label>
+  </p>
+  <p>
+    <input type="radio"
+           id="plainHtmlDisabled"
+           value="disabled"
+           ng-model="plainHtmlRadio"
+           disabled />
+    <label for="plainHtmlDisabled">A plain radio (disabled)</label>
+  </p>
+  <p>
+    <input type="radio"
+           id="plainHtmlChecked"
+           value="isChecked"
+           ng-model="plainHtmlRadio" />
+    <label for="plainHtmlChecked">A plain radio (checked)</label>
+  </p>
+  <p>
+    <input type="radio"
+           id="plainRadRemoveRadio"
+           value="shows"
+           ng-model="plainHtmlRadio"/>
+    <label for="plainRadRemoveRadio">Add Following Radio:</label>
+
+    <input type="radio"
+           id="plainRadRemoveable"
+           value="hidden"
+           ng-if="plainHtmlRadio === 'shows'" />
+  </p>
 </div>

--- a/src/rxRadio/docs/rxRadio.js
+++ b/src/rxRadio/docs/rxRadio.js
@@ -10,4 +10,5 @@ angular.module('demoApp')
     $scope.invalidNgDisabled = 1;
 
     $scope.radCreateDestroy = 'destroyed';
+    $scope.plainHtmlRadio = 'isChecked';
 });

--- a/src/rxRadio/docs/rxRadio.midway.js
+++ b/src/rxRadio/docs/rxRadio.midway.js
@@ -204,17 +204,17 @@ describe('rxRadio', function () {
                 otherRadio = encore.rxRadio.initialize($('#plainHtmlNormal'));
             });
 
-            it('should show the checkbox by default', function () {
+            it('should show the radio button by default', function () {
                 expect(willBeHidden.isPresent()).to.eventually.be.false;
             });
 
-            it('should remove the checkbox from the DOM', function () {
+            it('should remove the radio button from the DOM', function () {
                 willHide.select();
                 expect(willBeHidden.isDisplayed()).to.eventually.be.true;
                 expect(willBeHidden.isPresent()).to.eventually.be.true;
             });
 
-            it('should put the checkbox back', function () {
+            it('should put the radio button back', function () {
                 otherRadio.select();
                 expect(willBeHidden.isPresent()).to.eventually.be.false;
             });

--- a/src/rxRadio/docs/rxRadio.midway.js
+++ b/src/rxRadio/docs/rxRadio.midway.js
@@ -91,6 +91,27 @@ describe('rxRadio', function () {
         valid: false
     }));
 
+    describe('plain HTML radio buttons', function () {
+        describe('Valid Enabled Unchecked', encore.exercise.rxRadio({
+            cssSelector: "#plainHtmlNormal",
+            disabled: false,
+            selected: false
+        }));
+
+        describe('Valid Disabled Unchecked', encore.exercise.rxRadio({
+            cssSelector: "#plainHtmlDisabled",
+            disabled: true,
+            selected: false
+        }));
+
+        describe('Valid Enabled Checked', encore.exercise.rxRadio({
+            cssSelector: "#plainHtmlChecked",
+            disabled: false,
+            selected: true
+        }));
+
+    });
+
     describe('Show/Hide Input', function () {
         var radHate, radLike, radLove;
 
@@ -171,6 +192,34 @@ describe('rxRadio', function () {
                 });
             });
         });
+
+        describe('plain HTML radio buttons', function () {
+            var willHide;
+            var willBeHidden;
+            var otherRadio;
+
+            before(function () {
+                willHide = encore.rxRadio.initialize($('#plainRadRemoveRadio'));
+                willBeHidden = encore.rxRadio.initialize($('#plainRadRemoveable'));
+                otherRadio = encore.rxRadio.initialize($('#plainHtmlNormal'));
+            });
+
+            it('should show the checkbox by default', function () {
+                expect(willBeHidden.isPresent()).to.eventually.be.false;
+            });
+
+            it('should remove the checkbox from the DOM', function () {
+                willHide.select();
+                expect(willBeHidden.isDisplayed()).to.eventually.be.true;
+                expect(willBeHidden.isPresent()).to.eventually.be.true;
+            });
+
+            it('should put the checkbox back', function () {
+                otherRadio.select();
+                expect(willBeHidden.isPresent()).to.eventually.be.false;
+            });
+
+        });
     });//Show/Hide Input
 
     describe('Destroy Input', function () {
@@ -225,4 +274,5 @@ describe('rxRadio', function () {
             });
         });
     });//Destroy Input
+
 });

--- a/src/rxRadio/rxRadio.exercise.js
+++ b/src/rxRadio/rxRadio.exercise.js
@@ -34,12 +34,12 @@ exports.rxRadio = function (options) {
             }
         });
 
-        it('should be a radio type', function () {
-            expect(component.isRadio()).to.eventually.be.true;
-        });
-
         it('should be present', function () {
             expect(component.isPresent()).to.eventually.be.true;
+        });
+
+        it('should be a radio button', function () {
+            expect(component.isRadio()).to.eventually.be.true;
         });
 
         it('should ' + (options.visible ? 'be' : 'not be') + ' visible', function () {

--- a/src/rxRadio/rxRadio.page.js
+++ b/src/rxRadio/rxRadio.page.js
@@ -129,18 +129,6 @@ exports.rxRadio = {
     },
 
     /**
-     * Don't use this if you're expecting a regular html radio button on the page. This only checks for Encore
-     * specific rxForm-style radio buttons.
-     * @returns {rxRadio} Page object representing the _first_ `<input rx-radio />` element found on the page
-     */
-    main: (function () {
-        rxRadio.rootElement = {
-            get: function () { return $('input[rx-radio]'); }
-        };
-        return Page.create(rxRadio);
-    })(),
-
-    /**
      * @function
      * @description Generates a getter and a setter for an rxRadio element on your page.
      * @param {WebElement} elem - The WebElement for the rxRadio.

--- a/src/rxRadio/rxRadio.page.js
+++ b/src/rxRadio/rxRadio.page.js
@@ -5,60 +5,6 @@ var Page = require('astrolabe').Page;
 /**
  * @namespace
  */
-var htmlRadio = {
-    /**
-     * @function
-     * @returns {Boolean} Whether the radio is currently displayed
-     */
-    isDisplayed: {
-        value: function () {
-            return this.rootElement.isDisplayed();
-        }
-    },
-
-    /**
-     * @function
-     * @returns {Boolean} Whether the radio element is valid
-     */
-    isValid: {
-        value: function () {
-            return this.rootElement.getAttribute('class').then(function (classes) {
-                return _.contains(classes.split(' '), 'ng-valid');
-            });
-        }
-    },
-
-    /**
-     * @function
-     * @description Abstraction over `htmlRadio.rootElement.isSelected()` to keep things shorter.
-     * @returns {boolean} Whether or not the radio button is currently selected.
-     */
-    isSelected: {
-        value: function () {
-            return this.rootElement.isSelected();
-        }
-    },
-
-    /**
-     * @function
-     * @description Make sure radio is selected
-     */
-    select: {
-        value: function () {
-            var radio = this.rootElement;
-            return this.isSelected().then(function (selected) {
-                if (!selected) {
-                    radio.click();
-                }
-            });
-        }
-    }
-};
-
-/**
- * @namespace
- * @extends htmlRadio
- */
 var rxRadio = {
     eleWrapper: {
         get: function () {
@@ -73,76 +19,97 @@ var rxRadio = {
     },
 
     /**
-     * @function
-     * @returns {Boolean} whether root element is if type="radio"
+       Useful for situations where input types might change in the future, ensuring that the expected one is being used.
+       @returns {Boolean} Whether or not the element in question is a radio button.
      */
     isRadio: {
         value: function () {
-            return this.rootElement.getAttribute('type').then(function (ilk) {
-                return ilk === 'radio';
+            return this.rootElement.getAttribute('type').then(function (type) {
+                return type === 'radio';
             });
         }
     },
 
     /**
      * @function
-     * @returns {Boolean} Whether the styled element is currently displayed.
+     * @returns {Boolean} Whether the radio button is valid
+     */
+    isValid: {
+        value: function () {
+            return this.rootElement.getAttribute('class').then(function (classes) {
+                return _.contains(classes.split(' '), 'ng-valid');
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {Boolean} Whether the radio element is currently displayed.
      */
     isDisplayed: {
         value: function () {
-            return this.eleFakeRadio.isDisplayed();
-        }
-    },
-
-    /**
-     * @function
-     * @return {Boolean} whether or not the wrapper is disabled
-     */
-    isDisabled: {
-        value: function () {
-            return this.eleWrapper.getAttribute('class').then(function (classes) {
-                return _.contains(classes.split(' '), 'rx-disabled');
+            var page = this;
+            return this.eleFakeRadio.isPresent().then(function (isFakeRadio) {
+                return isFakeRadio ? page.eleFakeRadio.isDisplayed() : page.rootElement.isDisplayed();
             });
         }
     },
 
     /**
      * @function
-     * @returns {Boolean} Whether or not the styled element exists on the page
+     * @returns {Boolean} Whether or not the radio button is present.
      */
     isPresent: {
         value: function () {
-            return this.eleFakeRadio.isPresent();
+            return this.rootElement.isPresent();
         }
-    }
-};
-rxRadio = _.assign(htmlRadio, rxRadio);
-
-/**
- * @exports encore.htmlRadio
- */
-exports.htmlRadio = {
-    /**
-     * @function
-     * @param {WebElement} radioElement - WebElement to be transformed into an htmlRadio page object.
-     * @returns {htmlRadio} Page object representing the radio element
-     */
-    initialize: function (radioElement) {
-        htmlRadio.rootElement = {
-            get: function () { return radioElement; }
-        };
-        return Page.create(htmlRadio);
     },
 
     /**
-     * @returns {htmlRadio} Page object representing the _first_ `<input type="radio" />` element found on the page
+     * @function
+     * @return {Boolean} whether or not the radio element is disabled
      */
-    main: (function () {
-        htmlRadio.rootElement = {
-            get: function () { return $('input[type="radio"]'); }
-        };
-        return Page.create(htmlRadio);
-    })()
+    isDisabled: {
+        value: function () {
+            var page = this;
+            return this.eleFakeRadio.isPresent().then(function (isFakeRadio) {
+                if (isFakeRadio) {
+                    return page.eleWrapper.getAttribute('class').then(function (classes) {
+                        return _.contains(classes.split(' '), 'rx-disabled');
+                    });
+                }
+                return page.rootElement.getAttribute('disabled').then(function (disabled) {
+                    return disabled === null ? false : true;
+                });
+            });
+        }
+    },
+
+    /**
+     * @function
+     * @returns {boolean} Whether or not the radio button is currently selected.
+     */
+    isSelected: {
+        value: function () {
+            return this.rootElement.isSelected();
+        }
+    },
+
+    /**
+     * @function
+     * @returns {undefined}
+     * @description Makes sure that the radio button is selected.
+     */
+    select: {
+        value: function () {
+            var radio = this.rootElement;
+            return this.isSelected().then(function (selected) {
+                if (!selected) {
+                    radio.click();
+                }
+            });
+        }
+    }
 };
 
 /**
@@ -162,6 +129,8 @@ exports.rxRadio = {
     },
 
     /**
+     * Don't use this if you're expecting a regular html radio button on the page. This only checks for Encore
+     * specific rxForm-style radio buttons.
      * @returns {rxRadio} Page object representing the _first_ `<input rx-radio />` element found on the page
      */
     main: (function () {

--- a/src/rxSelect/docs/rxSelect.html
+++ b/src/rxSelect/docs/rxSelect.html
@@ -64,10 +64,6 @@
     <br />
   </div>
 
-  <!-- END OF DEMO -->
-  <!-- END OF DEMO -->
-  <!-- END OF DEMO -->
-
   <h3 class="title">Select States</h3>
   <table>
     <thead>
@@ -154,4 +150,47 @@
       </tr>
     </tbody>
   </table>
+
+    <h3 class="title">Plain HTML Select Boxes (for comparison)</h3>
+  <p>
+    <select id="plainHtmlNormal" ng-required="true">
+      <option value="">Plain HTML Select Option</option>
+      <option value="first">First Option</option>
+      <option value="second">Second Option</option>
+      <option value="third">Third Option</option>
+      <option value="fourth">Fourth Option</option>
+    </select>
+  </p>
+  <p>
+    <select id="plainHtmlDisabled" disabled>
+      <option value="">Disabled HTML Select Option</option>
+      <option value="first">First Option</option>
+      <option value="second">Second Option</option>
+      <option value="third">Third Option</option>
+      <option value="fourth">Fourth Option</option>
+    </select>
+  </p>
+  <p>
+    <select id="plainHtmlSecondSelected"
+            ng-model="htmlSelectAlternativeValue">
+      <option value="">Starts on Second Option</option>
+      <option value="first">First Option</option>
+      <option value="second">Non Default Starting Option</option>
+      <option value="third">Third Option</option>
+      <option value="fourth">Fourth Option</option>
+    </select>
+  </p>
+  <p>
+    <select id="plainSelShowSelect"
+            ng-model="plainHtmlSelect">
+      <option value="hide">Hide Next Select Box</option>
+      <option value="show">Show Next Select Box</option>
+    </select>
+
+    <select id="plainSelRemoveable"
+            value="hidden"
+            ng-if="plainHtmlSelect !== 'hide'">
+      <option value="">Is Present</option>
+    </select>
+  </p>
 </div>

--- a/src/rxSelect/docs/rxSelect.js
+++ b/src/rxSelect/docs/rxSelect.js
@@ -10,4 +10,6 @@ angular.module('demoApp')
     $scope.invalidEnabled = 4;
     $scope.invalidNgDisabled = 'na';
     $scope.invalidDisabled = 'na';
+
+    $scope.htmlSelectAlternativeValue = 'second';
 });

--- a/src/rxSelect/docs/rxSelect.midway.js
+++ b/src/rxSelect/docs/rxSelect.midway.js
@@ -1,7 +1,3 @@
-var rxSelect = encore.rxSelect;
-var htmlCheckbox = encore.htmlCheckbox;
-var htmlRadio = encore.htmlRadio;
-
 describe('rxSelect', function () {
     var subject;
 
@@ -13,47 +9,77 @@ describe('rxSelect', function () {
         cssSelector: '#selValidEnabled',
         disabled: false,
         visible: true,
-        valid: true
+        valid: true,
+        selectedText: 'Third'
     }));
 
     describe('(State) Valid NG-Disabled', encore.exercise.rxSelect({
         cssSelector: '#selValidNgDisabled',
         disabled: true,
         visible: true,
-        valid: true
+        valid: true,
+        selectedText: "Disabled by 'ng-disabled' attribute"
     }));
 
     describe('(State) Valid Disabled', encore.exercise.rxSelect({
         cssSelector: '#selValidDisabled',
         disabled: true,
         visible: true,
-        valid: true
+        valid: true,
+        selectedText: "Disabled by 'disabled' attribute"
     }));
 
     describe('(State) Invalid Enabled', encore.exercise.rxSelect({
         cssSelector: '#selInvalidEnabled',
         disabled: false,
         visible: true,
-        valid: false
+        valid: false,
+        selectedText: "Fourth"
     }));
 
     describe('(State) Invalid NG-Disabled', encore.exercise.rxSelect({
         cssSelector: '#selInvalidNgDisabled',
         disabled: true,
         visible: true,
-        valid: false
+        valid: false,
+        selectedText: "Disabled by 'ng-disabled' attribute"
     }));
 
     describe('(State) Invalid Disabled', encore.exercise.rxSelect({
         cssSelector: '#selInvalidDisabled',
         disabled: true,
         visible: true,
-        valid: false
+        valid: false,
+        selectedText: "Disabled by 'disabled' attribute"
     }));
+
+    describe('plain HTML select elements', function () {
+        describe('Enabled Default Starting Value', encore.exercise.rxSelect({
+            cssSelector: "#plainHtmlNormal",
+            disabled: false,
+            valid: false,
+            selectedText: "Plain HTML Select Option"
+        }));
+
+        describe('Disabled', encore.exercise.rxSelect({
+            cssSelector: "#plainHtmlDisabled",
+            disabled: true,
+            valid: false,
+            selectedText: "Disabled HTML Select Option"
+        }));
+
+        describe('Valid Enabled Non-Default Starting Value', encore.exercise.rxSelect({
+            cssSelector: "#plainHtmlSecondSelected",
+            disabled: false,
+            valid: true,
+            selectedText: "Non Default Starting Option"
+        }));
+
+    });
 
     describe('How do you like your bacon?', function () {
         before(function () {
-            subject = rxSelect.initialize($('#selBaconPrep'));
+            subject = encore.rxSelect.initialize($('#selBaconPrep'));
         });
 
         it('should be invalid', function () {
@@ -131,14 +157,41 @@ describe('rxSelect', function () {
                 expect(subject.isValid()).to.eventually.be.false;
             });
         });
+
+        describe('plain HTML select elements', function () {
+            var willHide;
+            var willBeHidden;
+
+            before(function () {
+                willHide = encore.rxSelect.initialize($('#plainSelShowSelect'));
+                willBeHidden = encore.rxSelect.initialize($('#plainSelRemoveable'));
+            });
+
+            it('should show the select element by default', function () {
+                expect(willBeHidden.isPresent()).to.eventually.be.true;
+                expect(willBeHidden.isDisplayed()).to.eventually.be.true;
+            });
+
+            it('should remove the select element to the DOM', function () {
+                willHide.select('Hide Next Select Box');
+                expect(willBeHidden.isPresent()).to.eventually.be.false;
+            });
+
+            it('should add the select element back', function () {
+                willHide.select('Show Next Select Box');
+                expect(willBeHidden.isPresent()).to.eventually.be.true;
+                expect(willBeHidden.isDisplayed()).to.eventually.be.true;
+            });
+
+        });
     });
 
     describe('Show/Hide Select', function () {
         var checkbox;
 
         before(function () {
-            checkbox = htmlCheckbox.initialize($('#chkShow'));
-            subject = rxSelect.initialize($('#selTargetShow'));
+            checkbox = encore.rxCheckbox.initialize($('#chkShow'));
+            subject = encore.rxSelect.initialize($('#selTargetShow'));
         });
 
         describe('when checkbox checked', function () {
@@ -166,9 +219,9 @@ describe('rxSelect', function () {
         var radDestroyed, radCreated;
 
         before(function () {
-            radDestroyed = htmlRadio.initialize($('#radDestroyed'));
-            radCreated = htmlRadio.initialize($('#radCreated'));
-            subject = rxSelect.initialize($('#selTargetCreated'));
+            radDestroyed = encore.rxRadio.initialize($('#radDestroyed'));
+            radCreated = encore.rxRadio.initialize($('#radCreated'));
+            subject = encore.rxSelect.initialize($('#selTargetCreated'));
         });
 
         describe('when created', function () {

--- a/src/rxSelect/rxSelect.exercise.js
+++ b/src/rxSelect/rxSelect.exercise.js
@@ -9,6 +9,7 @@ var rxSelect = require('./rxSelect.page').rxSelect;
  * @param {Boolean} [options.disabled=false] - Determines if the select is disabled
  * @param {Boolean} [options.visible=true] - Determines if the select is visible
  * @param {Boolean} [options.valid=true] - Determines if the select is valid
+ * @param {String} selectedText - The expected selected text of the dropdown.
  */
 exports.rxSelect = function (options) {
     if (options === undefined) {
@@ -47,5 +48,11 @@ exports.rxSelect = function (options) {
         it('should ' + (options.valid ? 'be' : 'not be') + ' valid', function () {
             expect(component.isValid()).to.eventually.eq(options.valid);
         });
+
+        if (options.selectedText) {
+            it('should have the correct selected option already chosen', function () {
+                expect(component.selectedOption.text).to.eventually.equal(options.selectedText);
+            });
+        }
     };
 };

--- a/src/rxSelect/rxSelect.page.js
+++ b/src/rxSelect/rxSelect.page.js
@@ -272,18 +272,6 @@ exports.rxSelect = {
     },
 
     /**
-     * Don't use this if you're expecting a regular html select element on the page. This only checks for Encore
-     * specific rxForm-style select elements.
-     * @returns {rxSelect} Page object representing the _first_ `<select rx-select>` element found on the page
-     */
-    main: (function () {
-        rxSelect.rootElement = {
-            get: function () { return $('select[rx-select]'); }
-        };
-        return Page.create(rxSelect);
-    })(),
-
-    /**
      * @function
      * @description Generates a getter and a setter for an rxSelect element on your page.
      * @param {WebElement} elem - The WebElement for the rxSelect.


### PR DESCRIPTION
This addresses a couple of issues with the rxForm refactor, from the perspective of the page objects.

1. There are some missing tests for plain old HTML elements. These have been added in the demo "for comparison", and also to test against.

2. Some of the exercises now assert against more specific things (such as text in select elements).

3. ~~The exercises no longer ask for what type of element the component is (these functions have been removed from the page objects entirely as well). If you're using a checkbox/radio/select element, you can interact with it in specific ways to determine it's type. There's no need to ask explicitly.~~ This was added back in. No change here.

4. The `html*` and `rx*` page objects have been unified under a single object that responds to both plain html-type elements and rx-type elements. It's easier to use on in every instance of a form element, instead of forcing a tester to understand the subtle differences between a native form element, and one that has been extended by the framework.

before:

```
var plainHtml = encore.htmlSelect.initialize($('#plainHtml'));
var encoreSelect = encore.rxSelect.initialize($('#rxSelect'));
```

after:

```
var plainHtml = encore.rxSelect.initialize($('#plainHtml'));
var encoreSelect = encore.rxSelect.initialize($('#rxSelect'));
```
