### PR TITLE
chore(rxBatchActions): #1244 Add midways, exercises and page-objects

### DIFF
--- a/src/rxBulkSelect/docs/rxBulkSelect.midway.js
+++ b/src/rxBulkSelect/docs/rxBulkSelect.midway.js
@@ -14,7 +14,7 @@ describe('rxBulkSelect', function () {
             get: function () {
                 return $('rx-modal-action#selectDatacenters a');
             }
-        },
+        }
 
     });
 
@@ -22,13 +22,16 @@ describe('rxBulkSelect', function () {
         demoPage.go('#/components/rxBulkSelect');
     });
 
-    describe('exercises', encore.exercise.rxBulkSelect());
+    describe('exercises', encore.exercise.rxBulkSelect({
+        batchActions: ['Shutdown Selected Datacenters']
+    }));
 
     describe('rxBulkSelectValidate', function () {
 
-        var validateModal;
+        var bulkSelect, validateModal;
 
         beforeEach(function () {
+            bulkSelect = encore.rxBulkSelect.main;
             validateModal = encore.rxModalAction.initialize();
         });
 
@@ -41,7 +44,6 @@ describe('rxBulkSelect', function () {
             page.selectFirst();
             expect(validateModal.canSubmit()).to.eventually.be.true;
         });
-
     });
 
 });

--- a/src/rxBulkSelect/rxBulkSelect.exercise.js
+++ b/src/rxBulkSelect/rxBulkSelect.exercise.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
    @exports encore.exercise.rxBulkSelect
    @param {Object} [options=] - Test options. Used to build valid tests.
    @param {rxBulkSelect} [options.instance=] - Component to exercise.
+   @param {string[]} [options.batchActions] - List of batch actions to exercise, will not run exercises if empty.
    @param {number} [options.count=10] - Number of items in the table.
    @param {string} [options.cssSelector=] - DEPRECATED: Fallback selector string to initialize widget with.
    @example
@@ -21,7 +22,8 @@ exports.rxBulkSelect = function (options) {
     }
 
     options = _.defaults(options, {
-        count: 10
+        count: 10,
+        batchActions: []
     });
 
     return function () {
@@ -99,5 +101,40 @@ exports.rxBulkSelect = function (options) {
             expect(component.isEnabled()).to.eventually.be.false;
         });
 
+        if (options.batchActions.length > 0) {
+            it('should have a batch actions menu', function () {
+                expect(component.batchActions.isPresent()).to.eventually.be.true;
+            });
+
+            it('should disable the batch actions menu when no items selected', function () {
+                expect(component.batchActions.isEnabled()).to.eventually.be.false;
+            });
+
+            it('should enable the batch actions menu when an item is selected', function () {
+                component.row(0).select();
+                expect(component.batchActions.isEnabled()).to.eventually.be.true;
+            });
+
+            it('should expand the batch action menu when clicked', function () {
+                component.batchActions.expand();
+                expect(component.batchActions.isExpanded()).to.eventually.be.true;
+            });
+
+            it('should have the correct number of batch actions', function () {
+                expect(component.batchActions.actionCount()).to.eventually.eql(options.batchActions.length);
+            });
+
+            _.each(options.batchActions, function (action) {
+                it('should have the batch action "' + action + '"', function () {
+                    expect(component.batchActions.hasAction(action)).to.eventually.be.true;
+                });
+
+                it('should be able to open the modal for batch action "' + action + '"', function () {
+                    var modal = component.batchActions.action(action).openModal();
+                    expect(modal.isDisplayed()).to.eventually.be.true;
+                    modal.close();
+                });
+            });
+        }
     };
 };

--- a/src/rxBulkSelect/rxBulkSelect.page.js
+++ b/src/rxBulkSelect/rxBulkSelect.page.js
@@ -5,8 +5,43 @@ var Page = require('astrolabe').Page;
 /**
    @namespace
  */
+
 var rxBulkSelectDefaultRowFn = function (rowElement) {
     return exports.rxCheckbox.initialize(rowElement.$('input[type="checkbox"]'));
+};
+
+var rxBatchActionMenu = function (rootElement) {
+    var actionMenu = exports.rxActionMenu.initialize(rootElement);
+
+    // Need to override several properties styles and the ng-hide attribute
+    // compared to what is seen in rxActionMenu.
+    Object.defineProperties(actionMenu, {
+        'isExpanded': {
+            value: function () {
+                return rootElement.$('.batch-action-menu-container')
+                    .getAttribute('class').then(function (className) {
+                        return className.indexOf('ng-hide') === -1;
+                });
+            }
+        },
+        'icoCog': {
+            get: function () {
+                return rootElement.$('.fa-cogs');
+            }
+        },
+        'isEnabled': {
+            value: function () {
+                return rootElement.$('.btn-link.header-button').isEnabled();
+            }
+        },
+        'isPresent': {
+            value: function () {
+                return rootElement.isPresent();
+            }
+        }
+    });
+
+    return actionMenu;
 };
 
 var rxBulkSelect = {
@@ -26,6 +61,12 @@ var rxBulkSelect = {
             return this.rootElement.element(
                 by.cssContainingText('.btn-link', 'Batch Actions')
             ).isEnabled();
+        }
+    },
+
+    batchActions: {
+        get: function () {
+            return rxBatchActionMenu(this.rootElement.$('rx-batch-actions'));
         }
     },
 

--- a/src/rxBulkSelect/templates/rxBatchActions.html
+++ b/src/rxBulkSelect/templates/rxBatchActions.html
@@ -1,4 +1,4 @@
-<ul class="actions-area pull-right">
+<ul class="batch-actions-area pull-right">
     <li class="msg-info-blue">
         <button class="btn-link header-button" ng-click="toggleBulkActions()" ng-disabled="!rowsSelected">
             <span tooltip="{{ rowsSelected ? '' : 'You must select one or more rows to use batch actions.' }}">


### PR DESCRIPTION
See issue #1244

I chose to implement the batch actions menu by wrapping rxActionMenu, as they seemed to have a lot of similar functionality, but it was necessary to override several properties of rxActionMenu.

I used a pattern similar to that used in rxModalAction, however in that case you could not override core functionality of rxModalAction, which I had need to do here.  It might be worth splitting this page object up, but I felt that was less dry and would necessitate more testing.


- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM