### PR TITLE
docs(VERSIONING): clarification on npm adduser

### DIFF
--- a/guides/versioning.md
+++ b/guides/versioning.md
@@ -97,7 +97,7 @@ module.export = {
 To publish `rx-page-objects` to the public npm registry.
 
 0. `npm get registry` should return `https://registry.npmjs.org/`
-1. `npm adduser`
+1. `npm adduser --registry=https://registry.npmjs.org/`
   * Username: `encore-ui`
   * Password: Get from PasswordSafe > "Encore UI" > "npm" > "Node Package Manager Deploys"
 2. From `~/.npmrc` move the line beginning with `//registry.npmjs.org` to a `.npmrc` file in the root of the repo.


### PR DESCRIPTION
`npm adduser` (by default) will add the given user credentials to the currently set registry. Given that a user may have the internal npm registry set as their default, it would add the credentials to the incorrect registry.  This will make sure that the public npmjs registry is the target for the additional credentials.