### PR TITLE
test(rxMetadata): Add function to get a definition element.

### DIFF
--- a/src/components/rxMetadata/scripts/rxMetadata.page.js
+++ b/src/components/rxMetadata/scripts/rxMetadata.page.js
@@ -38,6 +38,19 @@ var rxMetadata = {
 
     /**
      * @function
+     * @returns {ElementFinder} The definition web element matching the term, whether it be an rx-meta or
+       rx-meta-show-hide element.
+     */
+    definitionElementByTerm: {
+        value: function (term) {
+            var rxMetaSelector = 'rx-meta[label="' + term  + '"] .definition';
+            var rxMetaShowHideSelector = 'rx-meta-show-hide[label="' + term  + '"] .definition';
+            return $(rxMetaSelector + ', ' + rxMetaShowHideSelector);
+        }
+    },
+
+    /**
+     * @function
      * @returns {Boolean} Whether or not the root element is currently displayed.
      */
     isDisplayed: {


### PR DESCRIPTION
* [x] SOMEONE LGTM
* [x] SOMEONE LGTM

The already existing term() function gives me a way to get the definitionElement.getText(), but I don't want the text.

I want the element in cases where definitionElement is a link or something and I need to make assertions on it.