### PR TITLE
fix(grunt): fix deploy tasks

### DIFF
--- a/grunt-tasks/options/shell.js
+++ b/grunt-tasks/options/shell.js
@@ -2,16 +2,6 @@
 
 module.exports = function (grunt) {
     return {
-        rxPageObjects: {
-            command: 'npm pack',
-            options: {
-                stdout: true,
-                execOptions: {
-                    cwd: 'utils/rx-page-objects'
-                }
-            }
-        },
-
         npmPublish: {
             command: 'npm publish ./rx-page-objects',
             options: {

--- a/grunt-tasks/rxPageObjects.js
+++ b/grunt-tasks/rxPageObjects.js
@@ -3,7 +3,6 @@ module.exports = function (grunt) {
         var tasks = [
             'concat:rxPageObjects',
             'concat:rxPageObjectsExercises',
-            'shell:rxPageObjects',
             'jsdoc:rxPageObjects',
             'copy:rxPageObjectsDocs'
         ];

--- a/utils/rx-page-objects/package.json
+++ b/utils/rx-page-objects/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "rx-page-objects",
+  "author": "Rackspace Hosting, Inc. <encoreui@lists.rackspace.com> (http://rackerlabs.github.io/encore-ui/)",
+  "description": "Midway test page objects for all of the Encore UI components",
+  "version": "1.44.2-3",
+  "main": "index.js",
+  "license": "Apache License, Version 2.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "moment": "2.8.2",
+    "lodash": "2.4.1",
+    "node-timing.js": "1.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:rackerlabs/encore-ui.git"
+  }
+}


### PR DESCRIPTION
rxPageObjects deploy tasks were deploying packed versions of the deployed files, resulting in a tarball (*.tgz) file within the distributed directory. This process also packed previous tarballs already in the directory, so each subsequent tarball contained all of the previous tarballs, causing exponential file size increases to the point of failure to publish because the payload was too large.

* no tasks made use of these tarballs (grunt tasks removed)
* in my effort to troubleshoot, I accidentally removed the `package.json` (readded)

@Droogans, I'd like your seal of approval before I merge this PR.

### LGTMs

- [x] Droogans LGTM
- [x] parlarjb LGTM