### PR TITLE
style(rxCollapse): update rxCollapse to use 2.0 color palette

### DIFF
--- a/src/rxCollapse/rxCollapse.less
+++ b/src/rxCollapse/rxCollapse.less
@@ -11,7 +11,7 @@ rx-collapse {
       .box-sizing(border-box);
       width: 30px;
       padding: 0 10px;
-      background-color: @borderGrey;
+      background-color: @gray-500;
       vertical-align: middle;
       cursor: pointer;
 
@@ -33,7 +33,7 @@ rx-collapse {
       }
     }
 
-    border: 2px solid @borderGrey;
+    border: 2px solid @gray-500;
 
     .rx-collapse-title {
       display: inline-block;
@@ -48,7 +48,7 @@ rx-collapse {
   }
   .sml-title {
     cursor: pointer;
-    color: @cancel-gray;
+    color: @gray-700;
     font-size: 10pt;
   }
 

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -216,12 +216,6 @@
 @rxSearchBox-padding-horizontal: 5px;
 
 /*
- * rxCollapse
- */
-// TODO: rename with proper component prefix
-@borderGrey: #c7c7c7;
-
-/*
  * Button Groups (rxButton)
  */
 // TODO: rename with proper component prefix


### PR DESCRIPTION
https://jira.rax.io/browse/FRMW-333

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

### Before
<img width="1070" alt="screen shot 2015-11-17 at 11 27 02 am" src="https://cloud.githubusercontent.com/assets/1529366/11219266/22419320-8d1f-11e5-92a1-2f7582f23d81.png">
<img width="1066" alt="screen shot 2015-11-17 at 11 27 27 am" src="https://cloud.githubusercontent.com/assets/1529366/11219265/223fc5ea-8d1f-11e5-8675-87031c99029a.png">

### After
<img width="1069" alt="screen shot 2015-11-17 at 11 31 16 am" src="https://cloud.githubusercontent.com/assets/1529366/11219269/29623966-8d1f-11e5-92de-bae51e11721a.png">
<img width="1070" alt="screen shot 2015-11-17 at 11 31 32 am" src="https://cloud.githubusercontent.com/assets/1529366/11219268/296241a4-8d1f-11e5-9673-60a2954b7142.png">
