### PR TITLE
style(rxForm): update colors for rxSearchBox and rxCharacterCount

### DIFF
--- a/src/components/rxCharacterCount/rxCharacterCount.less
+++ b/src/components/rxCharacterCount/rxCharacterCount.less
@@ -8,7 +8,7 @@
 .counted-input-wrapper {
   width: 375px;
   position: relative;
-  background-color: #ffffff;
+  background-color: @rxForm-input-background-color;
 
   // These two selectors must always be styled with the same width.
   .input-highlighting,
@@ -34,20 +34,20 @@
     color: transparent;
 
     .over-limit-text {
-      background-color: @warnRed;
+      background-color: @rxForm-error-text-color;
       opacity: 0.3;
     }
   }
 
   .character-countdown {
     text-align: right;
-    color: @subduedTitle;
+    color: @rxFieldName-color;
 
     &.near-limit {
-      color: @orange;
+      color: @orange-700;
     }
     &.over-limit {
-      color: @red;
+      color: @rxForm-error-text-color;
     }
   }
 }

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -202,7 +202,7 @@
 @rxSearchBox-width: @rxForm-input-width;
 @rxSearchBox-color: @rxForm-input-text-color;
 @rxSearchBox-color-disabled: @disabled-text-color;
-@rxSearchBox-color-icon: #a9a9a9;
+@rxSearchBox-color-icon: @gray-500;
 @rxSearchBox-background: @rxForm-input-background-color;
 @rxSearchBox-background-disabled: @disabled-background-color;
 @rxSearchBox-border: 1px solid @rxForm-input-border-color;


### PR DESCRIPTION
https://jira.rax.io/browse/FRMW-539

- [X] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

# rxSearchBox
### Before
![screen shot 2015-12-14 at 3 34 56 pm](https://cloud.githubusercontent.com/assets/1529366/11794630/f9dd2746-a277-11e5-8164-071c69fef42f.png)

### After
![screen shot 2015-12-14 at 3 34 15 pm](https://cloud.githubusercontent.com/assets/1529366/11794632/fe1d8b2a-a277-11e5-9444-6c6381e228f8.png)

# rxCharacterCount
#### No text (before)
![screen shot 2015-12-14 at 3 38 00 pm](https://cloud.githubusercontent.com/assets/1529366/11794750/87a09ba8-a278-11e5-8b47-43c03de31522.png)

#### No text (after)
![screen shot 2015-12-14 at 3 37 21 pm](https://cloud.githubusercontent.com/assets/1529366/11794743/826a071e-a278-11e5-80f1-e27790f26c1b.png)

#### Count near limit (before)
![screen shot 2015-12-14 at 3 38 13 pm](https://cloud.githubusercontent.com/assets/1529366/11794883/48cfafd0-a279-11e5-95b0-f84dd842a5a5.png)

#### Count near limit (after)
![screen shot 2015-12-14 at 3 37 48 pm](https://cloud.githubusercontent.com/assets/1529366/11794880/44d3d8b6-a279-11e5-99cd-8042ac224fb1.png)

#### Count over limit (before)
![screen shot 2015-12-14 at 3 38 06 pm](https://cloud.githubusercontent.com/assets/1529366/11794733/74a8fca2-a278-11e5-8c67-4710ab5ead19.png)

#### Count over limit (after)
![screen shot 2015-12-14 at 3 37 14 pm](https://cloud.githubusercontent.com/assets/1529366/11794709/5a23bf34-a278-11e5-84d7-5c01ee131782.png)

#### Over limit with highlighting (before)
![screen shot 2015-12-14 at 3 38 32 pm](https://cloud.githubusercontent.com/assets/1529366/11794805/cf2270be-a278-11e5-97c0-28310e67e27f.png)

#### Over limit with highlighting (after)
![screen shot 2015-12-14 at 3 38 25 pm](https://cloud.githubusercontent.com/assets/1529366/11794799/c9d60026-a278-11e5-8480-0c280702fce9.png)
