### PR TITLE
Fix gh pages links

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,8 +1,19 @@
-function genericRouteController (breadcrumbTitle) {
-    return function (rxBreadcrumbsSvc) {
-        rxBreadcrumbsSvc.set([{
-            name: breadcrumbTitle || ''
-        }]);
+function genericRouteController (breadcrumbs) {
+    return function (rxBreadcrumbsSvc, Environment, $interpolate) {
+        if (breadcrumbs === undefined) {
+            breadcrumbs = [{
+                name: '',
+                path: ''
+            }]
+        }
+
+        breadcrumbs.forEach(function (breadcrumb) {
+            if (breadcrumb.path) {
+                breadcrumb.path = $interpolate(Environment.get().url)({ path: breadcrumb.path });
+            }
+        });
+
+        rxBreadcrumbsSvc.set(breadcrumbs);
     }
 }
 
@@ -17,9 +28,6 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
 
     $scope.component = component;
 })
-.controller('styleguideCtrl', function (rxBreadcrumbsSvc) {
-    rxBreadcrumbsSvc.set();
-})
 .config(function ($routeProvider, rxStatusTagsProvider) {
     $routeProvider
         .when('/', {
@@ -31,7 +39,7 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
         })
         .when('/overview', {
             templateUrl: 'overview.html',
-            controller: genericRouteController('Overview')
+            controller: genericRouteController()
         })
         .when('/components', {
             templateUrl: 'components.html',
@@ -39,39 +47,71 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
         })
         .when('/styleguide/basics', {
             templateUrl: 'styleguide/basics.html',
-            controller: 'styleguideCtrl'
+            controller: genericRouteController([{
+                name: 'Style Guide'
+            }])
         })
         .when('/styleguide/layouts', {
             templateUrl: 'styleguide/layouts.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Layouts'
+            }])
         })
         .when('/styleguide/layouts/1', {
             templateUrl: 'styleguide/layout-1.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Layouts', path: '#/styleguide/layouts'
+            }, {
+                name: 'Detail Page'
+            }])
         })
         .when('/styleguide/layouts/2', {
             templateUrl: 'styleguide/layout-2.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Layouts', path: '#/styleguide/layouts'
+            }, {
+                name: 'Data Table'
+            }])
         })
         .when('/styleguide/layouts/3', {
             templateUrl: 'styleguide/layout-3.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Layouts', path: '#/styleguide/layouts'
+            }, {
+                name: 'Create Form'
+            }])
         })
         .when('/styleguide/buttons', {
             templateUrl: 'styleguide/buttons.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Style Guide', path: '#/styleguide/basics'
+            }, {
+                name: 'Buttons'
+            }])
         })
         .when('/styleguide/tables', {
             templateUrl: 'styleguide/tables.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Style Guide', path: '#/styleguide/basics'
+            }, {
+                name: 'Tables'
+            }])
         })
         .when('/styleguide/forms', {
             templateUrl: 'styleguide/forms.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Style Guide', path: '#/styleguide/basics'
+            }, {
+                name: 'Forms'
+            }])
         })
         .when('/styleguide/modals', {
             templateUrl: 'styleguide/modals.html',
-            controller: genericRouteController()
+            controller: genericRouteController([{
+                name: 'Style Guide', path: '#/styleguide/basics'
+            }, {
+                name: 'Modals'
+            }])
         })
         .when('/component/:component', {
             redirectTo: function (routeParams) {
@@ -101,17 +141,16 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
         text: 'Demo Tag'
     });
 })
-.run(function ($rootScope, $window, $location, $anchorScroll, Environment, rxBreadcrumbsSvc, rxPageTitle) {
+.run(function ($rootScope, $window, $location, $anchorScroll, $interpolate,
+               Environment, rxBreadcrumbsSvc, rxPageTitle) {
     var baseGithubUrl = '//rackerlabs.github.io/encore-ui/';
     Environment.add({
         name: 'ghPages',
-        pattern: '//rackerlabs.github.io',
+        pattern: /\/\/rackerlabs.github.io/,
         url: baseGithubUrl + '{{path}}'
     });
 
-    if (Environment.envCheck('ghPages')) {
-        rxBreadcrumbsSvc.setHome(baseGithubUrl);
-    }
+    rxBreadcrumbsSvc.setHome($interpolate(Environment.get().url)({ path: '#/overview' }), 'Overview');
 
     var demoNav = [
         {
@@ -123,15 +162,16 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
                     linkText: 'Overview'
                 },
                 {
-                    href: 'ngdocs/index.html',
+                    href: '/ngdocs/index.html',
                     linkText: 'JS Docs'
                 },
                 {
-                    href: 'rx-page-objects/index.html',
+                    href: '/rx-page-objects/index.html',
                     linkText: 'Test Docs'
                 },
                 {
                     linkText: 'Other Links',
+                    href: '',
                     children: [
                         {
                             linkText: 'GitHub Repos',

--- a/demo/guides/guideController.js
+++ b/demo/guides/guideController.js
@@ -28,14 +28,9 @@ angular
         function setTitle () {
             var title = document.querySelector('rx-page').querySelector('h1, h2, h3, h4, h5')
             vm.title = title.innerText;
-            rxBreadcrumbsSvc.set([
-                {
-                    path: '/#/overview',
-                    name: 'Overview'
-                }, {
-                    name: vm.title
-                }
-            ]);
+            rxBreadcrumbsSvc.set([{
+                name: vm.title
+            }]);
 
             // Remove the now redundant title
             title.remove();

--- a/demo/overview.html
+++ b/demo/overview.html
@@ -33,19 +33,19 @@
             <div>
                 <h4 class="title sm">APIs &amp; Metrics</h4>
 
-                <a href="encore-ui/ngdocs/index.html#/api">
+                <a href="/ngdocs/index.html#/api">
                     <i class="fa fa-external-link"></i>
                     JS Docs
                 </a>
                 <p>API documentation for our directives, services, factories, and filters</p>
 
-                <a href="encore-ui/rx-page-objects/index.html">
+                <a href="/rx-page-objects/index.html">
                     <i class="fa fa-external-link"></i>
                     Test Docs
                 </a>
                 <p>API documentation for our Page Objects</p>
 
-                <a href="encore-ui/coverage/index.html">
+                <a href="/coverage/index.html">
                     <i class="fa fa-external-link"></i>
                     Unit Test Coverage
                 </a>

--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
@@ -31,16 +31,16 @@ describe('rxBreadcrumbs', function () {
             expect(first.isLast()).to.eventually.be.false;
         });
 
-        it('should have the name "Home"', function () {
-            expect(first.name).to.eventually.equal('Home');
+        it('should have the name "Overview"', function () {
+            expect(first.name).to.eventually.equal('Overview');
         });
 
         it('should not have a tag', function () {
             expect(first.lblTag.isPresent()).to.eventually.be.false;
         });
 
-        it('should have the href "/"', function () {
-            expect(first.href).to.eventually.equal(browser.baseUrl + '/');
+        it('should have the href "/#/overview"', function () {
+            expect(first.href).to.eventually.equal(browser.baseUrl + '/#/overview');
         });
 
     });
@@ -138,7 +138,7 @@ describe('rxBreadcrumbs', function () {
         });
 
         it('should have the correct names', function () {
-            expect(defaultBreadcrumbs.names).to.eventually.eql(['Home', 'Components', 'configs']);
+            expect(defaultBreadcrumbs.names).to.eventually.eql(['Overview', 'Components', 'configs']);
         });
     });
 

--- a/src/rxEnvironment/rxEnvironment.js
+++ b/src/rxEnvironment/rxEnvironment.js
@@ -102,15 +102,15 @@ angular.module('encore.ui.rxEnvironment', ['ngSanitize'])
     };
 
     /*
-     * Adds an environment to the stack
+     * Adds an environment to the front of the stack, ensuring it will be matched first
      * @public
      * @param {object} environment The environment to add. See 'environments' array for required properties
      */
     this.add = function (environment) {
         // do some sanity checks here
         if (isValidEnvironment(environment)) {
-            // add environment
-            environments.push(environment);
+            // add environment, over riding all others created previously
+            environments.unshift(environment);
         } else {
             $log.error('Unable to add Environment: defined incorrectly');
         }
@@ -130,7 +130,7 @@ angular.module('encore.ui.rxEnvironment', ['ngSanitize'])
     };
 
     /*
-     * Given an environment name, check if any of our registered environments 
+     * Given an environment name, check if any of our registered environments
      * match it
      * @public
      * @param {string} [name] Environment name to check


### PR DESCRIPTION
This should make nesting pages under an existing breadcrumb much simpler. Perhaps more of the style guide can become hierarchical in the future.

This also makes testing against the `ghPages` environment simpler. By changing the regular expression to match `/localhost/`, you can simulate what the url will look like when published to Github pages.