### PR TITLE
fix(depedencies): pin vinyl-fs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "moment": "~2.9.0",
     "node-timing.js": "^1.1.0",
     "protractor": "^2.0.0",
-    "semver": "~4.2.0"
+    "semver": "~4.2.0",
+    "vinyl-fs": "2.2.1"
   }
 }


### PR DESCRIPTION
Yet another upstream dependency is breaking Travis. Pin `vinyl-fs` to 2.2.1 in attempt to correct issue.