### PR TITLE
fix(z_index): FRMW-312-z-index-error

### DIFF
--- a/src/rxApp/rxApp.less
+++ b/src/rxApp/rxApp.less
@@ -481,7 +481,7 @@
 
         & > .rx-notifications {
             position:fixed;
-            z-index: 5;
+            z-index: 20;  // accommodate rxSelect .fake-select class
             top: 0px;
             left: 300px;
             right: 100px;


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-312 - BUG: z-index rxNotification

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

---
Removed `z-index` property from `.fake-select` class, which was setting the class above the `rxNotification` component. 