### PR TITLE
chore(npm): fix broken package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "~0.7.0",
     "grunt-contrib-cssmin": "~0.11.0",
-    "grunt-contrib-imagemin": "^0.9.2",
+    "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-uglify": "~0.7.0",


### PR DESCRIPTION
Yet another random NPM module updated upstream and caused Travis builds to break.

Correct broken package and shrinkwrap dependencies to prevent this from happening again.

### LGTMs
- [x] Dev LGTM
- [x] Dev LGTM