### PR TITLE
refactor(less): FRMW-131 use named color variables

### DIFF
--- a/demo/assets/demo.less
+++ b/demo/assets/demo.less
@@ -193,10 +193,10 @@ rx-page.styleguide {
         margin: 10px;
         box-sizing: border-box;
         background-color: #fff;
-        border: 1px solid #dededd;
+        border: 1px solid @disabled-gray;
         padding: 0;
 
-        box-shadow: 0 3px 5px -2px #898989;
+        box-shadow: 0 3px 5px -2px @cancel-gray;
 
         .swatch-heading,
         .swatch-body {

--- a/src/layout/responsiveLayout.less
+++ b/src/layout/responsiveLayout.less
@@ -18,11 +18,11 @@
     width: auto;
   }
 
-  .dark-blue { background-color: #4881c0; }
-  .light-blue { background-color: #86cafd; }
-  .dark-green { background-color: #24b56a; }
-  .light-green { background-color: #c8e5bf; }
-  .orange { background-color: #db7820; }
+  .dark-blue { background-color: @blue; }
+  .light-blue { background-color: @light-blue; }
+  .dark-green { background-color: @green; }
+  .light-green { background-color: @light-green; }
+  .orange { background-color: @orange; }
 
   .small-box-container {
     width: 95%;

--- a/src/progressbar/progressbar.less
+++ b/src/progressbar/progressbar.less
@@ -4,7 +4,7 @@
 @progress-bg: #f5f5f5;
 
 //** Default progress bar color
-@progress-bar-bg: #86cafd;
+@progress-bar-bg: @light-blue;
 
 //** Secondary progress bar color
 @progress-bar-secondary-bg: @infoBlue;

--- a/src/rxCharacterCount/rxCharacterCount.less
+++ b/src/rxCharacterCount/rxCharacterCount.less
@@ -36,10 +36,10 @@
         text-align: right;
         color: @subduedTitle;
         &.near-limit {
-            color: #db7820;
+            color: @orange;
         }
         &.over-limit {
-            color: #fc0f1d;
+            color: @red;
         }
     }
 }

--- a/src/rxCollapse/rxCollapse.less
+++ b/src/rxCollapse/rxCollapse.less
@@ -48,7 +48,7 @@ rx-collapse {
   }
   .sml-title {
     cursor: pointer;
-    color:#898989;
+    color: @cancel-gray;
     font-size: 10pt;
   }
 

--- a/src/rxStatusColumn/rxStatusColumn.less
+++ b/src/rxStatusColumn/rxStatusColumn.less
@@ -21,7 +21,7 @@ td.rx-status-column {
     &.status-WARNING {
         background: #fdbc3c;
         i {
-            color: #db7820;
+            color: @orange;
         }
     }
     &.status-ERROR {
@@ -31,13 +31,13 @@ td.rx-status-column {
         }
     }
     &.status-INFO {
-        background: #86cafd;
+        background: @light-blue;
         i {
             color: #287BBD;
         }
     }
     &.status-DISABLED {
-        background: #dededd;
+        background: @disabled-gray;
     }
 
     .fa-exclamation-circle {


### PR DESCRIPTION
Resubmitted PR https://github.com/rackerlabs/encore-ui/pull/1190 with proper upstream/origin workflow.  Thanks to @CITguy @TheNando @halkon for the assist.

Changed hard-coded hex colors to named variables https://jira.rax.io/browse/FRMW-131.  I also checked for uppercase hex colors.
 