### PR TITLE
chore(headings): Deprecate .title classes/subclasses

### DIFF
--- a/demo/assets/demo.less
+++ b/demo/assets/demo.less
@@ -1,36 +1,63 @@
-.component-description h1 {
-    font-size: 1.6em;
-    border-bottom: 1px solid #333;
-    margin-top: 1.2em;
-}
-
-.component-description h2 {
-    font-size: 1.4em;
-    border-bottom: 1px solid #ccc;
-    margin-top: .5em;
-}
-
-.component-description h3 {
-    font-size: 1.2em;
-    font-weight: bold;
-}
-
-.component-description h4 {
-    font-size: 1.1em;
-    font-weight: bold;
-    color: #777;
-}
-
+/* README */
 .component-description {
     border: 1px solid #aaa;
     background: #fff;
     padding: 10px;
     margin-bottom: 2em;
-}
 
-.component-description .readme-title {
-    margin-top: 0;
-}
+    // TODO: can we do something about this?
+    h1, h2, h3, h4, h5, h6 {
+        margin-bottom: 0;
+    }
+
+    h1 {
+        font-size: 1.6em;
+        border-bottom: 1px solid #333;
+        margin-top: 1.2em;
+    }
+
+    h2 {
+        font-size: 1.4em;
+        border-bottom: 1px solid #ccc;
+        margin-top: .5em;
+    }
+
+    h3 {
+        font-size: 1.2em;
+        font-weight: bold;
+    }
+
+    h4 {
+        font-size: 1.1em;
+        font-weight: bold;
+        color: #777;
+    }
+
+    ul,
+    ol {
+        li {
+            display: list-item;
+            margin: 5px 0 0 30px;
+        }
+    }
+
+    ul {
+        li,
+        .item {
+            list-style: disc;
+        }
+    }
+
+    ol {
+        li {
+            list-style: decimal;
+        }
+    }
+
+    .readme-title {
+        margin-top: 0;
+    }
+}//.component-description
 
 /* Remove background color from syntax highlighted code (prism.css) */
 pre[class*="language-"] {
@@ -38,7 +65,6 @@ pre[class*="language-"] {
 }
 
 // Colors
-
 ul.colors {
     overflow: hidden;
 
@@ -68,6 +94,7 @@ ul.colors {
         font-weight: 900;
     }
 
+    // These should all be set via LESS vars
     .action-accept {
         background-color: #24b56a;
     }
@@ -111,39 +138,20 @@ ul.colors {
     }
 }
 
-.component-description {
-    ul,ol {
-        li {
-            display: list-item;
-            margin: 5px 0 0 30px;
-        }
-    }
-
-    ul {
-        li,
-        .item {
-            list-style: disc;
-        }
-    }
-
-    ol {
-        li {
-            list-style: decimal;
-        }
-    }
-}
-
 .overview-column {
     width: 300px;
     margin-right: 100px;
+
     h4 {
         font-weight: 600;
     }
+
     a + p {
         margin-top: 5px;
     }
 }
 
+// TODO: Deprecate (attribute documentation belongs in API documentation)
 table.component-attributes {
     tbody {
         tr {
@@ -152,14 +160,18 @@ table.component-attributes {
             }
         }
     }
+
     tr {
-        th, td {
+        th,
+        td {
             &:last-child {
               text-align: left;
             }
         }
     }
-    th, td {
+
+    th,
+    td {
         vertical-align: top;
         text-align: center;
     }
@@ -219,19 +231,37 @@ p {
 }
 
 .markdown {
-    ul, ol {
+    ul,
+    ol {
         display: inline;
         margin: 0;
+
         p {
             display: inline-block;
         }
     }
+
     ol li {
         list-style: decimal inside;
     }
+
     ul li {
         list-style: disc inside;
         margin: 10px 10px 10px 23px;
         text-indent: -13px;
+    }
+}
+
+.component-demo {
+    h1, h2, h3, h4, h5, h6 {
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+}
+
+rx-page.styleguide {
+    h1, h2, h3, h4, h5, h6 {
+        margin-top: 2.0em;
     }
 }

--- a/demo/assets/generated_demo.css
+++ b/demo/assets/generated_demo.css
@@ -1,3 +1,18 @@
+/* README */
+.component-description {
+  border: 1px solid #aaa;
+  background: #fff;
+  padding: 10px;
+  margin-bottom: 2em;
+}
+.component-description h1,
+.component-description h2,
+.component-description h3,
+.component-description h4,
+.component-description h5,
+.component-description h6 {
+  margin-bottom: 0;
+}
 .component-description h1 {
   font-size: 1.6em;
   border-bottom: 1px solid #333;
@@ -17,11 +32,17 @@
   font-weight: bold;
   color: #777;
 }
-.component-description {
-  border: 1px solid #aaa;
-  background: #fff;
-  padding: 10px;
-  margin-bottom: 2em;
+.component-description ul li,
+.component-description ol li {
+  display: list-item;
+  margin: 5px 0 0 30px;
+}
+.component-description ul li,
+.component-description ul .item {
+  list-style: disc;
+}
+.component-description ol li {
+  list-style: decimal;
 }
 .component-description .readme-title {
   margin-top: 0;
@@ -85,18 +106,6 @@ ul.colors .action-delete {
 .styleguide-character-count .counted-input-wrapper .input-highlighting,
 .styleguide-character-count .counted-input-wrapper textarea {
   width: 328px;
-}
-.component-description ul li,
-.component-description ol li {
-  display: list-item;
-  margin: 5px 0 0 30px;
-}
-.component-description ul li,
-.component-description ul .item {
-  list-style: disc;
-}
-.component-description ol li {
-  list-style: decimal;
 }
 .overview-column {
   width: 300px;
@@ -183,4 +192,20 @@ p {
   list-style: disc inside;
   margin: 10px 10px 10px 23px;
   text-indent: -13px;
+}
+.component-demo h1:first-child,
+.component-demo h2:first-child,
+.component-demo h3:first-child,
+.component-demo h4:first-child,
+.component-demo h5:first-child,
+.component-demo h6:first-child {
+  margin-top: 0;
+}
+rx-page.styleguide h1,
+rx-page.styleguide h2,
+rx-page.styleguide h3,
+rx-page.styleguide h4,
+rx-page.styleguide h5,
+rx-page.styleguide h6 {
+  margin-top: 2.0em;
 }

--- a/demo/styleguide/basics.html
+++ b/demo/styleguide/basics.html
@@ -1,7 +1,5 @@
 <rx-page title="'Introduction'">
-
-    <h2 class="title lg clear">Basics</h2>
-
+    <h2>Basics</h2>
     <ul class="list">
         <li>This sub-site provides development teams at Rackspace with a set of design patterns, to help ensure a consistent and unified look-and-feel for all products under the Encore umbrella.</li>
         <li>This section of the Demo site focuses mainly on markup, CSS and design patterns. If you're curious about Encore-specific angular.js directives, find the "All Components" section in the left hand navigation.</li>
@@ -16,8 +14,7 @@
         <li>Kevin Lamping, a developer on the EncoreUI team, wrote a document to address <a href="https://github.com/rackerlabs/encore-ui/blob/master/guides/css-styleguide.md">coding standards while writing CSS</a>.</li>
     </ul>
 
-    <h3 class="title clear" id="color">Color</h3>
-
+    <h3 id="color">Color</h3>
     <ul class="list">
         <li><span class="msg-info">ENCORE-SPECIFIC:</span> Color is an integral part of communicating with users of Encore. Certain colors in Encore are reserved for certain types of actions or events.
         <ul class="colors">
@@ -99,57 +96,91 @@
         </ul>
     </ul>
 
-    <h3 class="title clear" id="typography">Typography</h3>
-
+    <h3 id="typography">Typography</h3>
     <ul class="list">
         <li><span class="msg-info">ENCORE-SPECIFIC:</span> We use Google Fonts, in particular the Roboto font. While Google Fonts are not included in the EncoreUI package, they are included if you use the encore-ui-template repository as a base.
         <li>For developers not using encore-ui-template, <a href="https://github.com/rackerlabs/encore-ui/tree/master/src/rxApp#fonts">read the README.md file for rxApp</a> on fonts for more information.</li>
     </ul>
 
-    <h3 class="title clear" id="flexbox-grid">Flexbox Grid</h3>
-
+    <h3 id="flexbox-grid">Flexbox Grid</h3>
     <ul class="list">
         <li>Encore UI includes a grid system forked from <a target="_blank" href="https://material.angularjs.org/#/layout/container">Angular Material's layout module</a> with minor usability enhancements to provide an assortment of attribute based layout options based on the flexbox layout model. Included are intuitive attribute based styles that ease the creation of responsive row and/or column based page layouts. Visit the <a href="#/components/layout">layout</a> section for info on how to use this attributes.</li>
     </ul>
 
-    <h3 class="title clear" id="heading-title-styles">Heading/Title Styles</h3>
+    <h3 id="heading-title-styles">Heading/Title Styles</h3>
     <div class="component-description clear">
         <ul class="list">
-            <li>Headings are sized using the <code>title</code> class and an additional <code>xl</code>, <code>lg</code>, <code>sm</code> and <code>xs</code> classes. Not adding the additional class defaults the size to medium.</li>
-            <li>The size of the heading is not impacted by the heading level used (e.g. &lt;h1&gt;, &lt;h2&gt;). This is done to ensure that the heading levels are sequential.</li>
-            <li><span class="msg-info">ENCORE-SPECIFIC:</span> For design consistency, we usually use the default medium size (&lt;h2 class="title"&gt;) for most subheaders. Other headers classes can be used for context.</li>
+            <li>Headings are sized according to their heading level (H1 larger than H2 larger than H3, etc.).</li>
+            <li><span class="msg-info">ENCORE-SPECIFIC:</span> For design consistency, we usually use an H3 heading for most subheaders. Other headings can be used for context.</li>
+            <li>
+              <strong class="msg-info">WARNING</strong>:
+              The <code>title</code>, <code>xl</code>, <code>lg</code>, <code>sm</code>, and <code>xs</code> heading classes are deprecated and will be removed in a future release of the framework.
+            </li>
         </ul>
+
+        <h4>Markup Conversion Table</h4>
+        <table class="table-striped">
+            <thead>
+                <tr>
+                    <th>Legacy Selector</th>
+                    <th>Current Markup</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><code>.title.xl</code></td>
+                    <td><code>&lt;h1&gt;</code></td>
+                </tr>
+                <tr>
+                    <td><code>.title.lg</code></td>
+                    <td><code>&lt;h2&gt;</code></td>
+                </tr>
+                <tr>
+                    <td><code>.title</code></td>
+                    <td><code>&lt;h3&gt;</code></td>
+                </tr>
+                <tr>
+                    <td><code>.title.sm</code></td>
+                    <td><code>&lt;h4&gt;</code></td>
+                </tr>
+                <tr>
+                    <td><code>.title.xs</code></td>
+                    <td><code>&lt;h5&gt;</code></td>
+                </tr>
+                <tr>
+                    <td><em>N/A</em></td>
+                    <td><code>&lt;h6&gt;</code></td>
+                </tr>
+            </tbody>
+        </table>
     </div>
 
     <rx-styleguide code-url="styleguide/basics/headings.html"></rx-styleguide>
 
-    <h3 class="title clear" id="date-formatting">Date formatting</h3>
+    <h3 id="date-formatting">Date formatting</h3>
     <ul class="list">
         <li>Dates in any context should be formatted this way: <code>Mar 2, 2015 @ 15:40 (UTC-0600)</code>–a three-letter capitalized month abbreviation (no period), followed by the day of the month (no leading zeroes), a comma, the four-digit year, an <code>@</code> symbol, military time, and UTC in parentheses.</li>
         <li>The only time this formatting standard would not be used is when relative dates would be helpful to the user, such as "4 hours ago" or "1 week ago".</li>
         <li>It is recommended that relative dates be reserved for more informal settings like user notes or comments. Relative dates should not extend too far into the past. For instance, "1 week ago" may be helpful to the user, but "8 months ago" or "3 years ago" is better represented by the non-relative format detailed above, as it reveals more specific information about dates that provide better context and information to the user when comparing dates and times.</li>
     </ul>
 
-    <h3 class="title clear" id="descriptions-metadata">Descriptions / Metadata</h3>
-
+    <h3 id="descriptions-metadata">Descriptions / Metadata</h3>
     <div class="component-description clear">
         <ul class="list">
             <li>The <a href="#/component/rxMetadata">rxMetadata</a> component provides the ability to display a list of terms with their associated descriptions. This is used throughout Encore to show metadata, especially on an individual object such as a server or a CBS volume.</li>
             <li><span class="msg-info">ENCORE-SPECIFIC:</span> This is an ideal solution if you have anywhere from 5-15 definitions (3 columns of 5 definitions). (See a Server Details page or Image Details page under Accounts -&gt; Cloud for an example.) Anything more - or anything displaying visual or image content - and you may want to consider a different design pattern. (See the "Non-Data based Tables" section in the Table page for more information.)</li>
         </ul>
     </div>
-
     <rx-styleguide code-url="styleguide/basics/metadata.html"></rx-styleguide>
 
-    <h3 class="title clear" id="no-data">When There is No Data to Display</h3>
-
+    <h3 id="no-data">When There is No Data to Display</h3>
     <ul class="list">
         <li>In table cells, metadata lists, or other displays of data, <code>N/A</code> should be used as an indicator to the user that there is no relevant data to display.</li>
         <li>Do not use <code>–</code>, <code>Empty</code>, <code>null</code>, or no indicator to communicate this, as there may be situations where those are valid inputs or data to display to a user depending on the context.</li>
         <li>Note that a separate style exists to communicate <a href="#/styleguide/basics#wells">when data isn't present due to permissions</a>, or when an entire table is empty (see "Null Patterns" section of <a href="#/styleguide/tables">Tables style guide</a>).
     </ul>
 
-    <h3 class="title" id="lists">Lists</h3>
+    <h3 id="lists">Lists</h3>
     <div class="component-description clear">
         <ul class="list">
             <li>Lists by default do not have styles. Add bullets/decimals to lists with the <code>list</code> class. It is also possible to build non-semantic lists using the additional <code>item</code> class.</li>
@@ -158,7 +189,7 @@
     </div>
     <rx-styleguide code-url="styleguide/basics/lists.html"></rx-styleguide>
 
-    <h3 class="title" id="collapsible">Collapsible Element</h3>
+    <h3 id="collapsible">Collapsible Element</h3>
     <div class="component-description clear">
         <ul class="list">
             <li>The collapsible element can be used to display and hide content.</li>
@@ -168,7 +199,7 @@
     </div>
     <rx-styleguide code-url="styleguide/basics/collapsible.html"></rx-styleguide>
 
-    <h3 class="title" id="wells">Wells</h3>
+    <h3 id="wells">Wells</h3>
     <div class="component-description clear">
         <ul class="list">
             <li>The <code>well</code> class creates a well effect - a box with significant padding and light gray background.</li>
@@ -181,31 +212,28 @@
     </div>
     <rx-styleguide code-url="styleguide/basics/wells.html"></rx-styleguide>
 
-    <h2 class="title lg" id="helper-classes">Helper Classes</h2>
+    <h2 id="helper-classes">Helper Classes</h2>
     <div class="component-description clear">
-
-<ul class="list">
-    <li>Subdued Text: The <code>.subdued</code> class is a basic color change to make text less prominent. The style persists if the class is nested in a link.</li>
-    <li>Full Width: <code>.full-width</code> class that marks content as full width (e.g. to give a button full width). Requires 'display' to be defined as inline-block or block.</li>
-    <li>Hidden content
         <ul class="list">
-            <li><code>.hidden</code> class - Will add to hide an element but not remove it from the spacing of the page.</li>
-            <li><code>.visually-hidden</code> class - Used to hide content visually but <a href="http://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html">can still be read by screen readers</a> (i.e. removed from the page spacing)</li>
+            <li>Subdued Text: The <code>.subdued</code> class is a basic color change to make text less prominent. The style persists if the class is nested in a link.</li>
+            <li>Full Width: <code>.full-width</code> class that marks content as full width (e.g. to give a button full width). Requires 'display' to be defined as inline-block or block.</li>
+            <li>Hidden content
+                <ul class="list">
+                    <li><code>.hidden</code> class - Will add to hide an element but not remove it from the spacing of the page.</li>
+                    <li><code>.visually-hidden</code> class - Used to hide content visually but <a href="http://developer.yahoo.com/blogs/ydn/clip-hidden-content-better-accessibility-53456.html">can still be read by screen readers</a> (i.e. removed from the page spacing)</li>
+                </ul>
+            </li>
+            <li>Clearing floats
+                <ul class="list">
+                    <li><code>.clear</code> class - Provides clearfix functionality See <a href="http://nicolasgallagher.com/micro-clearfix-hack/">http://nicolasgallagher.com/micro-clearfix-hack</a>.</li>
+                    <li><code>.clear-left</code>, <code>.clear-right</code> classes - Simple classes to help with clearing previous sibling floats</li>
+                </ul>
+            </li>
         </ul>
-    </li>
-    <li>Clearing floats
-        <ul class="list">
-            <li><code>.clear</code> class - Provides clearfix functionality See <a href="http://nicolasgallagher.com/micro-clearfix-hack/">http://nicolasgallagher.com/micro-clearfix-hack</a>.</li>
-            <li><code>.clear-left</code>, <code>.clear-right</code> classes - Simple classes to help with clearing previous sibling floats</li>
-        </ul>
-    </li>
-</ul>
-
     </div>
-
     <rx-styleguide code-url="styleguide/basics/helpers.html"></rx-styleguide>
 
-    <h3 class="title" id="progress-bars">Progress Bars</h3>
+    <h3 id="progress-bars">Progress Bars</h3>
     <div class="component-description clear">
         <ul class="list">
             <li>There are two states for progress bars: active and complete. Active progress bars have animated stripes, which are provided by the class <code>.active</code>. Full progress bars do not have this class, and are solid and static in appearance.</li>

--- a/demo/styleguide/basics/headings.html
+++ b/demo/styleguide/basics/headings.html
@@ -1,6 +1,7 @@
-<h1 class="title xl">Extra Large Class</h1>
-<h2 class="title lg">Large Class (Standard page header)</h2>
-<h3 class="title">Default Class (medium, standard sub-header)</h3>
-<h3 class="title subdued">Subdued Class</h3>
-<h4 class="title sm">Small Class</h4>
-<h5 class="title xs">Extra Small Class</h5>
+<h1>H1. Extra Large Heading</h1>
+<h2>H2. Large Heading (standard page header)</h2>
+<h3>H3. Heading (medium, standard sub-header)</h3>
+<h3 class="subdued">H3. Subdued Heading</h3>
+<h4>H4. Small Heading</h4>
+<h5>H5. Extra Small Heading</h5>
+<h6>H6. Tiny Heading</h6>

--- a/src/rxApp/common.less
+++ b/src/rxApp/common.less
@@ -141,38 +141,37 @@ table {
     }
 }
 
-// Heading/Title Styles
-.title {
-    font-size: 18px;
+/* ===== HEADINGS ===== */
+h1, h2, h3, h4, h5, h6 {
     margin: 1em 0;
 
-    & + & {
-        // remove the top margin if two titles are placed right next to each other
-        margin-top: 0;
+    &.subdued {
+        color: @subduedTitle;
     }
+}
+h1 { font-size: 28px; } // same as .title.xl
+h2 { font-size: 22px; } // same as .title.lg
+h3 { font-size: 18px; } // same as .title
+h4 { font-size: 16px; } // same as .title.sm
+h5 { font-size: 13px; } // same as .title.xs
+h6 { font-size: 10px; } // no legacy equivalent
+
+// Heading/Title Styles
+.title {
+    margin: 1em 0;
 
     // Sizing
-    &.xl {
-        font-size: 28px;
-    }
-
-    &.lg {
-        font-size: 22px;
-    }
-
-    &.sm {
-        font-size: 16px;
-    }
-
-    &.xs {
-        font-size: 13px;
-    }
+    &.xl { font-size: 28px; } // h1
+    &.lg { font-size: 22px; } // h2
+    &    { font-size: 18px; } // h3
+    &.sm { font-size: 16px; } // h4
+    &.xs { font-size: 13px; } // h5
 
     // Colors
     &.subdued {
         color: @subduedTitle;
     }
-}
+}//.title
 
 // Statuses
 .link-action,

--- a/src/rxApp/rxApp.less
+++ b/src/rxApp/rxApp.less
@@ -24,6 +24,12 @@
         line-height: @appLineHeight;
         padding-bottom: 10em;
         position: relative;
+
+        .site-title,
+        .nav-section-title {
+            margin: 0;
+            font-size: inherit;
+        }
     }
 
     .site-branding {


### PR DESCRIPTION
* added base H1-H6 styles above legacy .title styles
  * allows for backward compatibility as developers update their code
* added namespace for upcoming work on new styleguide pages

JIRA: https://jira.rax.io/browse/FRMW-37

- [x] Dev LGTM
- [ ] Dev LGTM
- [x] Design LGTM