### PR TITLE
chore(rxButton): FRMW-436-removed bottom margin

### DIFF
--- a/src/components/rxForm/rxForm.less
+++ b/src/components/rxForm/rxForm.less
@@ -442,6 +442,10 @@ rx-field-name {
           justify-content: flex-start;
           align-items: stretch;
 
+         .button {
+            margin-bottom: 0px;
+          }
+
           & > input,
           & > textarea {
             flex: 1 1 auto; // as dynamic flex item


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-436

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

---
Added `margin-bottom: 0px;` to `rxInput` -> `.button` to remove the `10px` bottom margin inherited from `rxButton`.