### PR TITLE
docs(rxAuth): FRMW-163-Migrate rxAuth to API Docs

### DIFF
--- a/src/rxAuth/README.md
+++ b/src/rxAuth/README.md
@@ -1,3 +1,3 @@
 [![unstable](http://badges.github.io/stability-badges/dist/unstable.svg)](http://github.com/badges/stability-badges)
 
-Auth service which provides a common mechanism authenticating, validating permissions and managing sessions.
+The `rxAuth` component provides logic for authenticating, validating permissions, and managing sessions.

--- a/src/rxAuth/rxAuth.js
+++ b/src/rxAuth/rxAuth.js
@@ -4,8 +4,8 @@
  * @description
  * # rxAuth Component
  *
- * [TBD]
- *
+ * The `rxAuth` component provides logic for authenticating, validating permissions, and managing sessions.
+ * 
  * ## Services
  * * {@link rxAuth.service:Auth Auth}
  */


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-163

- [x] Dev
- [x] Dev

Migrate `rxAuth` to API Documentation