### PR TITLE
refactor(various): refactor for future compatibility

### DIFF
--- a/grunt-tasks/options/watch.js
+++ b/grunt-tasks/options/watch.js
@@ -3,36 +3,78 @@ module.exports = {
         livereload: 1337
     },
     scripts: {
-        files: ['src/**/*.js', '!src/*/*.spec.js', '!src/**/*.midway.js',
-                '!src/**/*.page.js', '!src/**/*.exercise.js'],
-        tasks: ['build', 'karma:watch:run']
+        files: [
+            'src/**/*.js',
+            '!src/**/*.spec.js',
+            '!src/**/*.midway.js',
+            '!src/**/*.page.js',
+            '!src/**/*.exercise.js'
+        ],
+        tasks: [
+            'build',
+            'karma:watch:run'
+        ]
     },
     specs: {
-        files: ['src/**/*.spec.js'],
-        tasks: ['karma:watch:run', 'copy:coverage'],
+        files: [
+            'src/**/*.spec.js'
+        ],
+        tasks: [
+            'karma:watch:run',
+            'copy:coverage'
+        ],
         options: {
             livereload: false
         }
     },
     componentHtml: {
-        files: ['src/**/templates/*.html'],
-        tasks: ['html2js', 'build', 'karma:watch:run']
+        files: [
+            'src/**/templates/*.html'
+        ],
+        tasks: [
+            'html2js',
+            'build',
+            'karma:watch:run'
+        ]
     },
     componentLess: {
-        files: ['src/**/*.less'],
-        tasks: ['concat:tmpLess', 'less']
+        files: [
+            'src/**/*.less'
+        ],
+        tasks: [
+            'concat:tmpLess',
+            'less'
+        ]
     },
     componentImages: {
-        files: ['src/**/images/*'],
-        tasks: ['imagemin']
+        files: [
+            'src/**/images/*'
+        ],
+        tasks: [
+            'imagemin'
+        ]
     },
     demoSite: {
-        files: ['src/**/docs/*.html', 'src/**/*.md', 'demo/**/*', '!demo/bower_components/**/*'],
-        tasks: ['build']
+        files: [
+            'src/**/docs/*.html',
+            'src/**/*.md',
+            'demo/**/*',
+            '!demo/bower_components/**/*'
+        ],
+        tasks: [
+            'build'
+        ]
     },
     rxPageObjects: {
-        files: ['src/**/*.page.js', 'src/**/*.exercise.js'],
-        tasks: ['concat:rxPageObjects', 'concat:rxPageObjectsExercises',
-                'jsdoc2md:rxPageObjects', 'shell:rxPageObjectsDemoDocs']
+        files: [
+            'src/**/*.page.js',
+            'src/**/*.exercise.js'
+        ],
+        tasks: [
+            'concat:rxPageObjects',
+            'concat:rxPageObjectsExercises',
+            'jsdoc2md:rxPageObjects',
+            'shell:rxPageObjectsDemoDocs'
+        ]
     }
 };

--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.js
@@ -2,7 +2,7 @@
 angular.module('demoApp')
 .controller('rxBreadcrumbsCtrl', function ($scope, rxBreadcrumbsSvc) {
     rxBreadcrumbsSvc.set([{
-        path: '/',
+        path: '/#/components',
         name: 'Components',
     }, {
         name: '<strong>All Components</strong>',

--- a/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
+++ b/src/rxBreadcrumbs/docs/rxBreadcrumbs.midway.js
@@ -110,17 +110,19 @@ describe('rxBreadcrumbs', function () {
 
         it('should have an href property', function () {
             expect(middle.isLink()).to.eventually.be.true;
-            expect(middle.href).to.eventually.equal(browser.baseUrl + '/');
+            expect(middle.href).to.eventually.equal(browser.baseUrl + '/#/components');
         });
 
         it('should visit the correct page when clicking on the breadcrumb', function () {
-            var homeHref = browser.baseUrl + '/#/overview';
+            var componentsHref = browser.baseUrl + '/#/components';
 
             middle.visit();
-            expect(browser.getCurrentUrl()).to.eventually.equal(homeHref);
+            expect(browser.getCurrentUrl()).to.eventually.equal(componentsHref);
         });
-        // Note that after this test, we are now at the /#/overview page
 
+        after(function () {
+            demoPage.go('#/components/rxBreadcrumbs');
+        });
     });
 
     describe('default breadcrumbs', function () {

--- a/src/rxBulkSelect/scripts/rxBatchActions.js
+++ b/src/rxBulkSelect/scripts/rxBatchActions.js
@@ -61,7 +61,7 @@ angular.module('encore.ui.rxBulkSelect')
             };
             rxBulkSelectCtrl.registerForNumSelected(numSelectedChange);
 
-            if (!_.isUndefined(rxFloatingHeaderCtrl)) {
+            if (_.isObject(rxFloatingHeaderCtrl)) {
                 // When rxBatchActions lives inside of an rxFloatingHeader enabled table,
                 // the element will be cloned by rxFloatingHeader. The issue is that a normal
                 // .clone() does not clone Angular bindings, and thus the cloned element doesn't

--- a/src/rxOptionTable/docs/rxOptionTable.midway.js
+++ b/src/rxOptionTable/docs/rxOptionTable.midway.js
@@ -23,7 +23,7 @@ describe('rxOptionTable', function () {
         }));
 
         describe('empty table', encore.exercise.rxOptionTable({
-            cssSelector: '#emptyOptionTable',
+            instance: encore.rxOptionTable.initialize($('#emptyOptionTable')),
             visible: true,
             empty: true
         }));

--- a/src/rxOptionTable/templates/rxOptionTable.html
+++ b/src/rxOptionTable/templates/rxOptionTable.html
@@ -20,9 +20,8 @@
       <td class="option-table-input">
         <div class="fillWrapper">
           <label ng-switch="type">
-            <div class="alignWrapper">
+            <div class="alignWrapper" ng-switch-when="radio">
               <input rx-radio
-                 ng-switch-when="radio"
                  id="{{fieldId}}_{{$index}}"
                  ng-model="$parent.$parent.model"
                  value="{{row.value}}"
@@ -30,9 +29,9 @@
                  class="option-input"
                  ng-disabled="checkDisabled(row)"
                  rx-attributes="{'ng-required': required}">
-
+            </div>
+            <div class="alignWrapper" ng-switch-when="checkbox">
               <input rx-checkbox
-                 ng-switch-when="checkbox"
                  id="{{fieldId}}_{{$index}}"
                  class="option-input"
                  ng-checked="$parent.modelProxy[$index]"

--- a/src/rxSearchBox/rxSearchBox.js
+++ b/src/rxSearchBox/rxSearchBox.js
@@ -76,7 +76,7 @@ angular.module('encore.ui.rxSearchBox', [])
         },
         link: function (scope, element, attrs, controllers) {
             var rxFloatingHeaderCtrl = controllers[1];
-            if (!_.isUndefined(rxFloatingHeaderCtrl)) {
+            if (_.isObject(rxFloatingHeaderCtrl)) {
                 rxFloatingHeaderCtrl.update();
             }
         }


### PR DESCRIPTION
Backporting refactor work added in `ng1.3` branch. Should still be ng1.2 compatible.

* readability updated for `watch` config
* corrected rxBreadcrumbs demo/midway
* refactor rxOptionTable template to have `ng-switch-when` on wrapper elements
* refactor rxOptionTable to be compatible with ng1.3
* refactor rxBulkSelect to be compatible with ng1.3
* refactor rxSearchBox to be compatbile with ng1.3

### LGTMS
- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM