### PR TITLE
feat(docs): FRMW-154-Migrate rxMetadata to API docs

### DIFF
--- a/src/rxMetadata/README.md
+++ b/src/rxMetadata/README.md
@@ -1,14 +1,3 @@
 [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges)
 
 `rxMetadata` contains directives to provide consistent styling for the display of metadata information.
-
-## Organizing into Columns
-
-It is highly recommended that you make use of `<section>` elements to separate metadata information into columns.
-
-The `<section>` elements will be set to a fixed width and will wrap/stack if the container cannot fit all columns in a single row. *You can resize this page to see how the columns wrap.*
-
-## Long Data Values
-
-For data values that don't naturally break to fit the width of the column, a `.force-word-break` CSS class is available on the `<rx-meta>` element to prevent the value from overflowing to adjacent content.
-See "Super Long Value" metadata below.

--- a/src/rxMetadata/rxMetadata.js
+++ b/src/rxMetadata/rxMetadata.js
@@ -7,6 +7,34 @@
  * rxMetadata contains directives to provide consistent styling for
  * the display of metadata information.
  *
+ * ## Organizing Metadata into Columns
+ * It is highly recommended that you make use of `<section>` elements to separate metadata information into columns.
+ * The `<section>` elements will be set to a fixed width and will wrap/stack if the container cannot fit all columns 
+ * in a single row.
+ * 
+ * <pre>
+ * <rx-metadata>
+ *   <section>
+ *     <rx-meta label="Status" id="metaStatus">Active</rx-meta>
+ *     <rx-meta label="RCN">RCN-555-555-555</rx-meta>
+ *     <rx-meta label="Type">Cloud</rx-meta>
+ *     <rx-meta label="Service Level">Managed &rarr; Intensive</rx-meta>
+ *     <rx-meta label="Service Type">DevOps &rarr; SysOps</rx-meta>
+ *   </section>
+ * </rx-metadata>
+ * </pre>
+ *
+ * ## Long Data Values
+ * 
+ * For data values that do not naturally break to fit the width of the column, a `.force-word-break` CSS class is 
+ * available on the `<rx-meta>` element to prevent the value from overflowing to adjacent content.
+ *
+ * <pre>
+ *   <rx-meta label="Super Long Value" class="force-word-break">
+ *     A super long data value with anunseeminglyunbreakablewordthatcouldoverflowtothenextcolumn
+ *   </rx-meta>
+ * </pre>
+ * 
  * ## Directives
  * * {@link rxMetadata.directive:rxMetadata rxMetadata}
  * * {@link rxMetadata.directive:rxMeta rxMeta}
@@ -49,15 +77,15 @@ angular.module('encore.ui.rxMetadata', [])
  * <pre>
  * <rx-metadata>
  *   <section>
- *     <rx-meta label="fubar">
- *       out of working order; seriously, perhaps irreparably, damaged
+ *     <rx-meta label="Status">
+ *       degraded; system maintenance
  *     </rx-meta>
  *   </section>
  *   <section>
- *     <rx-meta label="Foo">Bar</rx-meta>
+ *     <rx-meta label="Field Name">Field Value Example</rx-meta>
  *   </section>
  *   <section>
- *     <rx-meta label="Bang">Biz</rx-meta>
+ *     <rx-meta label="Another Field Name">Another Field Value Example</rx-meta>
  *   </section>
  * </rx-metadata>
  * </pre>
@@ -97,8 +125,8 @@ angular.module('encore.ui.rxMetadata', [])
  * <pre>
  * <rx-metadata>
  *   <section>
- *     <rx-meta label="fubar">
- *       out of working order; seriously, perhaps irreparably, damaged
+ *     <rx-meta label="Status">
+ *       degraded; system maintenance
  *     </rx-meta>
  *   </section>
  * </rx-metadata>


### PR DESCRIPTION
Sprint 2: JIRA FRMW-154: https://jira.rax.io/browse/FRMW-154

- [x] Dev
- [x] Dev

I am migrating `rxMetadata` API Documentation in README to API docs.  `metadata` is deprecated.