### PR TITLE
chore(bower): anchor to ng1.2.28

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,11 +6,11 @@
     "./encore-ui.css"
   ],
   "dependencies": {
-    "angular": "~1.2.27",
-    "angular-animate": "~1.2.27",
-    "angular-sanitize": "~1.2.27",
-    "angular-resource": "~1.2.27",
-    "angular-route": "~1.2.27",
+    "angular": "1.2.28",
+    "angular-animate": "1.2.28",
+    "angular-sanitize": "1.2.28",
+    "angular-resource": "1.2.28",
+    "angular-route": "1.2.28",
     "angular-bootstrap": "~0.12.0",
     "lodash": "~2.4.1",
     "momentjs": "~2.5.0",
@@ -20,7 +20,7 @@
     "ng-debounce": "0.1.5"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.26",
+    "angular-mocks": "1.2.28",
     "jquery": "2.0.3",
     "pure": "0.5.0"
   }


### PR DESCRIPTION
Pin to angular 1.2.28 for time being.  Something with 1.2.29 is causing all kinds of havoc with Travis and testing.