### PR TITLE
fix(bugs): manual save + rxButton

### DIFF
--- a/demo/styleguide/forms/manual-saving.html
+++ b/demo/styleguide/forms/manual-saving.html
@@ -3,18 +3,18 @@
         <rx-notification ng-if="form.$dirty" type="info" stack="page">
             Changes made are not automatically saved. Click "Save Now" to save changes.
         </rx-notification>
-        <span class="title subdued">
+        <h3 class="subdued">
             <span ng-show="lastSaved">Last saved {{lastSaved | date:'medium'}}</span>
             <span ng-hide="lastSaved">Unsaved changes.</span>
-        </span>
-        <rx-button
-            classes="submit xs inline"
-            ng-click="form.$setPristine(); save()"
-            default-msg="Save Now"
-            toggle-msg="Saving"
-            toggle="saving"
-            disable="form.$invalid || form.$pristine">
-        </rx-button>
+            <rx-button
+                classes="submit xs inline"
+                ng-click="form.$setPristine(); save()"
+                default-msg="Save Now"
+                toggle-msg="Saving"
+                toggle="saving"
+                disable="form.$invalid || form.$pristine">
+            </rx-button>
+        </h3>
         <rx-form-section style="width: 200px;">
             <rx-field>
                 <rx-field-name>Field:</rx-field-name>

--- a/src/rxButton/rxButton.less
+++ b/src/rxButton/rxButton.less
@@ -5,7 +5,7 @@
     background: @buttonDefaultBg;
     color: @buttonColor;
     border: 0;
-    font-size: 1.1em;
+    font-size: 14px;
     padding: 7px 13px;
     margin-bottom: 10px;
     transition: all 0.3s cubic-bezier(0.175, 0.885, 0.320, 1.275);
@@ -21,24 +21,24 @@
 
     // Size Variations
     &.xl {
-        font-size: 1.25em;
+        font-size: 16px;
         padding: 20px 30px;
     }
 
     &.lg {
-        font-size: 1.15em;
+        font-size: 15px;
         padding: 15px 26px;
     }
 
     &.sm {
         padding: 5px 10px;
-        font-size: 1em;
+        font-size: 13px;
     }
 
     &.xs {
         padding: 3px 7px;
         margin-bottom: 5px;
-        font-size: .9em;
+        font-size: 12px;
     }
 
     // Color Variations


### PR DESCRIPTION
* update manual save example to use better markup based on current CSS (per conversation with @glynnis)
  * old markup using deprecated `title` class on inline `<span>` 
  * browser doesn't apply margins to `inline` elements
  * now using `<h3>`
* replace rxButton font-sizes with static, `px` values (per [JIRA 208](https://jira.rax.io/browse/FRMW-208))

### LGTMS
- [ ] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM