### PR TITLE
fix(npm): revert bandaid for dependency regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "moment": "~2.9.0",
     "node-timing.js": "^1.1.0",
     "protractor": "^2.0.0",
-    "semver": "~4.2.0",
-    "vinyl-fs": "2.2.1"
+    "semver": "~4.2.0"
   }
 }


### PR DESCRIPTION
* undo pinning to `vinyl-fs 2.2.1` (project has released 2.3.1 to correct regression)