### PR TITLE
chore(componentTemplate): update for standard component ngdocs

### DIFF
--- a/grunt-tasks/component-template/root/README.md
+++ b/grunt-tasks/component-template/root/README.md
@@ -1,3 +1,5 @@
 [![{%= stabilityName %}](http://badges.github.io/stability-badges/dist/{%= stabilityName %}.svg)](http://github.com/badges/stability-badges)
 
+[API Documentation](ngdocs/index.html#/api/{%= name %})
+
 {%= description %}

--- a/grunt-tasks/component-template/root/component.js
+++ b/grunt-tasks/component-template/root/component.js
@@ -1,1 +1,16 @@
+/**
+ * @ngdoc overview
+ * @name {%= name %}
+ * @description
+ * # {%= name %} Component
+ *
+ * ## Services
+ * * Links to service APIs provided by {%= name %} component.
+ *
+ * ## Directives
+ * * Links to directive APIs provided by {%= name %} component.
+ *
+ * ## Related Directives (if applicable)
+ * * Links to directive APIs provided by other components.
+ */
 angular.module('encore.ui.{%= name %}', []);


### PR DESCRIPTION
* add quick blurb to define basic component ngdocs overview page
* add link to component ngdocs overview page in README

### LGTMs
- [x] Dev LGTM
- [x] Dev LGTM