### PR TITLE
fix(rxTags): midway revert and workaround

### DIFF
--- a/src/rxTags/rxTags.page.js
+++ b/src/rxTags/rxTags.page.js
@@ -98,8 +98,19 @@ var rxTags = {
 
     sendBackspace: {
         value: function () {
-            this.txtNewTag.click();
-            this.txtNewTag.sendKeys(protractor.Key.BACK_SPACE);
+            /*
+             * Protractor isn't properly trapping the `BACK_SPACE = navigate back`
+             * functionality so we have to use SHIFT + BACK_SPACE as a workaround.
+             *
+             * Initially, changing ng-keydown to ng-keypress in the template seemed
+             * to work, but this only corrected the issue with Firefox. Chrome doesn't
+             * seem to recognize ng-keypress functionality.
+             */
+            var chordBackspace = protractor.Key.chord(
+                protractor.Key.SHIFT,
+                protractor.Key.BACK_SPACE
+            );
+            this.txtNewTag.sendKeys(chordBackspace);
         }
     },
 

--- a/src/rxTags/templates/rxTags.html
+++ b/src/rxTags/templates/rxTags.html
@@ -1,7 +1,7 @@
 <div class="rx-tags" ng-click="focusInput($event)">
     <div class="tag"
         ng-repeat="tag in tags track by tag.text"
-        ng-keypress="removeIfBackspace($event, tag)"
+        ng-keydown="removeIfBackspace($event, tag)"
         tabindex="{{ disabled ? '' : 0 }}">
         <i class="fa fa-tag"></i>
         <span class="text">{{tag.text}}</span>
@@ -11,7 +11,7 @@
     <input type="text"
         placeholder="{{ disabled ? '' : 'Enter a tag' }}"
         ng-model="newTag"
-        ng-keypress="focusTag($event, newTag)"
+        ng-keydown="focusTag($event, newTag)"
         ng-disabled="disabled"
         typeahead="tag as tag.text for tag in options | xor:tags | filter:{text: $viewValue}"
         typeahead-on-select="add(newTag)" />


### PR DESCRIPTION
* revert template back to `ng-keydown` (b/c Chrome doesn't work with `ng-keypress`)
* use protractor chord (SHIFT + BACK_SPACE) to workaround weirdness
* without this correction, rxTags will NOT work on Chrome

### LGTMS

- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM