### PR TITLE
test(rxLocalStorage): Fix failing array of objects test

### DIFF
--- a/src/rxLocalStorage/docs/rxLocalStorage.midway.js
+++ b/src/rxLocalStorage/docs/rxLocalStorage.midway.js
@@ -44,8 +44,7 @@ describe('rxLocalStorage', function () {
         expect(rxLocalStorage.getItem('anObject')).to.eventually.deep.equal(anObject);
     });
 
-    // FIXME: Travis fails on this test for some reason. (see JIRA FRMW-240)
-    it.skip('should set and return an array of objects', function () {
+    it('should set and return an array of objects', function () {
         var anArrayOfObjects = [
             {
                 'foo': {

--- a/src/rxLocalStorage/rxLocalStorage.page.js
+++ b/src/rxLocalStorage/rxLocalStorage.page.js
@@ -5,9 +5,9 @@ exports.rxLocalStorage = Page.create({
     setItem: {
         value: function (key, value) {
             var command = function (key, value) {
-                localStorage.setItem(key, JSON.stringify(value));
+                localStorage.setItem(key, value);
             };
-            this.driver.executeScript(command, key, value);
+            this.driver.executeScript(command, key, JSON.stringify(value));
         }
     },
 


### PR DESCRIPTION
Jira: https://jira.rax.io/browse/FRMW-240

Fixed failing rxLocalStorage test ("should set and return an array of objects") that we had to .skip() about 2 weeks ago.

Note: I don't know WHY this fixes the problem.

* [x] DEV LGTM
* [x] QE LGTM