### PR TITLE
fix(rxApp): Drop all user id display and logout display

### DIFF
--- a/src/components/rxApp/docs/rxApp.js
+++ b/src/components/rxApp/docs/rxApp.js
@@ -1,6 +1,10 @@
 /*jshint unused:false*/
 angular.module('demoApp')
-.controller('rxAppCtrl', function ($scope, $location, $rootScope, $window, encoreRoutes, rxVisibility) {
+.controller('rxAppCtrl', function ($scope, $location, $rootScope, $window, encoreRoutes, rxVisibility, Session) {
+    Session.getUserId = function () {
+        return 'bert3000';
+    };
+
     $scope.subtitle = 'With a subtitle';
 
     $scope.changeSubtitle = function () {

--- a/src/components/rxApp/docs/rxApp.midway.js
+++ b/src/components/rxApp/docs/rxApp.midway.js
@@ -19,10 +19,8 @@ describe('rxApp', function () {
         expect(rxAppCustom.sectionTitle).to.eventually.equal('Example Menu');
     });
 
-    it('should logout', function () {
-        rxAppCustom.logout();
-        expect(demoPage.currentUrl).to.eventually.contain('login');
-        demoPage.go('#/components/rxApp');
+    it('should not have a user name', function () {
+        expect(rxAppCustom.rootElement.all(by.binding('userId')).count()).to.eventually.equal(0);
     });
 
     describe('with collapsible navigation', function () {

--- a/src/components/rxApp/scripts/rxApp.page.js
+++ b/src/components/rxApp/scripts/rxApp.page.js
@@ -112,17 +112,6 @@ var rxApp = {
         }
     },
 
-    /**
-     * @instance
-     * @type {String}
-     * @description The currently logged in user's id.
-     */
-    userId: {
-        get: function () {
-            return this.rootElement.element(by.binding('userId')).getText();
-        }
-    },
-
     logout: {
         value: function () {
             this.rootElement.$('.site-logout').click();

--- a/src/components/rxApp/templates/rxApp.html
+++ b/src/components/rxApp/templates/rxApp.html
@@ -11,12 +11,6 @@
                 <span class="visually-hidden">{{ (collapsedNav) ? 'Show' : 'Hide' }} Main Menu</span>
                 <div class="double-chevron" ng-class="{'double-chevron-left': !collapsedNav}"></div>
             </button>
-            <div class="site-options">
-                <button class="btn-link site-option site-logout" rx-logout="{{logoutUrl}}">
-                    Logout
-                    <span ng-if="userId">({{ userId }})</span>
-                </button>
-            </div>
         </header>
         <nav class="rx-app-nav">
             <div ng-repeat="section in routes" class="nav-section nav-section-{{ section.type || 'all' }}">


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-679

### LGTMs
- [x] Dev LGTM
- [x] Dev LGTM
- [x] Design LGTM
- [x] QE LGTM

This is the least amount of work possible to keep everything working as is
while still blocking users from attempting to logout in the most obvious place
within encore apps, the left hand nav.

Anyone who is still supporting "logout" functionality will still be able to
"logout" users, even though it's not supported.

BREAKING CHANGE: Anyone who is checking the rxApp page objects for the userId
property will have their tests fail. This isn't a huge deal because part of the
update to the new version of the framework will make those tests irrelevant. Just
delete all tests exercising logout functionality and checking the currently logged
in user from your end to end test suite to successfully migrate to the newest
version of rx-page-objects.