### PR TITLE
style(colors): FRMW-322 Buttons/Actions

### DIFF
--- a/demo/assets/generated_demo.css
+++ b/demo/assets/generated_demo.css
@@ -136,7 +136,7 @@ pre code {
   background-color: #ffecb3;
 }
 .palette.orange .color.secondary-700 {
-  background-color: #ff8f00;
+  background-color: #d14904;
 }
 .palette.orange .color.accent {
   background-color: #ffd740;

--- a/src/rxApp/rxApp.less
+++ b/src/rxApp/rxApp.less
@@ -522,12 +522,12 @@
 .link-disabled {
   pointer-events: none;
   a {
-    color: #d5d3d3;
+    color: @gray-300;
   }
   .rx-spinner {
     margin-left: 10px;
-    border-bottom-color: #d5d3d3;
-    border-right-color: #d5d3d3;
+    border-bottom-color: @gray-300;
+    border-right-color: @gray-300;
   }
 }
 

--- a/src/rxButton/rxButton.less
+++ b/src/rxButton/rxButton.less
@@ -197,7 +197,7 @@ thead th .btn-link {
     flex: 1;
     text-align: center;
     padding: 7px 13px;
-    color: #989998;
+    color: @gray-700;
 
     &:first-of-type {
       border-top-left-radius: @buttonGroupBorderRadius;
@@ -223,6 +223,6 @@ thead th .btn-link {
 
   input:checked + label {
     color: @white;
-    background: #757575;
+    background: @gray-700;
   }
 }//.button-group

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -21,7 +21,7 @@
 // ## Oranges
 @orange-100: #ffecb3;
 @orange-500: #ffc107;
-@orange-700: #ff8f00;
+@orange-700: #d14904;
 @orange-accent: #ffd740;
 
 // ## Purples
@@ -76,19 +76,19 @@
 @tableRowSelected: #c6e4c8;
 
 // ## Buttons
-@optionHighlightBg: #007bff;
+@optionHighlightBg: @blue-500;
 @buttonColor: @white;
-@buttonColorDisabled: #f0efef;
-@buttonDefaultBg: #427fc4;
+@buttonColorDisabled: @gray-600;
+@buttonDefaultBg: @blue-700;
 @buttonDefaultBgHover: lighten(@buttonDefaultBg, 10%);
-@buttonPositiveBg: #16b667;
+@buttonPositiveBg: @green-700;
 @buttonPositiveBgHover: lighten(@buttonPositiveBg, 6%);
-@buttonNegativeBg: #cc0000;
+@buttonNegativeBg: @red-700;
 @buttonNegativeBgHover: lighten(@buttonNegativeBg, 10%);
-@buttonCancelBg: @cancel-gray;
+@buttonCancelBg: @gray-700;
 @buttonCancelBgHover: lighten(@buttonCancelBg, 10%);
-@buttonDisabledBg: #cfd2d4;
-@buttonSpinnerBg: @buttonColor;
+@buttonDisabledBg: @gray-300;
+@buttonSpinnerBg: @buttonColor; //Is this correct for ellipse Background?
 
 
 // # Borders
@@ -115,13 +115,13 @@
 @menuLinkLightBlue: #97b1d0;
 @menuLinkOrange: #ffa61b;
 @menuRed: #f37a7c;
-@warnRed: #eb2124;
+@warnRed: @red-700;
 @warnRedHover: saturate(@warnRed, 15%);
-@actionGreen: #3ab661;
+@actionGreen: @green-700;
 @actionGreenHover: saturate(@actionGreen, 15%);
-@infoOrange: #dd7800;
+@infoOrange: @orange-700;
 @infoOrangeHover: saturate(@infoOrange, 15%);
-@infoBlue: #4580c2;
+@infoBlue: @blue-700;
 @infoBlueHover: saturate(@infoBlue, 15%);
 
 // # PreProd warnings


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-322

- [x] Dev LGTM
- [ ] Dev LGTM
- [x] Design LGTM

@glynnis  I have updated these screenshots to reflect my changes from my recent commit.

**Buttons**
Before:
![01_before-01](https://cloud.githubusercontent.com/assets/14296817/11102739/057d1ede-8884-11e5-8428-7d25f7cfdd7b.png)

After:
![01_after-01](https://cloud.githubusercontent.com/assets/14296817/11102742/0580a310-8884-11e5-9ae8-3893fa476ced.png)

**Button Types**
Before:
![01_before-02](https://cloud.githubusercontent.com/assets/14296817/11102744/0580cb38-8884-11e5-820c-120d6c9fdc0f.png)

After: 
![01_after-02](https://cloud.githubusercontent.com/assets/14296817/11102741/058066ac-8884-11e5-83b0-46148e908abd.png)
@glynnis I think the red from before was a richer Red.

**Button With Animation**
Before:
![01_before-03](https://cloud.githubusercontent.com/assets/14296817/11102740/057d8590-8884-11e5-9f08-4f3228b8a18b.png)

After:
![01_after-03](https://cloud.githubusercontent.com/assets/14296817/11102743/0580d0c4-8884-11e5-9850-54b338c0ea10.png)

**Button Groups**
Before:
![02_before](https://cloud.githubusercontent.com/assets/14296817/11102748/058afb12-8884-11e5-9636-bfb0557325b6.png)

After:
![02_after](https://cloud.githubusercontent.com/assets/14296817/11102747/0589efd8-8884-11e5-8923-9ac49cac9580.png)

**Action Links**
Before:
![03_before](https://cloud.githubusercontent.com/assets/14296817/11102750/058e52d0-8884-11e5-8f2f-f72e54d33359.png)

After:
![03_after](https://cloud.githubusercontent.com/assets/14296817/11102746/058a1dc8-8884-11e5-9a0c-01d584183266.png)
@glynnis The Orange and Reds are hard to distinguish. Should we try converting the red back to its previous #cc0000?

**Action Link Colors**
Before:
![04_before](https://cloud.githubusercontent.com/assets/14296817/11102749/058ca714-8884-11e5-8b75-c8e2761a7d18.png)

After:
![04_after](https://cloud.githubusercontent.com/assets/14296817/11102751/058ef852-8884-11e5-8d2c-2d30d1889bae.png)


**Spinners with Action Links**
Before:
![05_before](https://cloud.githubusercontent.com/assets/14296817/11102753/05977a04-8884-11e5-9811-5a6ccdc7555e.png)

After:
![05_after_contrast-trouble](https://cloud.githubusercontent.com/assets/14296817/11102752/059473f4-8884-11e5-9230-cd8cc0335806.png)
@glynnis This is following the disabled gray that Eric and I establish for the disabled buttons, but is has a worse contrast on white background. Should we try a different gray for this scenario?