### PR TITLE
style(modals): FRMW-332 Updating Modals to Color 2.0

### DIFF
--- a/src/components/rxApp/rxApp.less
+++ b/src/components/rxApp/rxApp.less
@@ -446,7 +446,7 @@
     .rx-feedback .modal-link {
       background: url(images/icon-feedback.png) no-repeat 20px calc(~"50% + 1px");
       vertical-align: middle;
-      color: @menuLinkOrange;
+      color: @orange-500;
       padding: 0 21px 0 41px;
       float: right;
     }

--- a/src/components/rxModalAction/rxModalAction.less
+++ b/src/components/rxModalAction/rxModalAction.less
@@ -62,7 +62,7 @@
 
 .modal-header {
   padding: @modalPadding;
-  border-bottom: 1px solid @pageDivider;
+  border-bottom: 1px solid @gray-200;
   position: relative;
 
   .modal-title {
@@ -74,7 +74,7 @@
     line-height: 1.5;
     font-size: 1em;
     font-wieght: bold;
-    color: @subduedTitle;
+    color: @gray-700;
     margin: 0;
   }
   .modal-close {
@@ -85,10 +85,10 @@
     width: 1em;
     height: 1em;
     text-align: center;
-    color: @closeText;
+    color: @gray-600;
     &:hover,
     &:focus {
-      color: @closeTextHover;
+      color: @gray-800;
     }
 
     &:before {
@@ -122,7 +122,7 @@
 
 .modal-footer {
   padding: @modalPadding;
-  border-top: 1px solid @pageDivider;
+  border-top: 1px solid @gray-200;
 }
 
 @media (max-width:480px) {

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -99,7 +99,7 @@
 // # Borders
 
 // ## General
-@pageDivider: #e6e6e5;
+@pageDivider: #e6e6e5; // Deprecated
 @appHelpBorder: #424242;
 
 // ## Tables
@@ -141,8 +141,8 @@
 @subduedText: #bbbbbb;
 @subduedTextHover: darken(@subduedText, 15%);
 @subduedTitle: #989998;
-@closeText: #e5e5e5;
-@closeTextHover: darken(@closeText, 10%);
+@closeText: #e5e5e5; // Deprecated
+@closeTextHover: darken(@closeText, 10%); // Deprecated
 
 // ## Tables
 @tableHeaderText: @white;


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-332

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

I only found modals used in the following LESS files.
* vars.less
* common.less
* rxModalAction.less
* rxApp.less

and in the following components shown below.


## BEFORE
![01_before](https://cloud.githubusercontent.com/assets/14296817/11381806/c3b88e80-92c3-11e5-952b-87d6a10d8dca.png)

## AFTER
### Modals
http://localhost:9001/#/styleguide/modals
NOTE: Keep in mind that the current rxNotify PR will take care of the notification colors.
![01_after](https://cloud.githubusercontent.com/assets/14296817/11487204/2c17746e-9783-11e5-8974-e349538bbda1.png)

### rxModalAction
http://localhost:9001/#/components/rxModalAction
NOTE: Form colors will be corrected in rxForm
![02_after-rxmodalaction](https://cloud.githubusercontent.com/assets/14296817/11487205/2c17ae2a-9783-11e5-8ab0-ce487b801864.png)

### Wells
http://localhost:9001/#/styles/wells
![03_after-wells](https://cloud.githubusercontent.com/assets/14296817/11487206/2c17a696-9783-11e5-85e1-e324d4153641.png)

### rxActionMenu
http://localhost:9001/#/components/rxActionMenu
![04_after-rxactionmenu](https://cloud.githubusercontent.com/assets/14296817/11487207/2c19028e-9783-11e5-9829-63ed1cc0eead.png)

### rxFeedback
http://localhost:9001/#/components/rxFeedback
![05_after-rxfeedback](https://cloud.githubusercontent.com/assets/14296817/11487208/2c18fc8a-9783-11e5-9b50-8d27508b8d3f.png)

### rxBulkSelect
http://localhost:9001/#/components/rxBulkSelect
NOTE: Table colors will be corrected when they are addressed in the Tables color story.
![06_after-rxbulkselect](https://cloud.githubusercontent.com/assets/14296817/11487209/2c195bb2-9783-11e5-8c74-8ca27e4ca752.png)

### Submit Feedback
![07_after-submit-feedback](https://cloud.githubusercontent.com/assets/14296817/11487210/2c2770b2-9783-11e5-9156-bcf7280870e3.png)

