### PR TITLE
test(rxMisc): #1234 Modify currencyToPennies to accept an array too

### DIFF
--- a/src/rxMisc/docs/rxMisc.midway.js
+++ b/src/rxMisc/docs/rxMisc.midway.js
@@ -131,6 +131,11 @@ describe('rxMisc', function () {
             it('should not incur any binary rounding errors', function () {
                 expect(fn('$150.14')).to.equal(15014);
             });
+
+            it('should convert an array of currencies to an array of pennies', function () {
+                expect(fn(['$0.01', '$100 CAN', '($100 AUS)', '$1.10', '$150.14']))
+                    .to.eql([1, 10000, -10000, 110, 15014]);
+            });
         });
 
         describe('unless', function () {

--- a/src/rxMisc/rxMisc.page.js
+++ b/src/rxMisc/rxMisc.page.js
@@ -22,27 +22,38 @@ exports.rxMisc = {
 
     /**
      * @description
-     * Transform `currencyString` (USD) to an integer representing pennies. Built to reverse
-     * Angular's 'currency' filter. Do not pass in fractions of a penny.
-     * @param {string} currencyString - Raw text as output by Angular's `currency` filter.
+     * Transform `currencyStringOrArray` (USD) to an integer representing pennies or an array of integers representing
+     * pennies. Built to reverse Angular's 'currency' filter. Do not pass in fractions of a penny because it will be
+     * rounded with Math.round() which doesn't use bankers' rounding for negative numbers.
+     * @param {string|array<string>} currencyStringOrArray - Raw text or an array of raw texts as output by Angular's
+     * `currency` filter.
      *
      * @example
      * ```js
-     * encore.rxMisc.currencyToPennies('$0.01')      ==  1
-     * encore.rxMisc.currencyToPennies('$100 CAN')   ==  10000
+     * encore.rxMisc.currencyToPennies('$0.01') == 1
+     * encore.rxMisc.currencyToPennies('$100 CAN') == 10000
      * encore.rxMisc.currencyToPennies('($100 AUS)') == -10000
-     * encore.rxMisc.currencyToPennies('$1.10')      ==  110
+     * encore.rxMisc.currencyToPennies('$1.10') == 110
+     * encore.rxMisc.currencyToPennies(['$0.01', '($100 AUS)', '$150.14']) == [1, -10000, 15014]
      * ```
      */
-    currencyToPennies: function (currencyString) {
-        var resFloat = parseFloat(currencyString.split(' ')[0].replace(/[,$()]/g, '').trim());
+    currencyToPennies: function (currencyStringOrArray) {
+        var convert = function (currencyString) {
+            var resFloat = parseFloat(currencyString.split(' ')[0].replace(/[,$()]/g, '').trim());
 
-        // Negative number
-        if (currencyString.indexOf('(') > -1 && currencyString.indexOf(')') > -1) {
-            resFloat = -resFloat;
+            // Negative number
+            if (currencyString.indexOf('(') > -1 && currencyString.indexOf(')') > -1) {
+                resFloat = -resFloat;
+            }
+
+            return parseInt(Math.round(resFloat * 100), 10);
+        };
+
+        if (typeof currencyStringOrArray === 'string') {
+            return convert(currencyStringOrArray);
+        } else if (Array.isArray(currencyStringOrArray)) {
+            return _.map(currencyStringOrArray, convert);
         }
-
-        return parseInt(Math.round(resFloat * 100), 10);
     },
 
     /**


### PR DESCRIPTION
For #1234 

The rxMisc.page.currencyToPennies function can now accept an array of currencies. It still works with a single currency so it's backwards compatible.

### LGTMS

- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM