### PR TITLE
style(rxBreadcrumb): Update breadcrumbs for 2.0 color palette

### DIFF
--- a/demo/assets/_palette.less
+++ b/demo/assets/_palette.less
@@ -102,14 +102,17 @@
 
   &.blue {
     .color {
-      &.primary { // aka 500
-        background-color: @blue-500;
+      &.primary {
+        background-color: @blue-700;
       }
       &.secondary-100 {
         background-color: @blue-100;
       }
-      &.secondary-700 {
-        background-color: @blue-700;
+      &.secondary-500 {
+        background-color: @blue-500;
+      }
+      &.secondary-900 {
+        background-color: @blue-900;
       }
       &.accent {
         background-color: @blue-accent;

--- a/demo/assets/generated_demo.css
+++ b/demo/assets/generated_demo.css
@@ -106,13 +106,16 @@ pre code {
   background-color: #eb4d5c;
 }
 .palette.blue .color.primary {
-  background-color: #3391ff;
+  background-color: #1976d2;
 }
 .palette.blue .color.secondary-100 {
   background-color: #bbdefb;
 }
-.palette.blue .color.secondary-700 {
-  background-color: #1976d2;
+.palette.blue .color.secondary-500 {
+  background-color: #3391ff;
+}
+.palette.blue .color.secondary-900 {
+  background-color: #0d47a1;
 }
 .palette.blue .color.accent {
   background-color: #00bdff;

--- a/demo/styles/color.html
+++ b/demo/styles/color.html
@@ -41,20 +41,24 @@
 
     <div class="palette blue">
       <div class="color primary heading light-text">
-        <div>Blue 500 (Primary)</div>
-        <div>@blue-500 <small>#3391FF</small></div>
+        <div>Blue 700 (Primary)</div>
+        <div>@blue-700 <small>#1976D2</small></div>
       </div>
       <div class="color secondary-100 dark-text">
         <div>100</div>
         <div>@blue-100 <small>#BBDEFB</small></div>
       </div>
-      <div class="color primary light-text">
+      <div class="color secondary-500 light-text">
         <div>500</div>
         <div>@blue-500 <small>#3391FF</small></div>
       </div>
-      <div class="color secondary-700 light-text">
+      <div class="color primary light-text">
         <div>700</div>
         <div>@blue-700 <small>#1976D2</small></div>
+      </div>
+      <div class="color secondary-900 light-text">
+        <div>900</div>
+        <div>@blue-900 <small>#0D47A1</small></div>
       </div>
       <div class="color accent light-text">
         <div>Accent</div>

--- a/src/rxApp/rxApp.less
+++ b/src/rxApp/rxApp.less
@@ -514,7 +514,7 @@
     padding: 1px 2px;
     .border-radius(2px);
     top: 9px;
-    color: #427fc4;
+    color: @blue-900;
   }
 }
 

--- a/src/rxBreadcrumbs/rxBreadcrumbs.less
+++ b/src/rxBreadcrumbs/rxBreadcrumbs.less
@@ -3,21 +3,21 @@
 .rx-breadcrumbs {
   overflow: hidden;
   border-style: solid;
-  border-color: #cccccc;
+  border-color: @gray-100;
   float: left;
 
   .breadcrumb {
     float: left;
 
     .breadcrumb-name {
-      padding: @breadcrumbHeight/2 1em @breadcrumbHeight/2 2em;
+      padding: @rxBreadcrumbs-height/2 1em @rxBreadcrumbs-height/2 2em;
       font-size: 0.9em;
       display: block;
-      color: #555555;
+      color: @gray-900;
       position: relative;
       text-decoration: none;
       text-shadow: 0 1px 0 rgba(255,255,255,.5);
-      background: #dddddd;
+      background: @gray-400;
     }
     .breadcrumb-name.last {
       background: transparent;
@@ -28,29 +28,29 @@
       content: "";
       position: absolute;
       top: 50%;
-      margin-top: -@breadcrumbHeight;
+      margin-top: -@rxBreadcrumbs-height;
       border: 0 solid transparent;
-      border-width: @breadcrumbHeight 0 @breadcrumbHeight @breadcrumbArrowWidth;
-      right: -@breadcrumbArrowWidth;
+      border-width: @rxBreadcrumbs-height 0 @rxBreadcrumbs-height @rxBreadcrumbs-arrow-width;
+      right: -@rxBreadcrumbs-arrow-width;
     }
 
     a::after {
       /* TODO add in border gradient to match nav background */
-      border-left-color: #dddddd;
+      border-left-color: @gray-400;
       z-index: 2;
     }
     a::before {
-      border-left-color: #cccccc;
-      right: -(@breadcrumbArrowWidth + 1);
+      border-left-color: @gray-500;
+      right: -(@rxBreadcrumbs-arrow-width + 1);
       z-index: 1;
     }
 
     .first {
       padding-left: 1em;
-      background: #c8c8c8;
+      background: @gray-500;
     }
     .first::after {
-      border-left-color: #c8c8c8;
+      border-left-color: @gray-500;
     }
 
     a:hover {

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -14,6 +14,7 @@
 @blue-100: #bbdefb;
 @blue-500: #3391ff;
 @blue-700: #1976d2;
+@blue-900: #0d47a1;
 @blue-accent: #00bdff;
 
 // ## Greens
@@ -337,6 +338,5 @@
 /*
  * rxBreadcrumbs
  */
-// TODO: rename with proper component prefix
-@breadcrumbHeight: 1.2em;
-@breadcrumbArrowWidth: 9px;
+@rxBreadcrumbs-height: 1.2em;
+@rxBreadcrumbs-arrow-width: 9px;


### PR DESCRIPTION
https://jira.rax.io/browse/FRMW-335

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

### Before
<img width="376" alt="screen shot 2015-11-16 at 4 45 02 pm" src="https://cloud.githubusercontent.com/assets/1529366/11197148/1c6dc00c-8c81-11e5-9954-3627392fc36a.png">
<img width="367" alt="screen shot 2015-11-16 at 4 45 19 pm" src="https://cloud.githubusercontent.com/assets/1529366/11197149/1c71168a-8c81-11e5-964d-04b4c7d5b58b.png">

On hover:
<img width="356" alt="screen shot 2015-11-16 at 4 46 37 pm" src="https://cloud.githubusercontent.com/assets/1529366/11197190/52f82766-8c81-11e5-9815-e47f2262514b.png">


### After (updated 11/19/2015 @ 1:39pm)
<img width="352" alt="screen shot 2015-11-19 at 1 33 19 pm" src="https://cloud.githubusercontent.com/assets/1529366/11281962/9894243a-8ec2-11e5-8cc3-e9472a31a46a.png">
<img width="352" alt="screen shot 2015-11-19 at 1 33 35 pm" src="https://cloud.githubusercontent.com/assets/1529366/11281963/98966e3e-8ec2-11e5-9883-6b557d6b9784.png">


