### PR TITLE
chore(grunt): support for splitting up monolithic js source files

### DIFF
--- a/grunt-tasks/build.js
+++ b/grunt-tasks/build.js
@@ -1,8 +1,25 @@
 module.exports = function (grunt) {
     grunt.registerTask('build', 'Create build files', function () {
-        grunt.task.run(['clean:build', 'modules', 'concat:dist', 'concat:distTpls', 'concat:tmpLess',
-            'concat:tmpLessResp', 'less:encore', 'less:encoreResp', 'less:styleguide', 'copy:demomarkdown',
-            'copy:demohtml', 'copy:demoassets', 'copy:demopolyfills', 'imagemin', 'concat:rxPageObjects',
-            'concat:rxPageObjectsExercises', 'jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs', 'ngdocs']);
+        grunt.task.run([
+            'clean:build',
+            'modules',
+            'concat:dist',
+            'concat:distTpls',
+            'concat:tmpLess',
+            'concat:tmpLessResp',
+            'less:encore',
+            'less:encoreResp',
+            'less:styleguide',
+            'copy:demomarkdown',
+            'copy:demohtml',
+            'copy:demoassets',
+            'copy:demopolyfills',
+            'imagemin',
+            'concat:rxPageObjects',
+            'concat:rxPageObjectsExercises',
+            'jsdoc2md:rxPageObjects',
+            'shell:rxPageObjectsDemoDocs',
+            'ngdocs'
+        ]);
     });
 };

--- a/grunt-tasks/default.js
+++ b/grunt-tasks/default.js
@@ -1,4 +1,12 @@
 module.exports = function(grunt) {
-    grunt.registerTask('default', ['clean', 'syntax-check', 'html2js',
-        'build', 'test', 'minify', 'copy', 'ngdocs']);
+    grunt.registerTask('default', [
+        'clean',
+        'syntax-check',
+        'html2js',
+        'build',
+        'test',
+        'minify',
+        'copy',
+        'ngdocs'
+    ]);
 };

--- a/grunt-tasks/minify.js
+++ b/grunt-tasks/minify.js
@@ -1,3 +1,8 @@
 module.exports = function (grunt) {
-    grunt.registerTask('minify', ['cssmin', 'ngAnnotate', 'uglify', 'imagemin']);
+    grunt.registerTask('minify', [
+        'cssmin',
+        'ngAnnotate',
+        'uglify',
+        'imagemin'
+    ]);
 };

--- a/grunt-tasks/modules.js
+++ b/grunt-tasks/modules.js
@@ -46,11 +46,17 @@ module.exports = function (grunt) {
                 d[1], parseInt(d[2]) + ',', d[3], '@', d[4].substr(0, 5), d[5].replace('GMT', '(UTC') + ')'].join(' ');
         }
 
+        var srcFileGlobs = [
+            'src/' + name + '/' + name + '.js',  // (OLD Manifest) Must load first
+            'src/' + name + '/' + name + '.module.js', // (NEW Manifest) Must load first
+            'src/' + name + '/scripts/!(*.spec|*.page|*.exercise).js' // Load additional scripts
+        ];
+
         var module = {
             name: name,
             moduleName: enquote('encore.ui.' + name),
             displayName: ucwords(breakup(name, ' ')),
-            srcFiles: grunt.file.expand('src/' + name + '/!(*.spec|*.page|*.exercise).js'),
+            srcFiles: grunt.file.expand(srcFileGlobs),
             tplFiles: grunt.file.expand('src/' + name + '/*.tpl.html'),
             tplJsFiles: grunt.file.expand('templates/' + name + '/templates/*.html'),
             dependencies: dependenciesForModule(name),
@@ -64,7 +70,7 @@ module.exports = function (grunt) {
                 less: grunt.file.expand('src/' + name + '/*.less').map(grunt.file.read).join('\n'),
                 midway: grunt.file.expand('src/' + name + '/docs/*.midway.js').map(grunt.file.read).join('\n') +
                     '\n// this component\'s exercise.js file, if it exists, is below\n\n' +
-                    grunt.file.expand('src/' + name + '/*.exercise.js').map(grunt.file.read).join('\n')
+                    grunt.file.expand('src/' + name + '/**/*.exercise.js').map(grunt.file.read).join('\n')
             }
         };
 

--- a/grunt-tasks/options/concat.js
+++ b/grunt-tasks/options/concat.js
@@ -1,10 +1,14 @@
-var removeFromIndex = ['/*jshint node:true*/\n',
-                       'var _ = require(\'lodash\');\n',
-                       'var moment = require(\'moment\');\n',
-                       'var Page = require(\'astrolabe\').Page;\n'];
+var removeFromIndex = [
+    '/*jshint node:true*/\n',
+    'var _ = require(\'lodash\');\n',
+    'var moment = require(\'moment\');\n',
+    'var Page = require(\'astrolabe\').Page;\n'
+];
 
-var removeFromExercises = ['/*jshint node:true*/\n',
-                           'var _ = require(\'lodash\');\n'];
+var removeFromExercises = [
+    '/*jshint node:true*/\n',
+    'var _ = require(\'lodash\');\n'
+];
 
 module.exports = {
     dist: {
@@ -51,7 +55,10 @@ module.exports = {
                 return src;
             }
         },
-        src: ['src/*/*.exercise.js'],
+        src: [
+            'src/*/*.exercise.js',
+            'src/*/scripts/*.exercise.js'
+        ],
         dest: 'utils/rx-page-objects/exercise.js'
     },
     tmpLess: {

--- a/grunt-tasks/options/karma.js
+++ b/grunt-tasks/options/karma.js
@@ -24,8 +24,9 @@ module.exports = {
     options: {
         configFile: 'karma.conf.js',
         files: files.concat([
-            'src/*/*.js',
-            'src/*/templates/*.html'
+            'src/*/*.js',               // src/<component>/<component>.js
+            'src/*/templates/*.html',   // src/<component>/templates/<item>.html
+            'src/*/scripts/*.js'        // src/<component>/scripts/<item>.js
         ])
     },
     watch: {
@@ -44,7 +45,7 @@ module.exports = {
     minified: {
         options: {
             files: files.concat([
-                'src/*/*.spec.js',
+                'src/**/*.spec.js',
                 '<%= config.dist %>/<%= config.fileNameTpl %>.min.js'
             ])
         },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,13 +8,14 @@ module.exports = function (config) {
 
         // list of files to exclude
         exclude: [
-            'src/*/*.page.js',
-            'src/*/*.exercise.js',
+            'src/**/*.page.js',
+            'src/**/*.exercise.js'
         ],
 
         preprocessors: {
             'src/**/*.html': 'ng-html2js',
-            'src/*/!(*.spec).js': ['coverage']
+            'src/*/!(*.spec).js': ['coverage'],
+            'src/**/scripts/!(*.spec).js': ['coverage']
         },
 
         ngHtml2JsPreprocessor: {


### PR DESCRIPTION
Provides the ability to split up the monolithic component javascript source files. In addition to current file structure, this will support the following hierarchy:

```
src/
  <component>/
    docs/
    templates/ 
    README.md
    <component>.less
    <component>.module.js # defines angular module for component
    scripts/
      <item>.js
      <item>.exercise.js
      <item>.page.js
      <item>.spec.js
```

### LGTMS
- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM