### PR TITLE
fix(css): FRMW-421-Remove deprecated .title from rxActionMenu

### DIFF
--- a/src/rxActionMenu/docs/rxActionMenu.html
+++ b/src/rxActionMenu/docs/rxActionMenu.html
@@ -3,7 +3,7 @@
     by clicking on the cog itself.
     </p>
 
-    <h3 class="title">Typical Usage</h3>
+    <h3 id="typical-usage">Typical Usage</h3>
     <table>
         <thead>
             <tr>

--- a/src/rxActionMenu/docs/rxActionMenu.midway.js
+++ b/src/rxActionMenu/docs/rxActionMenu.midway.js
@@ -19,7 +19,7 @@ describe('rxActionMenu', function () {
     };
 
     var clickSomewhereElse = function () {
-        $('.component-demo .title').click();
+        $('#typical-usage').click();
     };
 
     before(function () {


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-421

- [x] Dev LGTM
- [x] Dev LGTM

---
Remove deprecated CSS `.title` class from `rxActionMenu`.