### PR TITLE
fix(grunt): remove reference to clean:rxPageObjects

### DIFF
--- a/grunt-tasks/rxPageObjects.js
+++ b/grunt-tasks/rxPageObjects.js
@@ -14,8 +14,6 @@ module.exports = function (grunt) {
             tasks.push('shell:npmPublish');
         }
 
-        tasks.push('clean:rxPageObjects');
         grunt.task.run(tasks);
-
     });
 };


### PR DESCRIPTION
`clean:rxPageObjects` was removed in a previous PR, but the `rxPageObjects` task still referenced it