### PR TITLE
style(rxTags): FRMW-328 Update rxTags To Color 2.0

### DIFF
--- a/src/rxTags/rxTags.less
+++ b/src/rxTags/rxTags.less
@@ -37,13 +37,13 @@ rx-tags {
     line-height: @rxTag-height;
     border-radius: @rxTag-height / 2;
     vertical-align: top;
-    background-color: #e0e0e0;
+    background-color: @gray-300;
     &:hover {
       cursor: default;
     }
 
     &:focus {
-      background-color: #007bff;
+      background-color: @blue-700;
       outline: none;
       .fa,
       .text,
@@ -59,27 +59,30 @@ rx-tags {
     .text {
       font-size: 12px;
       margin: 0 7px 0 10px;
-      color: #727272;
+      color: @gray-800;
     }
 
     .category {
       font-size: 10px;
       margin-right: 20px;
-      color: #878787;
+      color: @gray-800;
     }
 
     .fa-tag {
       margin-left: @rxTag-height / 2;
-      color: #999999;
+      color: @gray-600;
     }
 
     .fa-times {
       margin-right: @rxTag-height / 2;
-      color: #b8b8b8;
+      color: @gray-600;
       &:hover {
         cursor: pointer;
-        color: @warnRedHover;
+        color: @gray-800;
       }
     }
+  }
+  .tag:focus .fa-times:hover {
+    color: @white;
   }
 }


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-328

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

Images have been updated to reflect the most recent commit.

### rxTags
#### Before:
Showing the Previous Colors
![01_before_rxtags](https://cloud.githubusercontent.com/assets/14296817/11079440/09afb96a-87d2-11e5-91cc-5fecfb2a78cd.png)

#### Before:
(Includes tota11y) Color Contrast Ratios
![01_before_rxtags-with-color-contrast](https://cloud.githubusercontent.com/assets/14296817/11079439/09af1bea-87d2-11e5-8ca7-811f8766ef8c.png)

#### After:
I used the recommended colors from Zhen, but had to change some of the matches to get a good color ratio contrast as shown.
![02_after_rxtags](https://cloud.githubusercontent.com/assets/14296817/11079441/09b13cea-87d2-11e5-8ac9-75802482e87b.png)

### Focus State
#### Before:
![03_before_focus](https://cloud.githubusercontent.com/assets/14296817/11155918/3680e5ca-8a0e-11e5-99bf-722150afbb97.png)

#### After:
![04_after_focus](https://cloud.githubusercontent.com/assets/14296817/11155919/368243ca-8a0e-11e5-998e-deb26dcfcc13.png)

### Close Icon
#### Before:
![05_before_close](https://cloud.githubusercontent.com/assets/14296817/11155939/4a9f701c-8a0e-11e5-8478-31d85dd3b65a.png)

#### After:
##### On Load
![08_tag-on-load](https://cloud.githubusercontent.com/assets/14296817/11225578/9fdc510a-8d40-11e5-89ce-30ac7293d1b8.png)

##### Hover State
![08_tag-hover](https://cloud.githubusercontent.com/assets/14296817/11225577/9fdad776-8d40-11e5-8f06-e47c2553c6a3.png)

##### Focused State
![08_tag-focused](https://cloud.githubusercontent.com/assets/14296817/11225576/9fd99172-8d40-11e5-818e-48e09155c4c3.png)

##### Focused State and Hovering Again on the "X" button no longer produces the red icon
![08_tag-focused-with-hover](https://cloud.githubusercontent.com/assets/14296817/11225579/9fddba68-8d40-11e5-9aaa-3a769286f4f4.png)
