### PR TITLE
test(rxMisc): #1279 Round before parseInt in currencyToPennies

### DIFF
--- a/src/rxMisc/docs/rxMisc.midway.js
+++ b/src/rxMisc/docs/rxMisc.midway.js
@@ -116,10 +116,6 @@ describe('rxMisc', function () {
                 expect(fn('$0.01')).to.equal(1);
             });
 
-            it('should lose precision when converting a fraction of a penny to an int', function () {
-                expect(fn('$0.019')).to.equal(1);
-            });
-
             it('should ignore any dollar type indicators (CAN, AUS, USD)', function () {
                 expect(fn('$100 CAN')).to.equal(10000);
             });
@@ -134,6 +130,10 @@ describe('rxMisc', function () {
 
             it('should not incur any binary rounding errors', function () {
                 expect(fn('$1.10')).to.equal(110);
+            });
+
+            it('should not incur any binary rounding errors', function () {
+                expect(fn('$150.14')).to.equal(15014);
             });
         });
 

--- a/src/rxMisc/rxMisc.page.js
+++ b/src/rxMisc/rxMisc.page.js
@@ -44,7 +44,7 @@ exports.rxMisc = {
             resFloat = -resFloat;
         }
 
-        return parseInt(resFloat * 100, 10);
+        return parseInt(Math.round(resFloat * 100), 10);
     },
 
     /**


### PR DESCRIPTION
Attempt to fix #1279.

The rxMisc.page.js currencyToPennies function will sometimes `parseInt(15013.9999999999998)` when the expected result is 15014.

I removed the `it('should lose precision when converting a fraction of a penny to an int')` test case per @Droogans suggestion.