### PR TITLE
refactor(rxDebug): add rxDebug for ui testing purposes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -62,6 +62,7 @@
     <script src="scripts/showGuideController.js"></script>
     <!-- directives -->
     <script src="scripts/alwaysInvalid.js"></script>
+    <script src="scripts/rxDebug.js"></script>
     <script src="scripts/rxPrism.js"></script>
     <script src="scripts/rxStyleguide.js"></script>
     <script src="scripts/rxExample.js"></script>

--- a/demo/scripts/rxDebug.js
+++ b/demo/scripts/rxDebug.js
@@ -1,0 +1,11 @@
+angular.module('demoApp')
+.directive('rxDebug', function ($routeParams) {
+    return {
+        restrict: 'E',
+        transclude: true,
+        template: '<div ng-if="isDebugging" ng-transclude></div>',
+        link: function (scope) {
+            scope.isDebugging = $routeParams.debug === 'true';
+        }
+    };
+});

--- a/src/atoms/rxCheckbox/docs/rxCheckbox.html
+++ b/src/atoms/rxCheckbox/docs/rxCheckbox.html
@@ -139,6 +139,7 @@
   </tbody>
 </table>
 
+<rx-debug>
 <h3>Plain HTML Checkboxes (for comparison)</h3>
 <p>
   <input type="checkbox"
@@ -169,3 +170,4 @@
          id="plainChkRemoveable"
          ng-if="!plainChkIsRemoved" />
 </p>
+</rx-debug>

--- a/utils/demo.page.js
+++ b/utils/demo.page.js
@@ -1,7 +1,33 @@
 var Page = require('astrolabe').Page;
+var URL = require('../node_modules/astrolabe/lib/astrolabe/utils/url'); // http://i.imgur.com/iCWOGrq.gif
+var _ = require('lodash');
 
 module.exports = Page.create({
-    url: { value: '' },
+
+    /**
+     * @override
+     * @description I needed this to *always* go to the designated component demo page
+     * while using a `debug=true` flag. This exposes all facets of a demo component page,
+     * which is required to reach full test coverage. For normal users, they shouldn't have
+     * to see all eight or ten examples of a component -- one or two is sufficient. However, this
+     * function over ride keeps all typical `.go` functionality intact from the latest release.
+     * See the source for a link to the exact commit SHA that I borrowed the `.go` functionality from.
+     */
+    go: {
+        value: function () {
+            var url = new URL('');
+
+            // stuplum/astrolabe/blob/963eb5001d7d3ce019a6ed66cec62ba2bb0d316b/lib/astrolabe/page.js#L10-L13
+            _.each(arguments, function (arg) {
+                if(_.isString(arg)) { url.addPath(arg); }
+                if(_.isObject(arg)) { url.addParams(arg); }
+            });
+
+            url.addParams({ debug: true });
+
+            browser.get(url.url);
+        }
+    },
 
     storeTokenButton: {
         get: function () {


### PR DESCRIPTION
* Add `rxDebug` directive to hide page content unless the `?debug` URL query parameter is present.
* This does not affect distributed code.
* Useful to hide content when midway tests are _not_ running to reduce clutter in the documentation.

### Example

```html
<p>I'll always show up!</p>

<rx-debug>
  <p>I'll only show up if "?debug" is present in url!</p>
</rx-debug>
```