### PR TITLE
fix(z_index): FRMW-66-Bug-fix-rxFloatingHeader

### DIFF
--- a/src/rxFloatingHeader/rxFloatingHeader.less
+++ b/src/rxFloatingHeader/rxFloatingHeader.less
@@ -28,3 +28,9 @@ th.filter-header {
 tr.rx-floating-header:not(.rx-table-filter-row) {
     z-index: 2;
 }
+
+// Added to accommodate dropdown boxes to display "on top" of rx-floating-header 
+// components 
+thead .rx-floating-header:first-child {
+    z-index: 3;
+}


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-66 - BUG: z-index for rxSelectFilter is behind rxFloatingHeader

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM 

Added a `z-index` criteria for `rxFloatingHeader`