### PR TITLE
fix(colors): correct styling for primary link usage

### DIFF
--- a/demo/styles/color.html
+++ b/demo/styles/color.html
@@ -236,7 +236,7 @@
     </div>
 
     <div class="palette blue">
-      <div class="color secondary-700 light-text">
+      <div class="color primary light-text">
         <div>Blue - Standard Link<br />700</div>
         <div>@blue-700 <small>#1976D2</small></div>
       </div>


### PR DESCRIPTION
`.palette.blue .secondary-700` DNE, replaced with `.primary`

### LGTMS
- [x] Dev LGTM
- [x] Design LGTM
