### PR TITLE
style(tables): FRMW-321 Update Tables to Color 2.0

### DIFF
--- a/src/components/rxApp/common.less
+++ b/src/components/rxApp/common.less
@@ -1,7 +1,7 @@
 /*
  * Common
  */
-@import url("https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,700,700italic");
+@import url("https://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic");
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,100,100italic,300,300italic,400italic,700,700italic");
 @import "vars";
 @import (inline) "normalize.css";
@@ -90,6 +90,7 @@ table {
   }
   thead th {
     text-align: left;
+    font-weight: 500;
     background: @tableHeaderBg;
     color: @tableHeaderText;
     border: 1px solid @tableHeaderBorder;
@@ -113,19 +114,23 @@ table {
       cursor: pointer;
       &::after {
         display: inline-block;
-        color: @subduedText;
+        color: @gray-700;
         font-size: 20px;
         .chevron-mixin;
       }
     }
   }
   td.expanded {
-    background-color: @subtableBorder;
-    border-bottom-color: @subtableBorder;
+    background-color: @tableHeaderBg;
+    border-bottom-color: @tableHeaderBg;
     .double-chevron::after {
       color: @white;
       .chevron-mixin(-1);
     }
+  }
+  .fa-times.delete-x {
+    color: @gray-700;
+    cursor: pointer;
   }
   .fa-times.delete-x:hover {
     color: saturate(@red-700, 15%);
@@ -134,8 +139,8 @@ table {
 }
 
 .expanded-container {
-  padding: 0 3px 3px 3px;
-  background-color: @subtableBorder;
+  padding: 0 3px 20px 3px;
+  background-color: @tableHeaderBg;
 
   & > * {
     margin-left: 2%;
@@ -154,8 +159,9 @@ table {
     }
 
     th {
-      border-color: darken(@subtableBorder, 15%);
-      background-color: @subtableBorder;
+      border-color: @tableHeaderBorder;
+      background-color: @tableHeaderBg;
+      color: @tableHeaderText;
       border-top: 0;
       border-bottom: 0;
     }

--- a/src/components/rxBulkSelect/rxBulkSelect.less
+++ b/src/components/rxBulkSelect/rxBulkSelect.less
@@ -30,9 +30,9 @@ thead th[rx-bulk-select-header-check] {
   height: 0;
   & > i {
     cursor: pointer;
-    color: @subduedText;
+    color: @gray-700;
     &:hover {
-      color: @subduedTextHover;
+      color: @gray-800;
     }
   }
 }
@@ -84,7 +84,7 @@ thead th[rx-bulk-select-header-check] {
 
 .selected td:not(.status) {
   background: @tableRowSelected;
-  border-color: #bad4bb;
+  border-color: @green-100;
   // this 'double' makes it so that the border-color applies to the top border as well
   // @see http://stackoverflow.com/questions/7942212/css-table-row-border-color-with-border-collapse
   border-style: double;

--- a/src/components/rxFloatingHeader/rxFloatingHeader.less
+++ b/src/components/rxFloatingHeader/rxFloatingHeader.less
@@ -12,9 +12,9 @@
 th.filter-header {
   font-weight: normal;
   background: rgba(255, 255, 255, 0.95);
-  border: 1px solid #e1e0df;
+  border: 1px solid @gray-300;
   input.filter-box {
-    color: #404040;
+    color: @gray-900;
   }
   button {
     margin: 0;

--- a/src/components/rxOptionTable/rxOptionTable.less
+++ b/src/components/rxOptionTable/rxOptionTable.less
@@ -7,7 +7,7 @@
   // we also want a semi-consistent width, but not too wide for modals
   min-width: 39em;
 
-  td:not(.empty-data) {
+  td:not(.empty-message) {
     // remove default padding from td's so that we can make the label take up the full room
     padding: 0;
   }
@@ -44,7 +44,7 @@
   .disabled {
     label {
       cursor: default;
-      color: @inputColorDisabled;
+      color: @gray-600;
     }
   }
   .option-table-input {
@@ -52,13 +52,13 @@
     line-height: 0;
   }
   .current td {
-    color: #3ab661;
+    color: @green-700;
   }
   // @note KL: I'd like to stick with just adding the background to the <tr>, but
   // we need to make the selector more specific to override the table-stripe styles.
   .selected td {
     background: @tableRowSelected;
-    border-color: #bad4bb;
+    border-color: @green-100;
     // this 'double' makes it so that the border-color applies to the top border as well
     // @see http://stackoverflow.com/questions/7942212/css-table-row-border-color-with-border-collapse
     border-style: double;

--- a/src/components/rxPaginate/rxPaginate.less
+++ b/src/components/rxPaginate/rxPaginate.less
@@ -1,7 +1,6 @@
 /*
  * rxPaginate
  */
-@paginationColor: #ababab;
 
 .paginate-area {
   text-align: center;
@@ -46,7 +45,7 @@
   .pagination > li:first-child > a,
   .pagination > li:first-child > span {
     padding-left: 30px;
-    color: @infoBlue;
+    color: @blue-700;
     background: transparent;
     &:before {
       content: ".";
@@ -56,7 +55,7 @@
       display: block;
       position: absolute;
       border: 6px solid transparent;
-      border-bottom-color: @infoBlue;
+      border-bottom-color: @blue-700;
       border-top: 0;
       left: 10px;
       top: 55%;
@@ -94,7 +93,7 @@
       padding: 0;
       border: 0;
       background: transparent;
-      color: @infoBlue;
+      color: @blue-700;
     }
     span {
       float: none;
@@ -114,7 +113,8 @@
   .pagination > .page-links > li > span:hover,
   .pagination > .page-links > li > a:focus,
   .pagination > .page-links > li > span:focus {
-    background: #eeeeee;
+    border-top: 2px solid @gray-300;
+
   }
 
   .pagination > .page-links > .active > a,
@@ -158,7 +158,7 @@
   left: -1px;
   width: ~"calc(100% + 2px)";
   height: ~"calc(100% + 2px)";
-  background: rgba(222, 222, 221, 0.8);
+  background: rgba(250, 250, 250, 0.8); // == @gray-25 at 80%
   .loading-text-wrapper {
     width: 100px;
     margin: 20% auto;
@@ -167,11 +167,11 @@
     font-size: 18px;
     margin-top: 15%;
     text-align: center;
-    color: #777777;
+    color: @gray-700;
   }
   i {
     font-size: 30px;
     margin-left: 25px;
-    color: #777777;
+    color: @gray-700;
   }
 }

--- a/src/components/rxSortableColumn/rxSortableColumn.less
+++ b/src/components/rxSortableColumn/rxSortableColumn.less
@@ -32,7 +32,10 @@
       line-height: 13px;
 
       .bg {
-        color: #4a4a4a;
+        color: @gray-600;
+      }
+      .sort-direction-icon {
+        color: @gray-900;
       }
     }
   }

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -76,17 +76,16 @@
 @preprodActiveBackground: #d41f26;
 
 // ## Tables
-@tableHeaderBg: #878787;
+@tableHeaderBg: @gray-200;
 @tableBg: @white;
-@tableBgAlt: #f2f2f2;
-@tableRowSelected: #c6e4c8;
-@tableBorder: #e1e0df;
-@tableHeaderBorder: #6e6e6e;
-@subtableBorder: #adadad;
-@tableHeaderText: @white;
-@tableCellText: #555555;
+@tableBgAlt: @gray-25;
+@tableRowSelected: fade(@green-100, 30%);
+@tableBorder: @gray-200;
+@tableHeaderBorder: @gray-400;
+@subtableBorder: @gray-500;
+@tableHeaderText: @gray-900;
+@tableCellText: @gray-800;
 @tableCellPadding: 5px 10px;
-
 
 /* ======================================== *\
    COMPONENT VARIABLES
@@ -450,3 +449,8 @@
 // deprecated
 @modalPadding: @rxModalAction-padding;
 @modalBodyPadding: @rxModalAction-body-padding;
+
+/*
+ * rxPaginate
+ */
+@paginationColor: @gray-700;


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-321

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

I received Feedback from Eric in the comments below, I made my changes in my second commit, and then updated this initial comment with the latest screenshots.

## Loading Overlay
### Before
![00_before-loading-overlay](https://cloud.githubusercontent.com/assets/14296817/11542406/cf89f322-98fc-11e5-9cf7-ade0e9d19662.png)

### After
![00_after-loading-overlay](https://cloud.githubusercontent.com/assets/14296817/11699895/559d52da-9e8c-11e5-9c1c-79f63f911746.png)


## Tables Basics
### Before
![01_before-tabels-basics](https://cloud.githubusercontent.com/assets/14296817/11542423/dc945fbc-98fc-11e5-8f70-8270c475eb07.png)

### After
![01_after-tabels-basics](https://cloud.githubusercontent.com/assets/14296817/11862217/0bb2410e-a44e-11e5-8269-ee5799f5415a.png)

## rxPaginate
### Before
![02_before-rxpaginate](https://cloud.githubusercontent.com/assets/14296817/11542437/ec62c2d0-98fc-11e5-93d8-ff55737563eb.png)

### After
<img width="1046" alt="02_after-rxpaginate" src="https://cloud.githubusercontent.com/assets/14296817/11862226/2b878818-a44e-11e5-99a6-05cc93264770.png">

## Delete X Action
### Before
![03_before-delete-x-action](https://cloud.githubusercontent.com/assets/14296817/11542461/0253e2a4-98fd-11e5-9ff5-cdd20a96f08d.png)

### After
<img width="1048" alt="03_after-delete-x-action" src="https://cloud.githubusercontent.com/assets/14296817/11862227/378d47f6-a44e-11e5-8a3a-7eba881c8ebb.png">


## Single Action
### Before
![04_before-single-action](https://cloud.githubusercontent.com/assets/14296817/11542475/1749ddbc-98fd-11e5-947c-ce00fbc247ad.png)

### After
<img width="1047" alt="04_after-single-action" src="https://cloud.githubusercontent.com/assets/14296817/11862230/41033f5c-a44e-11e5-861b-ef497337fcb7.png">

## Filters
### Before
![05_before-filters](https://cloud.githubusercontent.com/assets/14296817/11542481/21343ed0-98fd-11e5-83de-8eeee813f671.png)

### After
<img width="1048" alt="05_after-filters" src="https://cloud.githubusercontent.com/assets/14296817/11862234/48ee8672-a44e-11e5-8326-d308596a6fa2.png">

## rxCollapse
### Before
![06_before-rxcollapse](https://cloud.githubusercontent.com/assets/14296817/11542485/2de23682-98fd-11e5-8ac0-878244c1209e.png)

### After
<img width="1045" alt="06_after-rxcollapse" src="https://cloud.githubusercontent.com/assets/14296817/11862236/51c9eb42-a44e-11e5-8053-e97cab60ff38.png">

## Expanded
### Before
![07_before-expanded](https://cloud.githubusercontent.com/assets/14296817/11542495/3a925330-98fd-11e5-8245-973ddf83cbb3.png)

### After
<img width="1044" alt="07_after-expanded" src="https://cloud.githubusercontent.com/assets/14296817/11862239/5c137f14-a44e-11e5-855e-0f235f0e9de6.png">

## Metadata
### Before
![08_before-metadata](https://cloud.githubusercontent.com/assets/14296817/11542500/4540b5c4-98fd-11e5-932d-d57d3ed45860.png)

### After
<img width="1048" alt="08_after-metadata" src="https://cloud.githubusercontent.com/assets/14296817/11862242/656225f2-a44e-11e5-8bbf-301aafc54402.png">

## rxPaginate API Based
### Before
![10_before-rxpaginate-api-based_tota11y](https://cloud.githubusercontent.com/assets/14296817/11542512/55eeafc0-98fd-11e5-9fa8-3366193682b4.png)

### After
<img width="1046" alt="10_after-rxpaginate-api-based" src="https://cloud.githubusercontent.com/assets/14296817/11862243/6dd2ac8e-a44e-11e5-825e-6ca782d464a2.png">

## rxBulkSelect
### Before
![11_before-rxbulkselect](https://cloud.githubusercontent.com/assets/14296817/11542521/64aa407e-98fd-11e5-8b6a-0b633fe6b4da.png)

### After
<img width="1046" alt="11_after-rxbulkselect" src="https://cloud.githubusercontent.com/assets/14296817/11862248/75c9d0b6-a44e-11e5-8274-dbe326efe210.png">

## rxOptionTable
### Before
![12_before-rxoptiontable](https://cloud.githubusercontent.com/assets/14296817/11542533/7378ed26-98fd-11e5-8d8a-3def85337676.png)

### After
<img width="625" alt="12_after-rxoptiontable" src="https://cloud.githubusercontent.com/assets/14296817/11862255/82cd8474-a44e-11e5-958f-68be1a383dd3.png">

## rxFloatingHeader
### Before
![14_before-rxfloatingheader](https://cloud.githubusercontent.com/assets/14296817/11542557/8c61a72e-98fd-11e5-9971-efadb968c696.png)

### After
<img width="1043" alt="14_after-rxfloatingheader-01" src="https://cloud.githubusercontent.com/assets/14296817/11862266/960234cc-a44e-11e5-8ab5-768fba29fb42.png">

## rxSortableColumn
This was updated after James' PR, then updated the colors here.

### Before
![15_before-rxsortablecolumn](https://cloud.githubusercontent.com/assets/14296817/11909218/55ecba36-a5a9-11e5-9de5-e8b7ff5163b1.png)

### After
![15_after-rxsortablecolumn](https://cloud.githubusercontent.com/assets/14296817/11909221/5ae5f91c-a5a9-11e5-93ea-fb33bc1b438a.png)
