### PR TITLE
docs(links): correct/remove dead links and documentation

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -222,10 +222,6 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
                             linkText: 'Lists'
                         },
                         {
-                            href: '#/styleguide/basics#collapsible',
-                            linkText: 'Collapsible Element'
-                        },
-                        {
                             href: '#/styleguide/basics#helper-classes',
                             linkText: 'Helper classes'
                         },

--- a/demo/styleguide/basics.html
+++ b/demo/styleguide/basics.html
@@ -95,7 +95,7 @@
     <ul class="list">
         <li>In table cells, metadata lists, or other displays of data, <code>N/A</code> should be used as an indicator to the user that there is no relevant data to display.</li>
         <li>Do not use <code>–</code>, <code>Empty</code>, <code>null</code>, or no indicator to communicate this, as there may be situations where those are valid inputs or data to display to a user depending on the context.</li>
-        <li>Note that a separate style exists to communicate <a href="#/styleguide/basics#wells">when data isn't present due to permissions</a>, or when an entire table is empty (see "Null Patterns" section of <a href="#/styleguide/tables">Tables style guide</a>).
+        <li>Note that a separate style exists to communicate <a href="#/styles/wells">when data isn't present due to permissions</a>, or when an entire table is empty (see "Null Patterns" section of <a href="#/styleguide/tables">Tables style guide</a>).
     </ul>
 
     <h3 id="lists">Lists</h3>
@@ -106,16 +106,6 @@
         </ul>
     </div>
     <rx-styleguide code-url="styleguide/basics/lists.html"></rx-styleguide>
-
-    <h3 id="collapsible">Collapsible Element</h3>
-    <div class="component-description clear">
-        <ul class="list">
-            <li>The collapsible element can be used to display and hide content.</li>
-            <li>It can be configured to show as either expanded or collapsed on page load.</li>
-            <li>A double chevron is used as a toggle to show/hide the inner contents, while keeping the header and border visible.</li>
-        </ul>
-    </div>
-    <rx-styleguide code-url="styleguide/basics/collapsible.html"></rx-styleguide>
 
     <h2 id="helper-classes">Helper Classes</h2>
     <div class="component-description clear">

--- a/demo/styleguide/forms.html
+++ b/demo/styleguide/forms.html
@@ -230,7 +230,7 @@
     <ul class="list">
       <li>Forms can be used on their own page. You can see this in Encore when you create a new object such as a Cloud Server or a Database under Encore Cloud.</li>
       <li>Forms are also used within modals. This can be see when modifying content that requires form fields such as actions performed on a Cloud Server instance.</li>
-      <li><a href="#/styleguide/basics#wells">Wells</a> can be used to create additional context for the form.</li>
+      <li><a href="#/styles/wells">Wells</a> can be used to create additional context for the form.</li>
     </ul>
 
     <h2 class="title lg" id="roadmap">UI Roadmap / Possible Future-work</h2>


### PR DESCRIPTION
Fixes #1183 

* remove old documentation section for collapsible element
* correct old "wells" links to use new href

### LGTMs
- [x] Dev LGTM
- [x] Dev LGTM