### PR TITLE
feat(userVoiceFeedback): User Voice redirection service

### DIFF
--- a/grunt-tasks/options/connect.js
+++ b/grunt-tasks/options/connect.js
@@ -22,6 +22,17 @@ module.exports = {
         options: {
             middleware: function (cnct) {
                 return [
+                    function (req, res, next) {
+                        if (req.url.indexOf('/encore/feedback') === 0) {
+                            var response = JSON.stringify({ base: 'https://angularjs.org/' });
+                            res.setHeader('Content-Type', 'application/json');
+                            res.setHeader('Content-Length', response.length);
+                            res.statusCode = 200;
+                            res.end(response);
+                            return false;
+                        }
+                        return next();
+                    },
                     config.proxyRequest,
                     config.modRewrite([
                         'login.html /login.html [L]',
@@ -40,7 +51,22 @@ module.exports = {
     keepalive: {
         options: {
             keepalive: true,
-            base: '<%= config.docs %>'
+            middleware: function (cnct) {
+                return [
+                    function (req, res, next) {
+                        if (req.url.indexOf('/encore/feedback') === 0) {
+                            var response = JSON.stringify({ base: 'https://angularjs.org/' });
+                            res.setHeader('Content-Type', 'application/json');
+                            res.setHeader('Content-Length', response.length);
+                            res.statusCode = 200;
+                            res.end(response);
+                            return false;
+                        }
+                        return next();
+                    },
+                    config.mountFolder(cnct, config.docs)
+                ];
+            }
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-bump": "~0.3.0",
     "grunt-cloudfiles": "~0.3.0",
     "grunt-complexity": "~0.2.0",
-    "grunt-connect-proxy": "0.2.0",
+    "grunt-connect-proxy": "0.1.10",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.9.0",

--- a/src/rxFeedback/README.md
+++ b/src/rxFeedback/README.md
@@ -4,10 +4,21 @@ Component built to gather and send user feedback
 
 ## Default Submission Function
 
-The `rxFeedback` component sends feedback to `/api/encore/feedback`, which routes feedback to `encoreui@lists`. 
-This endpoint also supports a `product` parameter `/api/encore/feedback/:product` for sending feedback to a 
-product-specific mailing list. Adding a custom endpoint is managed in `encore-service-pillar`. Once configured 
+The `rxFeedback` component sends feedback to `/api/encore/feedback`, which routes feedback to `encoreui@lists`.
+For the **Feedback Type** of "Feature Request", we will open up a new window redirecting the user to the **GET Feedback** website, which will now host all internal requests for features.
+
+This endpoint also supports a `product` parameter `/api/encore/feedback/:product` for sending feedback to a
+product-specific mailing list.
+
+Adding a custom endpoint is managed in `encore-service-pillar`. Once configured
 you can override the default endpoint with `rxFeedbackSvc.setEndpoint`.
+
+```javascript
+    // To be put in the run section of your application
+    .run(function (rxFeedbackSvc) {
+        rxFeedbackSvc.setEndpoint('/api/encore/feedback/cloud');
+    });
+```
 
 ## Custom Submission Function
 
@@ -25,4 +36,93 @@ feedback object with the following definition:
   },
   "description": "(string) user-submitted feedback"
 }
+```
+
+## UserVoice Redirect Integration
+
+### Development
+For development purposes, you may want to include one of the two following configurations depending on which type of project you have:
+
+*The latest version of the [Encore generator](https://github.com/rackerlabs/generator-encore) will include this proxy*
+
+**Gulp**: `gulp/util/prism.js`
+```javascript
+prism.create({
+    name: 'encorefeedback',
+    context: '/encore/feedback',
+    host: 'staging.encore.rackspace.com',
+    port: 443,
+    https: true,
+    changeOrigin: false
+});
+```
+
+**Grunt**: `tasks/util/config`
+```javascript
+{
+    context: '/encore/feedback',
+    host: 'staging.encore.rackspace.com',
+    port: 443,
+    https: true,
+    protocol: 'https',
+    changeOrigin: false
+}
+```
+
+### Production
+To manually include the Feedback changes without updating your version of Encore UI, please include the following:
+
+Include the following file in your `index.html` (after Encore UI or after injected dependencies):
+
+[http://3bea8551c95f45baa125-a22eac1892b2a6dcfdb36104c0e925de.r46.cf1.rackcdn.com/feedback-override.js](http://3bea8551c95f45baa125-a22eac1892b2a6dcfdb36104c0e925de.r46.cf1.rackcdn.com/feedback-override.js)
+
+```javascript
+<!-- inject:js -->
+<!-- endinject -->
+<!-- or -->
+<script src="bower_components/encore-ui/encore-ui-tpls.min.js"></script>
+<script src="bower_components/encore-ui-svcs/dist/encore-ui-svcs.js"></script>
+<!-- ... -->
+<script src="https://6618f7541d71c1a404be-a22eac1892b2a6dcfdb36104c0e925de.ssl.cf1.rackcdn.com/feedback-override.js"></script>
+```
+
+-- OR --
+
+Include in your `app.js` is the following snippet:
+
+```javascript
+// jscs:disable
+// jshint ignore:start
+angular.module('encore.ui.rxFeedback').factory("UserVoiceMapping",["$http","$location","$interval","$window",function(a,b,c,d){var e,f,g="https://get.feedback.rackspace.com/forums/297396",h="category",i=["Feature Request"],j=function(){var a=b.absUrl();return a="/"+a.split("/").slice(3).join("/"),a=a.slice(0,a.length-b.url().length)},k=function(){return e||(e=a({url:"/encore/feedback/route-map.json",cache:!0}).then(function(a){return a.data},function(){return{}})),e},l=function(a){var b=a.base||g,c=j();return _.has(a,c)&&(_.contains(a[c],"http")?b=a[c]:b+="/"+(a.categoryPrefix||h)+"/"+a[c]),b},m=function(){f&&(c.cancel(f),f=void 0)},n=function(a,b){return m(),a.loadingUserVoice=!0,f=c(function(){d.open(b,"_blank")},3e3,1,!1),f["finally"](function(){a.loadingUserVoice=!1}),b};return{cancelOpen:m,watch:function(a,b,c){c.showRedirectMessage=!1,m(),k(),a&&_.contains(i,a.label)&&(c.showRedirectMessage=!0,k().then(l).then(_.partial(n,c)).then(function(a){c.route=a}))}}}]);
+angular.module("templates/feedbackForm.html", []).run(["$templateCache", function(a) { a.put("templates/feedbackForm.html", '<rx-modal-form rx-form title="Submit Feedback" subtitle="for page: {{ currentUrl }}" submit-text="Send Feedback" class="rx-feedback-form"><rx-form-section><rx-field><rx-field-name>Report Type:</rx-field-name><rx-field-content><rx-input><select rx-select id="selFeedbackType" ng-model="fields.type" ng-options="opt as opt.label for opt in feedbackTypes" ng-init="fields.type = feedbackTypes[0]" required></select></rx-input></rx-field-content></rx-field></rx-form-section><rx-form-section ng-show="fields.type" ng-if="!showRedirectMessage"><rx-field><rx-field-name class="feedback-description">{{fields.type.prompt}}:</rx-field-name><rx-field-content><rx-input><textarea rows="8" placeholder="{{fields.type.placeholder}}" required ng-model="fields.description" class="feedback-textarea"></textarea></rx-input></rx-field-content></rx-field></rx-form-section><div ng-if="showRedirectMessage"><div class="redirect-description well centered"><h2 class="title subdued">We want to hear your voice!</h2>*You will now be redirected to a new window.*<br><a href="{{ route }}" target="_blank">{{ route }}</a> <button class="title button cancel xs" ng-if="loadingUserVoice" ng-click="cancelOpen()">Cancel Redirect</button></div></div></rx-modal-form>')}])
+angular.module("templates/rxFeedback.html", []).run(["$templateCache", function(a) { a.put("templates/rxFeedback.html", '<div class="rx-feedback"><rx-modal-action pre-hook="setCurrentUrl(this)" post-hook="sendFeedback(fields)" template-url="templates/feedbackForm.html">Submit Feedback</rx-modal-action></div>')}])
+// jshint ignore:end
+// jscs:enable
+
+```
+
+and in the `.config` section of your `app.js`:
+
+```javascript
+   .config(function($provide) {
+      $provide.decorator('rxFeedbackDirective', function ($delegate, UserVoiceMapping) {
+            var directive = $delegate[0];
+
+            var link = directive.link;
+
+            directive.compile = function () {
+                return function (scope) {
+                    link.apply(this, arguments);
+                    var setCurrentUrl = scope.setCurrentUrl || function () {};
+                    scope.cancelOpen = UserVoiceMapping.cancelOpen;
+                    scope.setCurrentUrl = function (modalScope) {
+                        setCurrentUrl(modalScope);
+                        modalScope.$watch('fields.type', UserVoiceMapping.watch);
+                    };
+                };
+            };
+            return $delegate;
+        });
+    });
+
 ```

--- a/src/rxFeedback/docs/rxFeedback.midway.js
+++ b/src/rxFeedback/docs/rxFeedback.midway.js
@@ -34,6 +34,7 @@ describe('rxFeedback', function () {
     });
 
     describe('feedback types and labels', function () {
+        var defaultBaseUrl = 'https://angularjs.org/';
         var typesAndLabels = {
             'Incorrect Data': {
                 descriptionLabel: 'Problem Description:',
@@ -41,9 +42,10 @@ describe('rxFeedback', function () {
                                          'so we can figure it out for you.'].join('')
             },
             'Feature Request': {
-                descriptionLabel: 'Feature Description:',
-                descriptionPlaceholder: ['Please be as descriptive as possible ',
-                                         'so we can make your feature awesome.'].join('')
+                redirectDescriptionText: ['We want to hear your voice!',
+                                          '*You will now be redirected to a new window.*',
+                                          defaultBaseUrl,
+                                          'Cancel Redirect'].join('\n')
             },
             'Kudos': {
                 descriptionLabel: 'What made you happy?:',
@@ -69,7 +71,27 @@ describe('rxFeedback', function () {
                     expect(successfulFeedback[property]).to.eventually.equal(text);
                 });
             });
+        });
 
+        it('should open a new window after 3 seconds for Feature Request', function () {
+            successfulFeedback.type = 'Feature Request';
+            // Gives it enough time for window to pop open and get redirected to fedsso login
+            browser.sleep(3100);
+            browser.getAllWindowHandles().then(function (handles) {
+                expect(handles.length).to.eql(2);
+                browser.switchTo().window(handles[1]).then(function () {
+                    // This will automatically go to the NAM Rackspace Login page
+                    expect(browser.driver.getCurrentUrl()).to.eventually.eql(defaultBaseUrl);
+                    browser.driver.close();
+
+                    // Get back to original window
+                    browser.switchTo().window(handles[0]);
+                });
+            });
+        });
+
+        after(function () {
+            successfulFeedback.type = 'Kudos';
         });
 
     });

--- a/src/rxFeedback/rxFeedback.js
+++ b/src/rxFeedback/rxFeedback.js
@@ -1,3 +1,4 @@
+
 angular.module('encore.ui.rxFeedback', ['ngResource'])
 .value('feedbackTypes', [
     {
@@ -86,7 +87,122 @@ angular.module('encore.ui.rxFeedback', ['ngResource'])
 
     return container;
 })
-.directive('rxFeedback', function (feedbackTypes, $location, rxFeedbackSvc, rxScreenshotSvc, rxNotify, Session) {
+.factory('UserVoiceMapping', function ($http, $location, $interval, $window) {
+
+    var defaultUserVoiceURL = 'https://get.feedback.rackspace.com/forums/297396';
+    var defaultCategoryPrefix = 'category';
+    var userVoiceTypes = ['Feature Request'];
+    var httpPromise, openPromise;
+
+    // Gets the base HREF parsed from the full URL
+    var getBaseHref = function () {
+        // Get the full URL
+        var route = $location.absUrl();
+        // Remove proto://domain:port portion of the URI
+        route = '/' + route.split('/').slice(3).join('/');
+        // Remove the URL that angular recognizes
+        route = route.slice(0, route.length - $location.url().length);
+
+        return route;
+    };
+
+    // Fetch the route mappings, if the fetch fails provide a default barebones object
+    var fetchRoutes = function () {
+        // Make sure we're only fetching once
+        if (!httpPromise) {
+            // Save the promise to keep using
+            httpPromise = $http({
+                url: '/encore/feedback/route-map.json',
+                cache: true
+            }).then(function (response) {
+                // We only want the data after this point
+                return response.data;
+            }, function () {
+                // Connection failed to CDN? return an empty object
+                return {};
+            });
+        }
+        return httpPromise;
+    };
+
+    // Construct the user voice URL along with the proper mapping suffix if needed
+    var matchRoute = function (mapping) {
+        // Grab the base url in case it has changed from CDN
+        var url = mapping.base || defaultUserVoiceURL;
+        // Check if we have the category ID for the route
+        var route = getBaseHref();
+        if (_.has(mapping, route)) {
+            // if we have a full static URL just use it
+            if (_.contains(mapping[route], 'http')) {
+                url = mapping[route];
+            } else {
+                url += '/' + (mapping.categoryPrefix || defaultCategoryPrefix) + '/' + mapping[route];
+            }
+        }
+        return url;
+    };
+
+    // Cancel interval of opening a window
+    var cancelOpenWindow = function () {
+        if (openPromise) {
+            $interval.cancel(openPromise);
+        }
+        openPromise = undefined;
+    };
+
+    // Open a new window with the defined route
+    var openWindow = function (scope, route) {
+        // reset the open window promise
+        openPromise = $interval(function () {
+            $window.open(route, '_blank');
+        }, 3000, 1, false);
+
+        // Set the flag for showing the cancel redirect button
+        scope.loadingUserVoice = true;
+
+        // On fulfillment of the process, mark the button to be hidden no matter what
+        openPromise.finally(function () {
+            scope.loadingUserVoice = false;
+        });
+
+        // Let's return the route for any other functions to use it
+        return route;
+    };
+
+    return {
+        cancelOpen: cancelOpenWindow,
+        watch: function watchValue (type, old, scope) {
+            // By Default we do not want to show the redirect message
+            scope.showRedirectMessage = false;
+
+            // Let's cancel any attempts to open a window
+            // Otherwise this creates an unsavory behavior of changing values and
+            // a random window opens
+            cancelOpenWindow();
+
+            // Let's prefetch route maps only when the watch has been set up
+            // Caching will make sure that the network request only happens once
+            fetchRoutes();
+
+            // Check if we are doing "Feature Requests"
+            if (type && _.contains(userVoiceTypes, type.label)) {
+                scope.showRedirectMessage = true;
+
+                // Get the route mapping, match the current route,
+                fetchRoutes()
+                    .then(matchRoute)
+                    .then(_.partial(openWindow, scope))
+                    .then(function (route) {
+                        // This is sugar for the template only
+                        scope.route = route;
+                    });
+            }
+        }
+    };
+
+})
+.directive('rxFeedback', function (feedbackTypes, $location, rxFeedbackSvc, rxScreenshotSvc, rxNotify, Session,
+           UserVoiceMapping) {
     return {
         restrict: 'E',
         templateUrl: 'templates/rxFeedback.html',
@@ -96,8 +212,13 @@ angular.module('encore.ui.rxFeedback', ['ngResource'])
         link: function (scope) {
             scope.feedbackTypes = feedbackTypes;
 
+            scope.cancelOpen = function () {
+                UserVoiceMapping.cancelOpen();
+            };
+
             scope.setCurrentUrl = function (modalScope) {
                 modalScope.currentUrl = $location.url();
+                modalScope.$watch('fields.type', UserVoiceMapping.watch);
             };
 
             var showSuccessMessage = function (response) {

--- a/src/rxFeedback/rxFeedback.page.js
+++ b/src/rxFeedback/rxFeedback.page.js
@@ -69,6 +69,12 @@ var rxFeedback = {
         }
     },
 
+    redirectDescriptionText: {
+        get: function () {
+            return this.rootElement.$('.redirect-description').getText();
+        }
+    },
+
     send: {
         /**
           Prepares, writes, and submits feedback.

--- a/src/rxFeedback/templates/feedbackForm.html
+++ b/src/rxFeedback/templates/feedbackForm.html
@@ -15,7 +15,7 @@
     </rx-field>
   </rx-form-section>
 
-  <rx-form-section ng-show="fields.type">
+  <rx-form-section ng-show="fields.type" ng-if="!showRedirectMessage">
     <rx-field>
       <rx-field-name class="feedback-description">{{fields.type.prompt}}:</rx-field-name>
       <rx-field-content>
@@ -29,4 +29,12 @@
       </rx-field-content>
     </rx-field>
   </rx-form-section>
+  <div ng-if="showRedirectMessage">
+    <div class="redirect-description well centered">
+        <h2 class="title subdued">We want to hear your voice!</h2>
+        *You will now be redirected to a new window.*<br />
+        <a href="{{ route }}" target="_blank">{{ route }}</a><br />
+        <button class="title button cancel xs clear" ng-if="loadingUserVoice" ng-click="cancelOpen()">Cancel Redirect</button>
+    </div>
+  </div>
 </rx-modal-form>


### PR DESCRIPTION
No JIRA

- [x] Dev LGTM
- [ ] Dev LGTM
- [ ] Design LGTM

This overrides the behavior of `rxFeedback` when a user chooses `Feature Request`, they will be forwarded to the internal **GET Feedback** 

Depending on which application we are on, there will be a category ID for each, and the redirect will happen to that category.

Allowing to override the base URL for **GET Feedback** as well as how the categories get appended on to the URL, in order to allow for change without having to re-release the framework again.
