### PR TITLE
feat(browserSync): Include simple FF/Chrome syncing

### DIFF
--- a/grunt-tasks/options/browserSync.js
+++ b/grunt-tasks/options/browserSync.js
@@ -1,0 +1,11 @@
+module.exports = {
+    dev: {
+        bsFiles: {
+            src: '*.html, *.css, *.js'
+        },
+        options: {
+            proxy: 'localhost:9001'
+        }
+
+    }
+};

--- a/guides/ui-setup.md
+++ b/guides/ui-setup.md
@@ -53,6 +53,20 @@ Run the following command:
 
 You can then open `http://localhost:9001` in a new browser and view the demo app. The page will automatically refresh when the code is updated.
 
+## Running Browser Sync
+
+It's important to develop new components while looking at both Firefox and Chrome. You can make this task much easier by running [browser sync](https://browsersync.io/) in a new terminal window after starting the local development server.
+
+```
+grunt browserSync
+```
+
+This will allow you to visit http://localhost:3000/ in both Firefox and Chrome at the same time (as well as any other browser you wish to sync, including your phone or tablet).
+
+When you scroll in one browser, or device, all other connected browsers or devices will also scroll. This also includes clicking elements, visiting links, etc.
+
+This tool is designed to forward all traffic from the typical development server located at http://localhost:9001 and sync it at the new location on port 3000. You can still visit the original development server without any side effects. Use of this tool is completely optional, but strongly recommended.
+
 ### Warning: EMFILE, too many open files 'src'
 
 If you see the following [error when running `grunt server`](https://github.com/gruntjs/grunt-contrib-copy/issues/21#issuecomment-46194402):
@@ -154,4 +168,3 @@ If your application is gulp-based (i.e. created with the EncoreUI Template or En
  4. When you are done testing your EncoreUI changes in your local project, run `bower update` from your project directory. This will tell it to start using the official bower repositories once again.
 
 Note that if you make further changes in your EncoreUI directory, you'll have to run `grunt copy:bower` from within the EncoreUI directory to cause these changes to become visible in the local symlink directory. Requiring this step is a failure on our part, and in the future we'll modify our EncoreUI `watch` task to make sure this happens automatically.
-

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "execSync": "^1.0.2",
     "glob": "~4.3.4",
     "grunt": "0.4.5",
+    "grunt-browser-sync": "2.2.0",
     "grunt-bump": "0.3.1",
     "grunt-cloudfiles": "~0.3.0",
     "grunt-complexity": "~0.2.0",


### PR DESCRIPTION
I always forget to look at new components in both Chrome and Firefox. I added this tool to make it easier for me to compare the CSS (especially) side by side when writing automation code/manual testing.

![browsersync](https://cloud.githubusercontent.com/assets/1214609/12518340/aad1d35a-c0fd-11e5-88bc-e71a6b40a863.gif)

This does not affect live reload in any way. This tool is designed to sync content that you watch yourself on port 3000. The actual watching happens on port 9001 still.