### PR TITLE
test(rxMisc): Remove a test and update currencyToPennies ngdoc

### DIFF
--- a/src/rxMisc/docs/rxMisc.midway.js
+++ b/src/rxMisc/docs/rxMisc.midway.js
@@ -124,10 +124,6 @@ describe('rxMisc', function () {
                 expect(fn('($100 AUS)')).to.equal(-10000);
             });
 
-            it('should lose precision when converting negative fractions of a penny to an int', function () {
-                expect(fn('($1.011)')).to.equal(-101);
-            });
-
             it('should not incur any binary rounding errors', function () {
                 expect(fn('$1.10')).to.equal(110);
             });

--- a/src/rxMisc/rxMisc.page.js
+++ b/src/rxMisc/rxMisc.page.js
@@ -22,17 +22,14 @@ exports.rxMisc = {
     /**
      * @description
      * Transform `currencyString` (USD) to an integer representing pennies. Built to reverse
-     * Angular's 'currency' filter. If your currency string includes fractions of a penny,
-     * that precision will be lost!
+     * Angular's 'currency' filter. Do not pass in fractions of a penny.
      * @param {string} currencyString - Raw text as output by Angular's `currency` filter.
      *
      * @example
      * ```js
      * encore.rxMisc.currencyToPennies('$0.01')      ==  1
-     * encore.rxMisc.currencyToPennies('$0.019')     ==  1
      * encore.rxMisc.currencyToPennies('$100 CAN')   ==  10000
      * encore.rxMisc.currencyToPennies('($100 AUS)') == -10000
-     * encore.rxMisc.currencyToPennies('($1.011)')   == -101
      * encore.rxMisc.currencyToPennies('$1.10')      ==  110
      * ```
      */


### PR DESCRIPTION
I forgot to update the ngdoc for currencyToPennies in my last commit. Oops!

Also removed an irrelevant test since we're now saying currencyToPennies should not be passed fractions of a penny.