### PR TITLE
style(rxActionMenu): update to use 2.0 colors

### DIFF
--- a/demo/styles/color.html
+++ b/demo/styles/color.html
@@ -60,14 +60,14 @@
         <div>900</div>
         <div>@blue-900 <small>#0D47A1</small></div>
       </div>
-      <div class="color accent light-text">
+      <div class="color accent dark-text">
         <div>Accent</div>
         <div>@blue-accent <small>#00BDFF</small></div>
       </div>
     </div>
 
     <div class="palette green">
-      <div class="color primary heading light-text">
+      <div class="color primary heading dark-text">
         <div>Green 500 (Primary)</div>
         <div>@green-500 <small>#4CAF51</small></div>
       </div>
@@ -75,7 +75,7 @@
         <div>100</div>
         <div>@green-100 <small>#C8E6C9</small></div>
       </div>
-      <div class="color primary light-text">
+      <div class="color primary dark-text">
         <div>500</div>
         <div>@green-500 <small>#4CAF51</small></div>
       </div>
@@ -83,7 +83,7 @@
         <div>700</div>
         <div>@green-700 <small>#2E7D32</small></div>
       </div>
-      <div class="color accent light-text">
+      <div class="color accent dark-text">
         <div>Accent</div>
         <div>@green-accent <small>#43B947</small></div>
       </div>
@@ -102,9 +102,9 @@
         <div>500</div>
         <div>@orange-500 <small>#FFC107</small></div>
       </div>
-      <div class="color secondary-700 dark-text">
+      <div class="color secondary-700 light-text">
         <div>700</div>
-        <div>@orange-700 <small>#FF8F00</small></div>
+        <div>@orange-700 <small>#D14904</small></div>
       </div>
       <div class="color accent dark-text">
         <div>Accent</div>
@@ -207,9 +207,9 @@
 
   <div layout="row" layout-wrap layout-align="top left">
     <div class="palette green">
-      <div class="color primary light-text">
-        <div>Green - Create/Add<br />500</div>
-        <div>@green-500 <small>#4CAF51</small></div>
+      <div class="color secondary-700 light-text">
+        <div>Green - Create/Add<br />700</div>
+        <div>@green-700 <small>#2E7D32</small></div>
       </div>
       <div class="detail">
         <ul class="list">
@@ -269,9 +269,19 @@
       </div>
       <div class="detail">
         <ul class="list">
-          <li>
-            Used to communicate a button, link, or element is disabled.
-          </li>
+          <li>Used to communicate a button or element is disabled.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="palette gray">
+      <div class="color shade-600 dark-text">
+        <div>Gray - Disabled<br />600</div>
+        <div>@gray-600 <small>#9E9E9E</small></div>
+      </div>
+      <div class="detail">
+        <ul class="list">
+          <li>Used to communicate that an icon or link is disabled.</li>
         </ul>
       </div>
     </div>
@@ -284,14 +294,15 @@
       <div class="detail">
         <ul class="list">
           <li>Used to communicate that an icon, button, or link is associated with a cancel action.</li>
+          <li>For plain text, this gray communicates that something is less important so that darker, primary text content stands out more.</li>
         </ul>
       </div>
     </div>
 
     <div class="palette orange">
-      <div class="color secondary-700">
+      <div class="color secondary-700 light-text">
         <div>Orange - Warning/Critical Change<br />700</div>
-        <div>@orange-700 <small>#FF8F00</small></div>
+        <div>@orange-700 <small>#D14904</small></div>
       </div>
       <div class="detail">
         <ul class="list">
@@ -307,9 +318,9 @@
     </div>
 
     <div class="palette red">
-      <div class="color primary light-text">
-        <div>Red - Error/Destructive<br />500</div>
-        <div>@red-500 <small>#F44336</small></div>
+      <div class="color secondary-700 light-text">
+        <div>Red - Error/Destructive<br />700</div>
+        <div>@red-700 <small>#D32F2F</small></div>
       </div>
       <div class="detail">
         <ul class="list">

--- a/src/components/rxActionMenu/docs/rxActionMenu.html
+++ b/src/components/rxActionMenu/docs/rxActionMenu.html
@@ -1,99 +1,96 @@
 <div>
-    <p>The cog in the first row is dismissable by clicking anywhere, but the second cog can only be dismissed
-    by clicking on the cog itself.
-    </p>
+  <p>The cog in the first row is dismissable by clicking anywhere, but the second cog can only be dismissed
+  by clicking on the cog itself.
+  </p>
 
-    <h3 id="typical-usage">Typical Usage</h3>
-    <table>
-        <thead>
-            <tr>
-                <th>
-                    Name
-                </th>
-                <th>
-                </th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>Globally dismissible</td>
-                <td>
-                    <rx-action-menu id="globalDismissal">
-                        <ul class="actions-area">
-                            <li>
-                                <rx-modal-action
-                                    template-url="addActionTemplate.html"
-                                    classes="msg-action">
-                                    <i class="fa fa-plus fa-lg"></i> Add
-                                </rx-modal-action>
-                            </li>
-                            <li>
-                                <rx-modal-action
-                                    template-url="deleteActionTemplate.html"
-                                    classes="msg-warn">
-                                    <i class="fa fa-times fa-lg"></i> Delete
-                                </rx-modal-action>
-                            </li>
-                        </ul>
-                    </rx-action-menu>
-                </td>
-            </tr>
-            <tr>
-                <td>Only dismissible by clicking on cog</td>
-                <td>
-                    <rx-action-menu global-dismiss="false">
-                        <ul class="actions-area">
-                            <li>
-                                <rx-modal-action
-                                    template-url="addActionTemplate.html"
-                                    classes="msg-action">
-                                    <i class="fa fa-plus fa-lg"></i> Add
-                                </rx-modal-action>
-                            </li>
-                            <li>
-                                <rx-modal-action
-                                    template-url="deleteActionTemplate.html"
-                                    classes="msg-warn">
-                                    <i class="fa fa-times fa-lg"></i> Delete
-                                </rx-modal-action>
-                            </li>
-                        </ul>
-                    </rx-action-menu>
-                </td>
-            </tr>
-                <td>Unorthodox Behaviors (no modals, hidden item)</td>
-                <td ng-controller="rxActionMenuCtrl">
-                    <rx-action-menu id="custom">
-                        <ul class="actions-area">
-                            <li>
-                              <button class="btn-link trigger" ng-click="add()">
-                                  <span class="msg-action"><i class="fa fa-plus fa-lg"></i> Add</span>
-                              </button>
-                            </li>
-                            <li>
-                              <button class="btn-link trigger" ng-click="remove()">
-                                  <span class="msg-warn"><i class="fa fa-times fa-lg"></i> Delete</span>
-                              </button>
-                            </li>
-                            <li ng-show="false">
-                              <button class="btn-link trigger">
-                                  <span class="msg-warn"><i class="fa fa-times fa-lg"></i> Visually Hidden</span>
-                              </button>
-                            </li>
-                        </ul>
-                    </rx-action-menu>
-                </td>
-        </tbody>
-    </table>
+  <h3 id="typical-usage">Typical Usage</h3>
+  <table class="table-striped">
+    <thead>
+      <tr>
+          <th>Name</th>
+          <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Globally dismissible</td>
+        <td>
+          <rx-action-menu id="globalDismissal">
+            <ul class="actions-area">
+              <li>
+                <rx-modal-action
+                    template-url="addActionTemplate.html"
+                    classes="msg-action">
+                    <i class="fa fa-plus fa-lg"></i> Add
+                </rx-modal-action>
+              </li>
+              <li>
+                <rx-modal-action
+                    template-url="deleteActionTemplate.html"
+                    classes="msg-warn">
+                    <i class="fa fa-times fa-lg"></i> Delete
+                </rx-modal-action>
+              </li>
+            </ul>
+              </rx-action-menu>
+            </td>
+      </tr>
+      <tr>
+        <td>Only dismissible by clicking on cog</td>
+        <td>
+          <rx-action-menu global-dismiss="false">
+            <ul class="actions-area">
+              <li>
+                <rx-modal-action
+                    template-url="addActionTemplate.html"
+                    classes="msg-action">
+                    <i class="fa fa-plus fa-lg"></i> Add
+                </rx-modal-action>
+              </li>
+              <li>
+                <rx-modal-action
+                    template-url="deleteActionTemplate.html"
+                    classes="msg-warn">
+                    <i class="fa fa-times fa-lg"></i> Delete
+                </rx-modal-action>
+              </li>
+            </ul>
+          </rx-action-menu>
+        </td>
+      </tr>
+      <td>Unorthodox Behaviors (no modals, hidden item)</td>
+      <td ng-controller="rxActionMenuCtrl">
+        <rx-action-menu id="custom">
+          <ul class="actions-area">
+            <li>
+              <button class="btn-link trigger" ng-click="add()">
+                <span class="msg-action"><i class="fa fa-plus fa-lg"></i> Add</span>
+              </button>
+            </li>
+            <li>
+              <button class="btn-link trigger" ng-click="remove()">
+                <span class="msg-warn"><i class="fa fa-times fa-lg"></i> Delete</span>
+              </button>
+            </li>
+            <li ng-show="false">
+              <button class="btn-link trigger">
+                <span class="msg-warn"><i class="fa fa-times fa-lg"></i> Visually Hidden</span>
+              </button>
+            </li>
+          </ul>
+        </rx-action-menu>
+      </td>
+    </tbody>
+  </table>
 
-    <script type="text/ng-template" id="deleteActionTemplate.html">
-        <rx-modal-form title="Delete Action" submit-text="Delete">
-            <span>Do you want to delete something?</span>
-        </rx-modal-form>
-    </script>
-    <script type="text/ng-template" id="addActionTemplate.html">
-        <rx-modal-form title="Add Action" submit-text="Add">
-            <span>Do you want to add something?</span>
-        </rx-modal-form>
-    </script>
+  <script type="text/ng-template" id="deleteActionTemplate.html">
+      <rx-modal-form title="Delete Action" submit-text="Delete">
+          <span>Do you want to delete something?</span>
+      </rx-modal-form>
+  </script>
+  <script type="text/ng-template" id="addActionTemplate.html">
+      <rx-modal-form title="Add Action" submit-text="Add">
+          <span>Do you want to add something?</span>
+      </rx-modal-form>
+  </script>
 </div>

--- a/src/components/rxActionMenu/rxActionMenu.less
+++ b/src/components/rxActionMenu/rxActionMenu.less
@@ -1,14 +1,14 @@
 @import "vars";
 
-// containers for actionmenus that spawn modals
+// containers for action menus that spawn modals
 .action-menu-container {
   position: relative;
   width: 15px;
   & > i {
     cursor: pointer;
-    color: @subduedText;
+    color: @gray-600;
     &:hover {
-      color: @subduedTextHover;
+      color: @gray-700;
     }
   }
 }


### PR DESCRIPTION
https://jira.rax.io/browse/FRMW-331

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

### Before
![screen shot 2015-11-24 at 1 29 23 pm](https://cloud.githubusercontent.com/assets/1529366/11378136/649fe8a8-92af-11e5-8838-ce192d17c8f0.png)
![screen shot 2015-11-24 at 1 29 35 pm](https://cloud.githubusercontent.com/assets/1529366/11378135/649fe2a4-92af-11e5-835f-a6a806530839.png)

### After
![screen shot 2015-11-24 at 1 29 41 pm](https://cloud.githubusercontent.com/assets/1529366/11378152/6fa4ed0c-92af-11e5-85c0-0d09fa94626e.png)
![screen shot 2015-11-24 at 1 29 58 pm](https://cloud.githubusercontent.com/assets/1529366/11378150/6f67bc70-92af-11e5-9b4c-a7a4b6c1cf48.png)
![screen shot 2015-11-24 at 1 30 19 pm](https://cloud.githubusercontent.com/assets/1529366/11378151/6f6a5f66-92af-11e5-93a1-db2b1acfad7f.png)

Note that link colors within the action menus were not changed as part of this PR. Just including a screenshot of them to indicate that they have indeed inherited the work from another PR that dealt with action link colors.