### PR TITLE
chore(rxFloatingHeader): add Y tolerance to midways

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -25,6 +25,7 @@ var config = {
     },
 
     onPrepare: function () {
+        browser.driver.manage().window().setSize(1366, 768); // laptop
         expect = require('chai').use(require('chai-as-promised')).expect;
         demoPage = require('./utils/demo.page.js');
         encore = require('./utils/rx-page-objects/index');

--- a/src/rxFloatingHeader/docs/rxFloatingHeader.midway.js
+++ b/src/rxFloatingHeader/docs/rxFloatingHeader.midway.js
@@ -1,11 +1,15 @@
-var rxFloatingHeader = encore.rxFloatingHeader;
-
 describe('rxFloatingHeader', function () {
     var table, tr, middleRow, middleRowY, initialY;
+    var yTolerance = 2; // +/- pixel tolerance for Y value comparison
+    var lower, upper;
+    var actual;
 
-    describe('One header row table', function () {
+    before(function () {
+        demoPage.go('#/components/rxFloatingHeader');
+    });
+
+    describe('Single-row header table', function () {
         before(function () {
-            demoPage.go('#/components/rxFloatingHeader');
             table = $('table[rx-floating-header].no-filter');
             tr = table.$('thead tr:first-of-type');
             middleRow = table.$('.middle-row');
@@ -19,18 +23,34 @@ describe('rxFloatingHeader', function () {
             expect(table.isDisplayed()).to.eventually.be.true;
         });
 
-        it('should float header after scrolling to middle of table', function () {
-            rxFloatingHeader.scrollToElement(middleRow);
-            expect(rxFloatingHeader.compareYLocations(tr, middleRowY)).to.eventually.be.true;
-        });
+        describe('after scrolling to middle of table', function () {
+            before(function () {
+                encore.rxMisc.scrollToElement(middleRow);
+            });
 
-        it('should put the header back when scrolling to the top', function () {
-            rxFloatingHeader.scrollToElement($('.page-titles'));
-            expect(rxFloatingHeader.compareYLocations(tr, initialY)).to.eventually.be.true;
-        });
-    });
+            it('should float header', function () {
+                actual = encore.rxMisc.transformLocation(tr, 'y');
+                lower = middleRowY - yTolerance;
+                upper = middleRowY + yTolerance;
+                expect(actual).to.eventually.be.within(lower, upper);
+            });
 
-    describe('Multi header row table', function () {
+            describe('after scrolling back to top', function () {
+                before(function () {
+                    encore.rxMisc.scrollToElement($('.page-titles'));
+                });
+
+                it('should put the header back', function () {
+                    actual = encore.rxMisc.transformLocation(tr, 'y');
+                    lower = initialY - yTolerance;
+                    upper = initialY + yTolerance;
+                    expect(actual).to.eventually.be.within(lower, upper);
+                });
+            });//after scrolling to top
+        });//after scrolling to middle
+    });//Single-row header table
+
+    describe('Multi-row header table', function () {
         var filterHeader, titlesHeader, initialFilterY, filterHeight, windowSize;
         var window = browser.driver.manage().window();
         var trs;
@@ -55,30 +75,49 @@ describe('rxFloatingHeader', function () {
             });
         });
 
-        it('should float the header after scrolling to middle of table', function () {
-            rxFloatingHeader.scrollToElement(middleRow);
-            expect(rxFloatingHeader.compareYLocations(filterHeader, middleRowY)).to.eventually.be.true;
-        });
+        describe('after scrolling to middle of table', function () {
+            before(function () {
+                encore.rxMisc.scrollToElement(middleRow);
+            });
 
-        it('should have the right distance between the float header and the middle of the table', function () {
-            expect(rxFloatingHeader.compareYLocations(titlesHeader, middleRowY + filterHeight)).to.eventually.be.true;
-        });
+            it('should float the header', function () {
+                actual = encore.rxMisc.transformLocation(filterHeader, 'y');
+                lower = middleRowY - yTolerance;
+                upper = middleRowY + yTolerance;
+                expect(actual).to.eventually.be.within(lower, upper);
+            });
 
-        it('should scroll to the first element when given an ElementArrayFinder', function () {
-            rxFloatingHeader.scrollToElement(trs);
-            expect(rxFloatingHeader.compareYLocations(filterHeader, initialFilterY)).to.eventually.be.true;
-        });
+            it('should have correct distance between float header and middle of table', function () {
+                actual = encore.rxMisc.transformLocation(titlesHeader, 'y');
+                lower = middleRowY + filterHeight - yTolerance;
+                upper = middleRowY + filterHeight + yTolerance;
+                expect(actual).to.eventually.be.within(lower, upper);
+            });
+        });//after scrolling to middle of table
 
-        it('should have the right distance between the title header and the initial starting point', function () {
-            expect(rxFloatingHeader.compareYLocations(titlesHeader, initialFilterY + filterHeight))
-                .to.eventually.be.true;
+        describe('when given an ElementArrayFinder', function () {
+            before(function () {
+                encore.rxMisc.scrollToElement(trs);
+            });
+
+            it('should scroll to the first element', function () {
+                actual = encore.rxMisc.transformLocation(filterHeader, 'y');
+                lower = initialFilterY - yTolerance;
+                upper = initialFilterY + yTolerance;
+                expect(actual).to.eventually.be.within(lower, upper);
+            });
+
+            it('should have correct distance between title header and initial starting point', function () {
+                actual = encore.rxMisc.transformLocation(titlesHeader, 'y');
+                lower = initialFilterY + filterHeight - yTolerance;
+                upper = initialFilterY + filterHeight + yTolerance;
+                expect(actual).to.eventually.be.within(lower, upper);
+            });
         });
 
         after(function () {
             // Return window to original size
             window.setSize(windowSize.width, windowSize.height);
         });
-
-    });
-
+    });//Multi-row header table
 });

--- a/src/rxFloatingHeader/rxFloatingHeader.page.js
+++ b/src/rxFloatingHeader/rxFloatingHeader.page.js
@@ -1,81 +1,46 @@
 /*jshint node:true*/
-var _ = require('lodash');
 
 /**
-   @exports encore.rxFloatingHeader
+ * @exports encore.rxFloatingHeader
  */
 exports.rxFloatingHeader = {
-
     /**
-       Accepts an ElementArrayFinder, which can have several locations. Should the
-       list of elements be stacked vertically (say, in a list of table rows),
-       the element with the smallest Y coordinate will be scrolled to.
-       @function
-       @param {WebElement} elem - An element, or a list of elements to scroll to
-       @returns {undefined}
-    */
+     * @deprecated Use rxMisc.scrollToElement
+     * @description
+     * **ALIASED**: Plese use {@link rxMisc.scrollToElement} instead.
+     * This function will be removed in a future release of the framework.
+     */
     scrollToElement: function (elem) {
-        return elem.getLocation().then(function (loc) {
-            if (_.isArray(loc)) {
-                loc = _.min(loc, 'y');
-            }
-
-            var command = ['window.scrollTo(0, ', loc.y.toString(), ');'].join('');
-            browser.executeScript(command);
-        });
+        return encore.rxMisc.scrollToElement(elem);
     },
 
     /**
-       @function
-       @param {WebElement} e1 - First element to compare Y locations against.
-       @param {WebElement} e2 - Second element to compare Y locations against.
-       @returns {Boolean} Whether or not `e1` and `e2` have the same Y coordinates.
+     * @deprecated Use rxMisc.compareYLocations
+     * @description
+     * **ALIASED**: Plese use {@link rxMisc.compareYLocations} instead.
+     * This function will be removed in a future release of the framework.
      */
     compareYLocations: function (e1, e2) {
-        return this.compareLocations(e1, e2, 'y');
+        return encore.rxMisc.compareYLocations(e1, e2);
     },
 
     /**
-       @function
-       @param {WebElement} e1 - First element to compare X locations against.
-       @param {WebElement} e2 - Second element to compare X locations against.
-       @returns {Boolean} Whether or not `e1` and `e2` have the same X coordinates.
-    */
-    compareXLocations: function (e1, e2) {
-        return this.compareLocations(e1, e2, 'x');
-    },
-
-    /**
-      Unify input from either a location object or a web element into a promise
-      representing the location attribute (x or y) of either input.
-      Both `transformLocation($('.element'), 'y')` and `transformLocation({x: 20, y: 0}, 'y')`
-      return a promise representing the y value of the resulting (or provided) location object.
-      @private
-    */
-    transformLocation: function (elementOrLocation, attribute) {
-        if (_.isFunction(elementOrLocation.getLocation)) {
-            var elem = elementOrLocation;
-            return elem.getLocation().then(function (loc) {
-                return loc[attribute];
-            });
-        } else {
-            var location = elementOrLocation;
-            if (_.has(location, attribute)) {
-                return protractor.promise.fulfilled(location[attribute]);
-            } else {
-                return protractor.promise.fulfilled(location);
-            }
-        }
-    },
-
-    /**
-       @private
+     * @deprecated Use rxMisc.compareXLocations
+     * @description
+     * **ALIASED**: Plese use {@link rxMisc.compareXLocations} instead.
+     * This function will be removed in a future release of the framework.
      */
-    compareLocations: function (e1, e2, attribute) {
-        var promises = [this.transformLocation(e1, attribute), this.transformLocation(e2, attribute)];
-        return protractor.promise.all(promises).then(function (locations) {
-            return locations[0] === locations[1];
-        });
-    }
+    compareXLocations: function (e1, e2) {
+        return encore.rxMisc.compareXLocations(e1, e2);
+    },
 
+    /**
+     * @deprecated Use rxMisc.transformLocation
+     * @description
+     * **ALIASED**: Plese use {@link rxMisc.transformLocation} instead.
+     * This function will be removed in a future release of the framework.
+     */
+    transformLocation: function (elementOrLocation, attribute) {
+        return encore.rxMisc.transformLocation(elementOrLocation, attribute);
+    }
 };

--- a/src/rxMisc/rxMisc.page.js
+++ b/src/rxMisc/rxMisc.page.js
@@ -1,4 +1,5 @@
 /*jshint node:true*/
+var _ = require('lodash');
 
 /**
  * @namespace
@@ -177,6 +178,86 @@ exports.rxMisc = {
                 return times;
             }
         });
-    }
+    },
 
+    /**
+     * Accepts an ElementArrayFinder, which can have several locations. Should the
+     * list of elements be stacked vertically (say, in a list of table rows),
+     * the element with the smallest Y coordinate will be scrolled to.
+     * @function
+     * @param {WebElement} elem An element, or a list of elements to scroll to
+     * @returns {undefined}
+     */
+    scrollToElement: function (elem) {
+        return elem.getLocation().then(function (loc) {
+            if (_.isArray(loc)) {
+                loc = _.min(loc, 'y');
+            }
+
+            var command = ['window.scrollTo(0, ', loc.y.toString(), ');'].join('');
+            browser.executeScript(command);
+        });
+    },
+
+    /**
+     * @function
+     * @param {WebElement} e1 First element to compare Y locations against.
+     * @param {WebElement} e2 Second element to compare Y locations against.
+     * @returns {Boolean} Whether or not `e1` and `e2` have the same Y coordinates.
+     */
+    compareYLocations: function (e1, e2) {
+        return this.compareLocations(e1, e2, 'y');
+    },
+
+    /**
+     * @function
+     * @param {WebElement} e1 First element to compare X locations against.
+     * @param {WebElement} e2 Second element to compare X locations against.
+     * @returns {Boolean} Whether or not `e1` and `e2` have the same X coordinates.
+     */
+    compareXLocations: function (e1, e2) {
+        return this.compareLocations(e1, e2, 'x');
+    },
+
+    /**
+     * @function
+     * @description
+     * Unify input from either a location object or a web element into a promise
+     * representing the location attribute (x or y) of either input.
+     * Both `transformLocation($('.element'), 'y')` and `transformLocation({x: 20, y: 0}, 'y')`
+     * return a promise representing the y value of the resulting (or provided) location object.
+     */
+    transformLocation: function (elementOrLocation, attribute) {
+        if (_.isFunction(elementOrLocation.getLocation)) {
+            var elem = elementOrLocation;
+            return elem.getLocation().then(function (loc) {
+                return loc[attribute];
+            });
+        } else {
+            var location = elementOrLocation;
+            if (_.has(location, attribute)) {
+                return protractor.promise.fulfilled(location[attribute]);
+            } else {
+                return protractor.promise.fulfilled(location);
+            }
+        }
+    },
+
+    /**
+     * @private
+     * @function
+     * @param {WebElement} e1 First element to compare locations against.
+     * @param {WebElement} e2 Second element to compare locations against.
+     * @param {String} attribute attribute to compare ('x' or 'y')
+     */
+    compareLocations: function (e1, e2, attribute) {
+        var promises = [
+            this.transformLocation(e1, attribute),
+            this.transformLocation(e2, attribute)
+        ];
+
+        return protractor.promise.all(promises).then(function (locations) {
+            return locations[0] === locations[1];
+        });
+    }
 };


### PR DESCRIPTION
Expanded upon #1229, to apply Y value tolerance to all checks.

> This isn't an issue on Travis, but when running tests locally, there is an issue where the floating header will be off by one pixel on higher resolution displays. This fix adds a tolerance around the location of the floating header during protractor tests to be +/- 2 pixels.

- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM