### PR TITLE
style(color): FRMW-700 Update @blue-700 Hex Value

### DIFF
--- a/demo/templates/styles/color.html
+++ b/demo/templates/styles/color.html
@@ -42,7 +42,7 @@
     <div class="palette blue">
       <div class="color primary heading light-text">
         <div>Blue 700 (Primary)</div>
-        <div>@blue-700 <small>#1976D2</small></div>
+        <div>@blue-700 <small>#0d74d1</small></div>
       </div>
       <div class="color secondary-100 dark-text">
         <div>100</div>
@@ -54,7 +54,7 @@
       </div>
       <div class="color primary light-text">
         <div>700</div>
-        <div>@blue-700 <small>#1976D2</small></div>
+        <div>@blue-700 <small>#0d74d1</small></div>
       </div>
       <div class="color secondary-900 light-text">
         <div>900</div>
@@ -238,7 +238,7 @@
     <div class="palette blue">
       <div class="color primary light-text">
         <div>Blue - Standard Link<br />700</div>
-        <div>@blue-700 <small>#1976D2</small></div>
+        <div>@blue-700 <small>#0d74d1</small></div>
       </div>
       <div class="detail">
         <ul class="list">

--- a/src/styles/vars.less
+++ b/src/styles/vars.less
@@ -13,7 +13,7 @@
 // ## Blues
 @blue-100: #bbdefb;
 @blue-500: #3391ff;
-@blue-700: #1976d2;
+@blue-700: #0d74d1;
 @blue-900: #0d47a1;
 @blue-accent: #00bdff;
 


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-700

- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM

This story and PR were created in order to update the @blue-700 hex value. Reason is so that the PhoneUI can update to this framework and make most of the blue links have a better contrast of 4.5 ratio within the panels. Most panels use the @gray-25 background color which allow this new blue color to work well with links.