### PR TITLE
style(rxForm): Update color for rxMultiSelect + rxToggleSwitch

### DIFF
--- a/src/components/rxMultiSelect/rxMultiSelect.less
+++ b/src/components/rxMultiSelect/rxMultiSelect.less
@@ -20,13 +20,13 @@ rx-multi-select {
     top: -1px;
     left: -1px;
     width: 100%;
-    border: 1px solid @inputBorderColor;
-    background: @white;
+    border: 1px solid @rxForm-input-border-color;
+    background: @rxForm-input-background-color;
     box-shadow: 0 3px 15px 0 rgba(0, 0, 0, 0.35);
   }
 
   rx-select-option[value="all"] label {
-    border-bottom: 1px solid @inputBorderColor;
+    border-bottom: 1px solid @rxForm-input-border-color;
   }
 }
 
@@ -36,8 +36,7 @@ rx-multi-select {
     padding: 4px 6px;
 
     &:hover {
-      background: @optionHighlightBg;
-      color: @white;
+      background: @blue-100;
       cursor: pointer;
     }
   }

--- a/src/components/rxToggleSwitch/rxToggleSwitch.less
+++ b/src/components/rxToggleSwitch/rxToggleSwitch.less
@@ -1,30 +1,15 @@
-/*
- * rxToggleSwitch
- */
-@textColor: @white;
-@offStateColor: #b3b3b3;
-@borderColor: darken(@offStateColor, 10%);
-@onStateColor: #00ac31;
-@knobColor: @white;
-@knobBorderColor: darken(@knobColor, 10%);
-@knobSize: 1.2em;
-@edgeSpacing: @knobSize * 0.9;
-@lineHeight: @knobSize * 1.25;
-@blurDist: @edgeSpacing;
-@blurSpread: (@edgeSpacing/3) * -1;
-
 .rx-toggle-switch {
   font-size: 0.8em;
-  line-height: @lineHeight;
+  line-height: @rxToggleSwitch-line-height;
 
   display: inline-block;
 
-  border: 1px @borderColor solid;
+  border: 1px @rxToggleSwitch-border-color solid;
   border-radius: 9px;
-  background-color: @offStateColor;
-  color: @textColor;
+  background-color: @rxToggleSwitch-off-state-color;
+  color: @rxToggleSwitch-text-color;
 
-  padding: 0 @edgeSpacing 0 @edgeSpacing;
+  padding: 0 @rxToggleSwitch-padding 0 @rxToggleSwitch-padding;
 
   width: 5em;
 
@@ -32,24 +17,25 @@
   position: relative;
   text-align: right;
 
-  .box-shadow(inset 1px 2px @blurDist @blurSpread rgba(0,0,0,0.50));
+  .box-shadow(inset 1px 2px @rxToggleSwitch-blur-dist @rxToggleSwitch-blur-spread rgba(0,0,0,0.50));
   .user-select(none);
   .box-sizing(border-box);
 
   &[disabled] {
-    background-color: desaturate(lighten(@offStateColor, 7%), 80%);
-    color: #666666;
+    background-color: @disabled-background-color;
+    color: @disabled-text-color;
     &.on {
-      background-color: desaturate(lighten(@onStateColor, 33%), 80%);
+      background-color: desaturate(lighten(@rxToggleSwitch-on-state-color, 40%), 30%);
+      color: darken(@disabled-text-color, 10%);
     }
     cursor: not-allowed;
     .knob {
-      background-color: #adadad;
-      border: 1px #999999 solid;
+      background-color: @disabled-background-color;
+      border: 1px @disabled-text-color solid;
     }
   }
   &.on {
-    background-color: @onStateColor;
+    background-color: @rxToggleSwitch-on-state-color;
     text-align: left;
     .knob {
       left: 100%;
@@ -66,13 +52,13 @@
     top: 0;
     left: 0;
 
-    width: @knobSize;
-    height: @knobSize;
-    border-radius: (@knobSize/2)+1;
-    background-color: @knobColor;
-    border: 1px @knobBorderColor solid;
+    width: @rxToggleSwitch-knob-size;
+    height: @rxToggleSwitch-knob-size;
+    border-radius: (@rxToggleSwitch-knob-size/2)+1;
+    background-color: @rxToggleSwitch-knob-color;
+    border: 1px @rxToggleSwitch-knob-border-color solid;
 
-    .box-shadow(0 0 @blurDist @blurSpread rgba(0,0,0,0.55));
+    .box-shadow(0 0 @rxToggleSwitch-blur-dist @rxToggleSwitch-blur-spread rgba(0,0,0,0.55));
     overflow: hidden;
   }
 }

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -239,6 +239,21 @@
 @rxTag-height: 24px;
 
 /*
+ * rxToggleSwitch
+ */
+@rxToggleSwitch-off-state-color: @gray-700;
+@rxToggleSwitch-on-state-color: @green-700;
+@rxToggleSwitch-text-color: @white;
+@rxToggleSwitch-border-color: @gray-600;
+@rxToggleSwitch-knob-color: @white;
+@rxToggleSwitch-knob-border-color: @gray-200;
+@rxToggleSwitch-knob-size: 1.2em;
+@rxToggleSwitch-padding: @rxToggleSwitch-knob-size * 0.9;
+@rxToggleSwitch-line-height: @rxToggleSwitch-knob-size * 1.25;
+@rxToggleSwitch-blur-dist: @rxToggleSwitch-padding;
+@rxToggleSwitch-blur-spread: (@rxToggleSwitch-padding/3) * -1;
+
+/*
  * progressbar
  */
 // TODO: rename with proper component prefix


### PR DESCRIPTION
https://jira.rax.io/browse/FRMW-538

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

# rxToggleSwitch
### Contrast before
![screen shot 2015-12-14 at 4 23 33 pm](https://cloud.githubusercontent.com/assets/1529366/11796334/6a21242c-a281-11e5-998d-cd11c5d00af3.png)

### Contrast after
![screen shot 2015-12-14 at 4 26 46 pm](https://cloud.githubusercontent.com/assets/1529366/11796341/6f1a9b20-a281-11e5-91c8-0c54ae699bd4.png)

### Off styles (before)
![screen shot 2015-12-14 at 4 44 57 pm](https://cloud.githubusercontent.com/assets/1529366/11796395/b08e0b1e-a281-11e5-8787-5bb3469bd0d5.png)

### Off styles (after)
![screen shot 2015-12-14 at 4 44 49 pm](https://cloud.githubusercontent.com/assets/1529366/11796385/a94752e8-a281-11e5-8dd0-146901360e3f.png)

### On styles (before)
![screen shot 2015-12-14 at 4 46 01 pm](https://cloud.githubusercontent.com/assets/1529366/11796411/c83f0bbe-a281-11e5-97be-20daa82173e3.png)

### On styles (after)
![screen shot 2015-12-14 at 4 46 06 pm](https://cloud.githubusercontent.com/assets/1529366/11796415/ce798838-a281-11e5-91cf-5cd31a627514.png)

### Disabled styles (before)
![screen shot 2015-12-14 at 4 46 53 pm](https://cloud.githubusercontent.com/assets/1529366/11796426/e2005800-a281-11e5-8985-6193810cc292.png)

### Disabled styles (after)
[Outdated screenshot.](https://cloud.githubusercontent.com/assets/1529366/11796430/e72a5be6-a281-11e5-8bb7-78026b894878.png)


# rxMultiSelect
### Unchecked item on hover (before)
![screen shot 2015-12-14 at 3 51 37 pm](https://cloud.githubusercontent.com/assets/1529366/11796045/c7f4d8ac-a27f-11e5-83f4-a6c2170ae593.png)

### Unchecked item on hover (after)
![screen shot 2015-12-14 at 4 02 03 pm](https://cloud.githubusercontent.com/assets/1529366/11796056/d4dd0abc-a27f-11e5-8fe2-f7791daf3d7f.png)

### Checked item on hover (before)
![screen shot 2015-12-14 at 3 51 44 pm](https://cloud.githubusercontent.com/assets/1529366/11796064/e01ea048-a27f-11e5-8f8a-0d4ca0d24c9a.png)

### Checked item on hover (after)
![screen shot 2015-12-14 at 4 02 09 pm](https://cloud.githubusercontent.com/assets/1529366/11796071/eaa546b6-a27f-11e5-9b4b-6a8f483d7217.png)

### Checked item before and after (no change)
![screen shot 2015-12-14 at 4 02 14 pm](https://cloud.githubusercontent.com/assets/1529366/11796078/f6683ba2-a27f-11e5-9de1-b86104d4a6a1.png)