### PR TITLE
style(colors): FRMW-322 Buttons/Actions

### DIFF
--- a/demo/assets/generated_demo.css
+++ b/demo/assets/generated_demo.css
@@ -139,7 +139,7 @@ pre code {
   background-color: #ffecb3;
 }
 .palette.orange .color.secondary-700 {
-  background-color: #ff8f00;
+  background-color: #d14904;
 }
 .palette.orange .color.accent {
   background-color: #ffd740;

--- a/src/rxApp/common.less
+++ b/src/rxApp/common.less
@@ -128,7 +128,7 @@ table {
     }
   }
   .fa-times.delete-x:hover {
-    color: @warnRedHover;
+    color: saturate(@red-700, 15%);
     cursor: pointer;
   }
 }
@@ -261,37 +261,37 @@ h6 {
 
 .msg-action,
 .msg-action a {
-  color: @actionGreen;
+  color: @green-700;
   &:hover,
   &:focus {
-    color: @actionGreen;
+    color: saturate(@green-700, 15%);
   }
 }
 
 .msg-warn,
 .msg-warn a {
-  color: @warnRed;
+  color: @red-700;
   &:hover,
   &:focus {
-    color: @warnRedHover;
+    color: saturate(@red-700, 15%);
   }
 }
 
 .msg-info,
 .msg-info a {
-  color: @infoOrange;
+  color: @orange-700;
   &:hover,
   &:focus {
-    color: @infoOrangeHover;
+    color: saturate(@orange-700, 15%);
   }
 }
 
 .msg-info-blue,
 .msg-info-blue a {
-  color: @infoBlue;
+  color: @blue-700;
   &:hover,
   &:focus {
-    color: @infoBlueHover;
+    color: saturate(@blue-700, 15%);
   }
 }
 

--- a/src/rxApp/rxApp.less
+++ b/src/rxApp/rxApp.less
@@ -522,12 +522,12 @@
 .link-disabled {
   pointer-events: none;
   a {
-    color: #d5d3d3;
+    color: @gray-600;
   }
   .rx-spinner {
     margin-left: 10px;
-    border-bottom-color: #d5d3d3;
-    border-right-color: #d5d3d3;
+    border-bottom-color: @gray-600;
+    border-right-color: @gray-600;
   }
 }
 

--- a/src/rxButton/rxButton.less
+++ b/src/rxButton/rxButton.less
@@ -197,7 +197,7 @@ thead th .btn-link {
     flex: 1;
     text-align: center;
     padding: 7px 13px;
-    color: #989998;
+    color: @gray-700;
 
     &:first-of-type {
       border-top-left-radius: @buttonGroupBorderRadius;
@@ -223,6 +223,6 @@ thead th .btn-link {
 
   input:checked + label {
     color: @white;
-    background: #757575;
+    background: @gray-700;
   }
 }//.button-group

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -26,7 +26,7 @@
 // ## Oranges
 @orange-100: #ffecb3;
 @orange-500: #ffc107;
-@orange-700: #ff8f00;
+@orange-700: #d14904;
 @orange-accent: #ffd740;
 
 // ## Purples
@@ -81,19 +81,19 @@
 @tableRowSelected: #c6e4c8;
 
 // ## Buttons
-@optionHighlightBg: #007bff;
+@optionHighlightBg: @blue-500;
 @buttonColor: @white;
-@buttonColorDisabled: #f0efef;
-@buttonDefaultBg: #427fc4;
+@buttonColorDisabled: @gray-600;
+@buttonDefaultBg: @blue-700;
 @buttonDefaultBgHover: lighten(@buttonDefaultBg, 10%);
-@buttonPositiveBg: #16b667;
+@buttonPositiveBg: @green-700;
 @buttonPositiveBgHover: lighten(@buttonPositiveBg, 6%);
-@buttonNegativeBg: #cc0000;
+@buttonNegativeBg: @red-700;
 @buttonNegativeBgHover: lighten(@buttonNegativeBg, 10%);
-@buttonCancelBg: @cancel-gray;
+@buttonCancelBg: @gray-700;
 @buttonCancelBgHover: lighten(@buttonCancelBg, 10%);
-@buttonDisabledBg: #cfd2d4;
-@buttonSpinnerBg: @buttonColor;
+@buttonDisabledBg: @gray-300;
+@buttonSpinnerBg: @white;
 
 
 // # Borders
@@ -120,14 +120,14 @@
 @menuLinkLightBlue: #97b1d0;
 @menuLinkOrange: #ffa61b;
 @menuRed: #f37a7c;
-@warnRed: #eb2124;
-@warnRedHover: saturate(@warnRed, 15%);
-@actionGreen: #3ab661;
-@actionGreenHover: saturate(@actionGreen, 15%);
-@infoOrange: #dd7800;
-@infoOrangeHover: saturate(@infoOrange, 15%);
-@infoBlue: #4580c2;
-@infoBlueHover: saturate(@infoBlue, 15%);
+@warnRed: #eb2124; // Deprecated
+@warnRedHover: saturate(@warnRed, 15%); // Deprecated
+@actionGreen: #3ab661; // Deprecated
+@actionGreenHover: saturate(@actionGreen, 15%); // Deprecated
+@infoOrange: #dd7800; // Deprecated
+@infoOrangeHover: saturate(@infoOrange, 15%); // Deprecated
+@infoBlue: #4580c2; // Deprecated
+@infoBlueHover: saturate(@infoBlue, 15%); // Deprecated
 
 // # PreProd warnings
 @preprodBackground: #aa161c;


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-322

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

Re-submitting this to run the visual regression. This is the same PR as previously submitted https://github.com/rackerlabs/encore-ui/pull/1359 One Dev and Design were already LGTM. Just need one more Dev LGTM.

### Buttons
Before:
![01_before-01](https://cloud.githubusercontent.com/assets/14296817/11102739/057d1ede-8884-11e5-8428-7d25f7cfdd7b.png)

After:
![01_after-01](https://cloud.githubusercontent.com/assets/14296817/11102742/0580a310-8884-11e5-9ae8-3893fa476ced.png)

### Button Types
Before:
![01_before-02](https://cloud.githubusercontent.com/assets/14296817/11102744/0580cb38-8884-11e5-820c-120d6c9fdc0f.png)

After: 
![01_after-02](https://cloud.githubusercontent.com/assets/14296817/11102741/058066ac-8884-11e5-83b0-46148e908abd.png)
@glynnis I think the red from before was a richer Red.

### Button With Animation
Before:
![01_before-03](https://cloud.githubusercontent.com/assets/14296817/11102740/057d8590-8884-11e5-9f08-4f3228b8a18b.png)

After:
![01_after-03](https://cloud.githubusercontent.com/assets/14296817/11102743/0580d0c4-8884-11e5-9850-54b338c0ea10.png)

### Button Groups
Before:
![02_before](https://cloud.githubusercontent.com/assets/14296817/11102748/058afb12-8884-11e5-9636-bfb0557325b6.png)

After:
![02_after](https://cloud.githubusercontent.com/assets/14296817/11102747/0589efd8-8884-11e5-8923-9ac49cac9580.png)

### Action Links
Before:
![03_before](https://cloud.githubusercontent.com/assets/14296817/11102750/058e52d0-8884-11e5-8f2f-f72e54d33359.png)

After:
![03_after](https://cloud.githubusercontent.com/assets/14296817/11102746/058a1dc8-8884-11e5-9a0c-01d584183266.png)

### Action Link Colors
Before:
![04_before](https://cloud.githubusercontent.com/assets/14296817/11102749/058ca714-8884-11e5-8b75-c8e2761a7d18.png)

After:
![04_after](https://cloud.githubusercontent.com/assets/14296817/11102751/058ef852-8884-11e5-8d2c-2d30d1889bae.png)


### Spinners with Action Links
Before:
![06_before](https://cloud.githubusercontent.com/assets/14296817/11224652/abf73ebe-8d3b-11e5-9401-e1a6c899e9bd.png)

After:
![06_after2](https://cloud.githubusercontent.com/assets/14296817/11227583/5f7ddfc8-8d4c-11e5-877a-0670a36f64c6.png)

@glynnis This is the screenshot of the disabled link at `@gray-600`

### Delete-X Hover
This was a change I made since it was in common.less, however I realized that this was crossing into the Tables story.  I kept it in since it was a minor change. This is the before and after for it.

Before:
![07_before-delete](https://cloud.githubusercontent.com/assets/14296817/11284810/61dcb114-8ed1-11e5-8296-f614eb373078.png)

After:
![07_after-delete](https://cloud.githubusercontent.com/assets/14296817/11284809/61cf8ab6-8ed1-11e5-862b-23ee97b816d5.png)

