### PR TITLE
test(exerciese): Remove deprecated cssSelector option

### DIFF
--- a/src/atoms/rxCheckbox/scripts/rxCheckbox.exercise.js
+++ b/src/atoms/rxCheckbox/scripts/rxCheckbox.exercise.js
@@ -1,14 +1,12 @@
 var _ = require('lodash');
-var rxCheckbox = require('./rxCheckbox.page').rxCheckbox;
 
 /**
  * @function
  * @description rxCheckbox exercises
  * @exports exercise/rxCheckbox
  * @returns {function} A function to be passed to mocha's `describe`.
- * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxCheckbox} [options.instance] - Component to exercise.
- * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
+ * @param {Object} options - Test options. Used to build valid tests.
+ * @param {rxCheckbox} options.instance - Component to exercise.
  * @param {Boolean} [options.disabled=false] - Whether the checkbox is disabled at the start of the exercise
  * @param {Boolean} [options.selected=false] - Whether the checkbox is selected at the start of the exercise
  * @param {Boolean} [options.visible=true] - Whether the checkbox is visible at the start of the exercise
@@ -30,14 +28,7 @@ exports.rxCheckbox = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxCheckbox.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should be present', function () {

--- a/src/components/rxBulkSelect/scripts/rxBulkSelect.exercise.js
+++ b/src/components/rxBulkSelect/scripts/rxBulkSelect.exercise.js
@@ -1,5 +1,5 @@
-var rxBulkSelect = require('./rxBulkSelect.page').rxBulkSelect;
 var _ = require('lodash');
+var rxBulkSelect = require('./rxBulkSelect.page').rxBulkSelect;
 
 /**
  * @function
@@ -10,7 +10,6 @@ var _ = require('lodash');
  * @param {rxBulkSelect} [options.instance={@link rxBulkSelect.initialize}] - Component to exercise.
  * @param {string[]} [options.batchActions=[]] - List of batch actions to exercise, will not run exercises if empty.
  * @param {number} [options.count=10] - Number of items in the table.
- * @param {string} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
  * @example
  * describe('default exercises', encore.exercise.rxBulkSelect({
  *     instance: myPage.bulkSelect, // select one of many widgets from your page objects
@@ -23,6 +22,7 @@ exports.rxBulkSelect = function (options) {
     }
 
     options = _.defaults(options, {
+        instance: rxBulkSelect.initialize(),
         count: 10,
         batchActions: []
     });
@@ -31,17 +31,7 @@ exports.rxBulkSelect = function (options) {
         var component;
 
         before(function () {
-
-            if (options.instance === undefined) {
-                component = rxBulkSelect.initialize();
-            } else {
-                component = options.instance;
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxBulkSelect.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('has no selected rows, a hidden message, and a disabled batch actions link', function () {

--- a/src/components/rxCharacterCount/scripts/rxCharacterCount.exercise.js
+++ b/src/components/rxCharacterCount/scripts/rxCharacterCount.exercise.js
@@ -1,14 +1,12 @@
 var _ = require('lodash');
-var rxCharacterCount = require('./rxCharacterCount.page').rxCharacterCount;
 
 /**
  * @function
  * @description rxCharacterCount exercises.
  * @exports exercise/rxCharacterCount
  * @returns {function} A function to be passed to mocha's `describe`.
- * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxCharacterCount} [options.instance={@link rxCharacterCount.intiailize}] - Component to exercise.
- * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
+ * @param {Object} options - Test options. Used to build valid tests.
+ * @param {rxCharacterCount} options.instance - Component to exercise.
  * @param {Number} [options.maxCharacters=254] - The total number of characters allowed.
  * @param {Number} [options.nearLimit=10] - The number of remaining characters needed to trigger the "near-limit" class.
  * @param {Boolean} [options.ignoreInsignificantWhitespace=false] - Whether or not the textbox ignores leading and
@@ -38,16 +36,7 @@ exports.rxCharacterCount = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            } else {
-                component = rxCharacterCount.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxCharacterCount.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should show element', function () {

--- a/src/components/rxCollapse/scripts/rxCollapse.exercise.js
+++ b/src/components/rxCollapse/scripts/rxCollapse.exercise.js
@@ -1,14 +1,12 @@
 var _ = require('lodash');
-var rxCollapse = require('./rxCollapse.page').rxCollapse;
 
 /**
  * @function
  * @description rxCollapse exercises.
  * @return {function} A function to be passed to mocha's `describe`.
  * @exports exercise/rxCollapse
- * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxCollapse} [options.instance=rxCollapse.initialize()] - Component to exercise.
- * @param {string} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
+ * @param {Object} options - Test options. Used to build valid tests.
+ * @param {rxCollapse} options.instance - Component to exercise.
  * @param {String} [options.title] - The title of the rxCollapse element.
  * @param {Boolean} [options.expanded=false] - Whether or not the rxCollapse element is currently expanded.
  * @example
@@ -32,16 +30,7 @@ exports.rxCollapse = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            } else {
-                component = rxCollapse.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxCollapse.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should show the element', function () {

--- a/src/components/rxForm/scripts/rxFieldName.exercise.js
+++ b/src/components/rxForm/scripts/rxFieldName.exercise.js
@@ -1,13 +1,10 @@
 var _ = require('lodash');
 
-var rxForm = require('./rxForm.page').rxForm;
-
 /**
  * rxFieldName exercises.
  * @exports exercise/rxFieldName
- * @param {Object} [options] - Test options. Used to build valid tests.
+ * @param {Object} options - Test options. Used to build valid tests.
  * @param {rxFieldName} options.instance - Component to exercise.
- * @param {string} [options.cssSelector] - **DEPRECATED**: Fallback selector string to initialize widget with.
  * @param {string} [options.visible=true] - Determines if the field name is visible.
  * @param {string} [options.present=true] - Determines if the field name is present in the DOM.
  * @param {string} [options.required=false] - Determines if the field name displays as a required field.
@@ -27,14 +24,7 @@ exports.rxFieldName = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxForm.fieldName.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should ' + (options.visible ? 'be' : 'not be') + ' visible', function () {

--- a/src/components/rxMetadata/scripts/rxMetadata.exercise.js
+++ b/src/components/rxMetadata/scripts/rxMetadata.exercise.js
@@ -5,13 +5,14 @@ var rxMetadata = require('./rxMetadata.page').rxMetadata;
  * rxMetadata exercises
  * @exports exercise/rxMetadata
  * @param {Object} [options] Test options. Used to build valid tests.
- * @param {string} [options.cssSelector] Fallback selector string to initialize widget with.
+ * @param {rxMetadata} [instance={@link rxMetadata.initialize}] Component to exercise.
  * @param {Boolean} [options.present=true] Determines if the metadata is present in the DOM.
  * @param {Boolean} [options.visible=true] Determines if the metadata is visible.
  * @param {Object} [options.transformFns] - Transformation functions to be passed to rxMetadata.
  * @param {Object} [options.terms] The expected label text of each metadata entry.
  * @example
  * describe('metadata', encore.exercise.rxMetadata({
+ *     instance: myPage.accountOverviewMetadata,
  *     transformFns: {
  *         'Signup Date': function (elem) {
  *             return elem.getText().then(function (text) {
@@ -44,6 +45,7 @@ exports.rxMetadata = function (options) {
     }
 
     options = _.defaults(options, {
+        instance: rxMetadata.initialize(),
         present: true,
         visible: true,
     });
@@ -52,12 +54,7 @@ exports.rxMetadata = function (options) {
         var component;
 
         before(function () {
-            if (options.cssSelector === undefined) {
-                // don't use main -- you need to be able to supply `transformFns` via `initialize`
-                component = rxMetadata.initialize($('rx-metadata'), options.transformFns);
-            } else {
-                component = rxMetadata.initialize($(options.cssSelector), options.transformFns);
-            }
+            component = rxMetadata.initialize(options.instance.rootElement, options.transformFns);
         });
 
         it('should ' + (options.present ? 'be' : 'not be') + ' present', function () {

--- a/src/components/rxMultiSelect/scripts/rxMultiSelect.exercise.js
+++ b/src/components/rxMultiSelect/scripts/rxMultiSelect.exercise.js
@@ -5,7 +5,6 @@ var rxMultiSelect = require('./rxMultiSelect.page').rxMultiSelect;
  * @exports exercise/rxMultiSelect
  * @param {Object} [options] - Test options. Used to build valid tests.
  * @param {rxMultiSelect} [options.instance={@link rxMultiSelect.initialize}] - Component to exercise.
- * @param {string} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
  * @param {Object} [options.inputs=[]] - The options of the select input.
  * @example
  * describe('default exercises', encore.exercise.rxMultiSelect({
@@ -19,6 +18,7 @@ exports.rxMultiSelect = function (options) {
     }
 
     options = _.defaults(options, {
+        instance: rxMultiSelect.initialize(),
         inputs: []
     });
 
@@ -26,16 +26,7 @@ exports.rxMultiSelect = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            } else {
-                component = rxMultiSelect.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxMultiSelect.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('hides the menu initially', function () {

--- a/src/components/rxOptionTable/scripts/rxOptionTable.exercise.js
+++ b/src/components/rxOptionTable/scripts/rxOptionTable.exercise.js
@@ -5,8 +5,7 @@ var rxOptionTable = require('./rxOptionTable.page').rxOptionTable;
  * @description rxOptionTable exercises.
  * @exports exercise/rxOptionTable
  * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxOptionTable} [options.instance=rxOptionTable.initialize] - Component to exercise.
- * @param {string} [options.cssSelector] - **DEPRECATED**: Fallback selector string to initialize widget with.
+ * @param {rxOptionTable} [options.instance={@link rxOptionTable.initialize}] - Component to exercise.
  * @param {string} [options.visible=true] - Determines if the option table is visible
  * @param {string} [options.empty=false] - Determines if the option table is empty
  */
@@ -16,6 +15,7 @@ exports.rxOptionTable = function (options) {
     }
 
     options = _.defaults(options, {
+        instance: rxOptionTable.initialize(),
         visible: true,
         empty: false
     });
@@ -24,16 +24,7 @@ exports.rxOptionTable = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            } else {
-                component = rxOptionTable.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxOptionTable.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should ' + (options.visible ? 'be' : 'not be') + ' visible', function () {

--- a/src/components/rxPaginate/scripts/rxPaginate.exercise.js
+++ b/src/components/rxPaginate/scripts/rxPaginate.exercise.js
@@ -1,13 +1,10 @@
 var _ = require('lodash');
 
-var rxPaginate = require('./rxPaginate.page').rxPaginate;
-
 /**
  * rxPaginate exercises.
  * @exports exercise/rxPaginate
- * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxPaginate} [options.instance=rxPaginate.initialize] - Component to exercise.
- * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
+ * @param {Object} options - Test options. Used to build valid tests.
+ * @param {rxPaginate} options.instance - Component to exercise.
  * @param {String} [options.pages=6] - Estimated page size in the pagination widget.
  * @param {Number[]} [options.pageSizes=[50, 200, 350, 500]] - Page sizes to validate.
  * @param {Number} [options.defaultPageSize=50] - Default page size on page load.
@@ -34,16 +31,7 @@ exports.rxPaginate = function (options) {
         var pagination;
 
         before(function () {
-            if (options.instance !== undefined) {
-                pagination = options.instance;
-            } else {
-                pagination = rxPaginate.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                pagination = rxPaginate.initialize($(options.cssSelector));
-            }
+            pagination = options.instance;
         });
 
         if (options.pages > 1) {

--- a/src/components/rxRadio/scripts/rxRadio.exercise.js
+++ b/src/components/rxRadio/scripts/rxRadio.exercise.js
@@ -1,12 +1,10 @@
 var _ = require('lodash');
-var rxRadio = require('./rxRadio.page').rxRadio;
 
 /**
  * @description rxRadio exercises
  * @exports exercise/rxRadio
- * @param {Object} [options] - Test options. Used to build valid tests.
+ * @param {Object} options - Test options. Used to build valid tests.
  * @param {rxRadio} options.instance - Component to exercise.
- * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
  * @param {Boolean} [options.disabled=false] - Whether or not the radio button is disabled at the start of the exercise.
  * @param {Boolean} [options.selected=false] - Whether or not the radio button is selected at the start of the exercise.
  * @param {Boolean} [options.visible=true] - Whether or not the radio button is visible at the start of the exercise.
@@ -28,14 +26,7 @@ exports.rxRadio = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxRadio.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should be present', function () {

--- a/src/components/rxSearchBox/scripts/rxSearchBox.exercise.js
+++ b/src/components/rxSearchBox/scripts/rxSearchBox.exercise.js
@@ -1,13 +1,11 @@
 var _ = require('lodash');
-var rxSearchBox = require('./rxSearchBox.page').rxSearchBox;
 
 /**
  * @description rxSearchBox exercises.
  * @see rxSearchBox
  * @exports exercise/rxSearchBox
- * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxSearchBox} [options.instance=rxSearchbox.initialize()] - Component to exercise.
- * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
+ * @param {Object} options - Test options. Used to build valid tests.
+ * @param {rxSearchBox} options.instance - Component to exercise.
  * @param {Boolean} [options.disabled=false] - Determines if the search box is disabled at the start of the exercise.
  * @param {String} [options.placeholder='Search...'] - Expected placeholder value.
  * @example
@@ -30,16 +28,7 @@ exports.rxSearchBox = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            } else {
-                component = rxSearchBox.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxSearchBox.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should show the element', function () {

--- a/src/components/rxSelect/scripts/rxSelect.exercise.js
+++ b/src/components/rxSelect/scripts/rxSelect.exercise.js
@@ -1,13 +1,11 @@
 var _ = require('lodash');
-var rxSelect = require('./rxSelect.page').rxSelect;
 
 /**
  * @description rxSelect exercises.
  * @see rxSelect
  * @exports exercise/rxSelect
- * @param {Object} [options] - Test options. Used to build valid tests.
+ * @param {Object} options - Test options. Used to build valid tests.
  * @param {rxSelect} options.instance - Component to exercise.
- * @param {string} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
  * @param {Boolean} [options.disabled=false] - Determines if the select is disabled
  * @param {Boolean} [options.visible=true] - Determines if the select is visible
  * @param {Boolean} [options.valid=true] - Determines if the select is valid
@@ -28,14 +26,7 @@ exports.rxSelect = function (options) {
         var component;
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxSelect.initialize($(options.cssSelector));
-            }
+            component = options.instance;
         });
 
         it('should be present', function () {

--- a/src/components/rxToggleSwitch/scripts/rxToggleSwitch.exercise.js
+++ b/src/components/rxToggleSwitch/scripts/rxToggleSwitch.exercise.js
@@ -1,13 +1,11 @@
 var _ = require('lodash');
-var rxToggleSwitch = require('./rxToggleSwitch.page').rxToggleSwitch;
 
 /**
  * @description rxToggleSwitch exercises.
  * @see rxToggleSwitch
  * @exports exercise/rxToggleSwitch
- * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxToggleSwitch} [options.instance=rxToggleSwitch.initialize()] - Component to exercise.
- * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
+ * @param {Object} options - Test options. Used to build valid tests.
+ * @param {rxToggleSwitch} options.instance - Component to exercise.
  * @param {Boolean} [options.disabled=false] - Determines if the switch can be toggled.
  * @param {Boolean} [options.enabledAtStart=null] -
  * Beginning state of toggle switch. The value will be detected automatically if not given.
@@ -45,17 +43,7 @@ exports.rxToggleSwitch = function (options) {
         };
 
         before(function () {
-            if (options.instance !== undefined) {
-                component = options.instance;
-            } else {
-                component = rxToggleSwitch.initialize();
-            }
-
-            if (options.cssSelector !== undefined) {
-                console.warn('Deprecated exercise option `cssSelector` will be removed in favor of `instance`');
-                component = rxToggleSwitch.initialize($(options.cssSelector));
-            }
-
+            component = options.instance;
             component.isEnabled().then(function (isEnabled) {
                 // use option if available, otherwise use detected state
                 enabledAtStart = _.isNull(options.enabledAtStart) ? isEnabled : options.enabledAtStart;


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-211

### LGTMs
- [x] Dev LGTM
- [x] Dev/QE LGTM

FRMW-211 #in-review

BREAKING CHANGE: You will need to refer to the component under test
using the `instance` option, which should be a page object that you
instantiate yourself, and hand into the exercise.