### PR TITLE
fix(rxPaginate): Remove old loading overlay.

### DIFF
--- a/src/rxPaginate/docs/rxPaginate.html
+++ b/src/rxPaginate/docs/rxPaginate.html
@@ -31,7 +31,7 @@
     </p>
     
     <h2 class="title">API-Based Pagination</h2>
-    <p>The API used by this demo is returning 100 items more than the user's selected `itemsPerPage`. If the user's `itemsPerPage` is 25, then the API will return 125 items on each request. This means with the default `itemsPerPage` of 25, five pages of results are coming back at a time. You should be able to click through pages 1-5 without a loading message, and then the loading message will appear for page 6.</p>
+    <p>The API used by this demo is returning 100 items more than the user's selected <code>itemsPerPage</code>. If the user's <code>itemsPerPage</code> is 25, then the API will return 125 items on each request. This means with the default <code>itemsPerPage</code> of 25, five pages of results are coming back at a time. You should be able to click through pages 1-5 without a loading message, and then the loading message will appear for page 6.</p>
 
     <p>Click the "Refresh" button to see how the current page can be reloaded without the user interacting with the <code>&lt;rx-paginate&gt;</code> buttons.</p>
 
@@ -99,7 +99,7 @@
     rx-select-filter {
         margin-left: 20px;
     }
-    .os-filter .rx-multi-select {
+    .os-filter .rxSelect {
         width: 200px;
     }
 </style>

--- a/src/rxPaginate/rxPaginate.js
+++ b/src/rxPaginate/rxPaginate.js
@@ -77,7 +77,6 @@ angular.module('encore.ui.rxPaginate', ['encore.ui.rxLocalStorage', 'debounce'])
                 };
 
                 var getItems = function (pageNumber, itemsPerPage) {
-                    scope.loadingState = 'loading';
                     var response = scope.serverInterface.getItems(pageNumber,
                                                    itemsPerPage,
                                                    params());
@@ -88,9 +87,7 @@ angular.module('encore.ui.rxPaginate', ['encore.ui.rxLocalStorage', 'debounce'])
                             error: errorMessage
                         });
                     }
-                    return response.finally(function () {
-                        scope.loadingState = '';
-                    });
+                    return response;
                 };
         
                 // Register the getItems function with the PageTracker
@@ -158,7 +155,7 @@ angular.module('encore.ui.rxPaginate', ['encore.ui.rxLocalStorage', 'debounce'])
  * @method showAndHide(promise) - Shows the overlay, and automatically
  * hides it when the given promise either resolves or rejects
  */
-.directive('rxLoadingOverlay', function ($compile, rxDOMHelper) {
+.directive('rxLoadingOverlay', function ($compile) {
     var loadingBlockHTML = '<div ng-show="showLoadingOverlay" class="loading-overlay">' +
                                 '<div class="loading-text-wrapper">' +
                                     '<i class="fa fa-fw fa-lg fa-spin fa-circle-o-notch"></i>' +
@@ -169,19 +166,8 @@ angular.module('encore.ui.rxPaginate', ['encore.ui.rxLocalStorage', 'debounce'])
     return {
         restrict: 'A',
         scope: true,
-        controller: function ($scope, $element) {
+        controller: function ($scope) {
             this.show = function () {
-                var offset = rxDOMHelper.offset($element);
-                var width = rxDOMHelper.width($element);
-                var height = rxDOMHelper.height($element);
-                if (!_.isUndefined($scope.loadingBlock)) {
-                    $scope.loadingBlock.css({
-                        top: offset.top + 'px',
-                        left: offset.left + 'px',
-                        width: width,
-                        height: height,
-                    });
-                }
                 $scope.showLoadingOverlay = true;
             };
 
@@ -201,8 +187,7 @@ angular.module('encore.ui.rxPaginate', ['encore.ui.rxLocalStorage', 'debounce'])
             scope.showLoadingOverlay = false;
 
             $compile(loadingBlockHTML)(scope, function (clone) {
-                scope.loadingBlock = clone;
-                element.after(clone);
+                element.append(clone);
             });
         }
     };

--- a/src/rxPaginate/rxPaginate.less
+++ b/src/rxPaginate/rxPaginate.less
@@ -155,7 +155,12 @@
 }
 
 .loading-overlay {
+    z-index: 100;
     position: absolute;
+    top: -1px;
+    left: -1px;
+    width: ~"calc(100% + 2px)";
+    height: ~"calc(100% + 2px)";
     background: rgba(222, 222, 221, 0.8);
     .loading-text-wrapper {
         width: 100px;
@@ -172,8 +177,4 @@
         margin-left: 25px;
         color: #777;
     }
-}
-
-.loading-row {
-    padding: 10px;
 }

--- a/src/rxPaginate/rxPaginate.spec.js
+++ b/src/rxPaginate/rxPaginate.spec.js
@@ -238,15 +238,17 @@ describe('Pagination', function () {
     });
 
     describe('rxPaginate (API-pagination)', function () {
-        var el, items, item, link, scope, compile, deferred, ul, $timeout,
-            validTemplate = '<rx-paginate ' +
-                                'page-tracking="pager" ' +
-                                'server-interface="api" ' +
-                                'filter-text="d.filter" ' +
-                                'selections="selected" ' +
-                                'sort-column="sort.predicate" ' +
-                                'sort-direction="sort.reverse" ' +
-                            '></rx-paginate>',
+        var el, items, item, link, scope, overlayScope, compile, deferred, ul, $timeout,
+            validTemplate = '<div rx-loading-overlay>' +
+                                '<rx-paginate ' +
+                                    'page-tracking="pager" ' +
+                                    'server-interface="api" ' +
+                                    'filter-text="d.filter" ' +
+                                    'selections="selected" ' +
+                                    'sort-column="sort.predicate" ' +
+                                    'sort-direction="sort.reverse" ' +
+                                '></rx-paginate>' +
+                            '</div>',
             api = {};
 
         var response = {
@@ -266,7 +268,6 @@ describe('Pagination', function () {
             // Load the directive's module
             module('encore.ui.rxPaginate');
             module('templates/rxPaginate.html');
-            module('encore.ui.rxMisc');
             module('encore.ui.rxNotify');
 
             // Inject in angular constructs
@@ -299,9 +300,10 @@ describe('Pagination', function () {
             
             ul = el.find('ul');
             items = el.find('li');
+            overlayScope = el.children().eq(-1).scope();
         });
         
-        it('should set loadingState to "loading" and clear on resolve', function () {
+        it('should show the loading overlay and hide on resolve', function () {
             // click second page link
             item = items.filter('.pagination-page').eq(1);
             link = item.find('a').eq(0);
@@ -315,19 +317,15 @@ describe('Pagination', function () {
             helpers.clickElement(link[0]);
 
             scope.$apply();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row')).to.be.true;
+            expect(overlayScope.showLoadingOverlay).to.be.true;
 
             deferred.resolve(response);
             
             scope.$apply();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row')).to.be.false;
+            expect(overlayScope.showLoadingOverlay).to.be.false;
         });
         
-        it('should set loadingState to "loading" and clear on reject', function () {
+        it('should show the loading overlay and hide on reject', function () {
             // click second page link
             item = items.filter('.pagination-page').eq(1);
             link = item.find('a').eq(0);
@@ -336,67 +334,51 @@ describe('Pagination', function () {
             helpers.clickElement(link[0]);
 
             scope.$apply();
-            ul = el.find('ul');
+            expect(overlayScope.showLoadingOverlay).to.be.true;
 
-            expect(ul.hasClass('loading-row')).to.be.true;
-
-            deferred.resolve(response);
+            deferred.reject(response);
             
             scope.$apply();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row')).to.be.false;
+            expect(overlayScope.showLoadingOverlay).to.be.false;
         });
 
-        it('should set loadingState when filterText changes', function () {
+        it('should show the loading overlay when filterText changes', function () {
             scope.d.filter = 'some search';
             scope.$apply();
             $timeout.flush();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row'), 'should show Loading').to.be.true;
+            expect(overlayScope.showLoadingOverlay).to.be.true;
 
             deferred.resolve(response);
             
             scope.$apply();
             $timeout.flush();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row'), 'should hide Loading').to.be.false;
+            expect(overlayScope.showLoadingOverlay).to.be.false;
         });
 
-        it('should set loadingState when selections changes', function () {
+        it('should show the loading overlay when selections changes', function () {
             scope.selected.os = _.first(scope.selected.os);
             scope.$apply();
             $timeout.flush();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row'), 'should show Loading').to.be.true;
+            expect(overlayScope.showLoadingOverlay).to.be.true;
 
             deferred.resolve(response);
 
             scope.$apply();
             $timeout.flush();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row'), 'should hide Loading').to.be.false;
+            expect(overlayScope.showLoadingOverlay).to.be.false;
         });
         
-        it('should set loadingState when sortColumn changes', function () {
+        it('should show the loading overlay when sortColumn changes', function () {
             scope.sort.predicate = 'os';
             scope.$apply();
             $timeout.flush();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row')).to.be.true;
+            expect(overlayScope.showLoadingOverlay).to.be.true;
 
             deferred.resolve(response);
             
             scope.$apply();
             $timeout.flush();
-            ul = el.find('ul');
-
-            expect(ul.hasClass('loading-row')).to.be.false;
+            expect(overlayScope.showLoadingOverlay).to.be.false;
         });
 
         it('should pass the current filter and sort values to getItems', function () {

--- a/src/rxPaginate/templates/rxPaginate.html
+++ b/src/rxPaginate/templates/rxPaginate.html
@@ -1,8 +1,5 @@
-<div class="rx-paginate" ng-switch="loadingState">
-    <ul ng-switch-when="loading" class="loading-row">
-        <li><span class="page-link" style="z-index: 5; position: relative">Loading...<span class="fa fa-fw fa-sm fa-spin fa-circle-o-notch"></span></span></li>
-    </ul>
-    <ul ng-switch-default class="pagination">
+<div class="rx-paginate">
+    <ul class="pagination">
         <li><a tabindex="0" ng-click="scrollToTop()">Back to top</a></li>
         <li>Showing {{ pageTracking | PaginatedItemsSummary}} items</li>
         <span class="page-links">


### PR DESCRIPTION
Correct me if I am wrong, but it seems this was left in on accident when `rxLoadingOverlay` was added.

Fixes #1139 