### PR TITLE
fix(rxSortableColumn): FRMW-457-fix sort icon overlapping title

### DIFF
--- a/src/components/rxSortableColumn/rxSortableColumn.less
+++ b/src/components/rxSortableColumn/rxSortableColumn.less
@@ -2,8 +2,6 @@
  * rxSortableColumn
  */
 .rx-sortable-column {
-  position: relative;
-
   .btn-link {
     // This needs to be set explicitly, otherwise `.table-filters button`
     // applies a font size of 93% and sortable columns have smaller headers.
@@ -11,34 +9,31 @@
   }
 
   .sort-action {
-    display: block;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: center;
     width: 100%;
-    margin: 0;
-    text-align: left;
+
     &:focus {
       // since we underline on focus, we can remove the outline rectangle that sticks around
       outline: none;
     }
-  }
 
-  .sort-icon {
-    display: block;
-    height: 0;
-    width: 0;
-    border: solid transparent;
-    border-width: 6px 5px;
-    position: absolute;
-    right: 0;
-    top: 50%;
-
-    &.asc {
-      margin-top: -9px;
-      border-bottom-color: #4a4a4a;
+    .display-value {
+      flex: 1;
+      text-align: left;
     }
-    &.desc {
-      margin-top: -3px;
-      border-top-color: #4a4a4a;
+
+    .sort-icon {
+      flex: 0 0 16px;
+      width: 13px;
+      height: 13px;
+      line-height: 13px;
+
+      .bg {
+        color: #4a4a4a;
+      }
     }
   }
 }
-

--- a/src/components/rxSortableColumn/scripts/rxSortableColumn.page.js
+++ b/src/components/rxSortableColumn/scripts/rxSortableColumn.page.js
@@ -6,16 +6,16 @@ var Page = require('astrolabe').Page;
    @private
  */
 var currentSortDirection = function (columnElement) {
-    var imgSortIcon = columnElement.$('.sort-icon');
-    return imgSortIcon.getAttribute('style').then(function (style) {
-        if (style.indexOf('hidden') > -1) {
-            // Sort arrow hidden; not sorted.
-            return -1;
-        } else {
-            return imgSortIcon.getAttribute('class').then(function (className) {
-                return className.indexOf('asc') > -1 ? 1 : 0;
-            });
-        }
+    var spanSortDirection = columnElement.$('.sort-direction-icon');
+
+    return spanSortDirection.isPresent().then(function (isPresent) {
+      if (isPresent) {
+        return spanSortDirection.getAttribute('class').then(function (klass) {
+          return (klass.indexOf('ascending') > -1 ? 1 : -1);
+        });
+      } else {
+        return 0;
+      }
     });
 };
 
@@ -32,7 +32,7 @@ var rxSortableColumn = {
 
     name: {
         get: function () {
-            return this.rootElement.$('.sort-action .ng-scope').getText();
+            return this.rootElement.$('.sort-action .display-value').getText();
         }
     },
 
@@ -43,7 +43,7 @@ var rxSortableColumn = {
      */
     sortAscending: {
         value: function () {
-            this.sort({ isAscending: true });
+            this.sort({ sortValue: 1 });
         }
     },
 
@@ -54,7 +54,7 @@ var rxSortableColumn = {
      */
     sortDescending: {
         value: function () {
-            this.sort({ isAscending: false });
+            this.sort({ sortValue: -1 });
         }
     },
 
@@ -78,7 +78,7 @@ var rxSortableColumn = {
                 // Coercing -1 to Boolean results in -1 === true. We don't want that.
                 // It's easier to leave as is since -1 != true and -1 != false.
                 // Meaning we'll always sort the list at least once if it's currently unsorted.
-                if (sortDirection != namedParams.isAscending) {
+                if (sortDirection != namedParams.sortValue) {
                     page.btnSort.click();
                     attempts += 1;
                     page.sort(namedParams, attempts);
@@ -202,7 +202,7 @@ var rxSortableColumns = {
     names: {
         get: function () {
             return this.getNamesUsing(function (columnElement) {
-                return columnElement.$('.sort-action .ng-scope').getText();
+                return columnElement.$('.sort-action .display-value').getText();
             });
         }
     },
@@ -271,8 +271,8 @@ exports.rxSortableColumn = {
      */
     sortDirections: {
         ascending: 1,
-        descending: 0,
-        notSorted: -1,
+        notSorted: 0,
+        descending: -1
     }
 
 };

--- a/src/components/rxSortableColumn/scripts/rxSortableColumn.spec.js
+++ b/src/components/rxSortableColumn/scripts/rxSortableColumn.spec.js
@@ -26,9 +26,9 @@ describe('rxSortableColumn', function () {
 
     it('should render template correctly', function () {
         expect(el).not.be.empty;
-        expect(el.find('button')).not.be.empty;
-        expect(el.find('button').text()).to.contain('Yo!');
+        expect(el.find('div')).not.be.empty;
+        expect(el.find('div').text()).to.contain('Yo!');
         expect(el.find('i')).not.be.empty;
-        expect(el.find('i').hasClass('asc')).to.be.true;
+        expect(el.find('i').hasClass('bg')).to.be.true;
     });
 });

--- a/src/components/rxSortableColumn/templates/rxSortableColumn.html
+++ b/src/components/rxSortableColumn/templates/rxSortableColumn.html
@@ -1,11 +1,17 @@
 <div class="rx-sortable-column">
-    <button class="sort-action btn-link" ng-click="sortMethod({property:sortProperty})">
-        <span class="visually-hidden">Sort by&nbsp;</span>
-        <span ng-transclude></span>
-        <i class="sort-icon"
-            ng-style="{visibility: predicate === '{{sortProperty}}' && 'visible' || 'hidden'}"
-            ng-class="{'desc': reverse, 'asc': !reverse}">
-            <span class="visually-hidden">Sorted {{reverse ? 'ascending' : 'descending'}}</span>
-        </i>
-    </button>
+  <div class="sort-action btn-link" ng-click="sortMethod({property:sortProperty})">
+    <span class="visually-hidden">Sort by&nbsp;</span>
+    <span class="display-value" ng-transclude></span>
+    <span class="visually-hidden">Sorted {{reverse ? 'ascending' : 'descending'}}</span>
+    <span class="sort-icon fa-stack">
+      <i class="bg fa fa-stack-1x fa-sort"></i>
+      <span ng-if="predicate === sortProperty" 
+        class="sort-direction-icon" 
+        ng-class="{ 'ascending': !reverse, 'descending': reverse }">
+
+        <i ng-if="reverse" class="fa fa-stack-1x fa-sort-desc"></i>
+        <i ng-if="!reverse" class="fa fa-stack-1x fa-sort-asc"></i>
+      </span>
+    </span>
+  </div>
 </div>


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-457

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

---
`rxSortableColumn` narrow table headers caused the sort icon to overlap the content.  Now the sort icon will wrap inside the header instead of overlapping the header content.