### PR TITLE
docs(rxPageObjects): clarify rxNotify; fix memberof typo

### DIFF
--- a/src/components/rxApp/scripts/rxPage.page.js
+++ b/src/components/rxApp/scripts/rxPage.page.js
@@ -63,7 +63,7 @@ var rxPage = {
 exports.rxPage = {
     /**
      * @function
-     * @memeberof rxPage
+     * @memberof rxPage
      * @description Creates a page object from an `rx-page` DOM element.
      * @param {ElementFinder} [rxFeedbackElement=$('rx-page')] -
      * ElementFinder to be transformed into an {@link rxPage} object.

--- a/src/components/rxSortableColumn/scripts/rxSortableColumn.page.js
+++ b/src/components/rxSortableColumn/scripts/rxSortableColumn.page.js
@@ -331,7 +331,7 @@ exports.rxSortableColumn = {
 
     /**
      * @function
-     * @memeberof rxSortableColumn
+     * @memberof rxSortableColumn
      * @param {ElementFinder} rxSortableColumnElement - ElementFinder to be transformed into an rxSortableColumn object.
      * @param {String} [repeaterString] - Repeater string from the table. Required for {@link rxSortableColumn#data}
      * and {@link rxSortableColumn#getDataUsing}.
@@ -353,7 +353,7 @@ exports.rxSortableColumn = {
      * @function
      * @description Entry point for the {@link rxSortableColumns} namespace. Used to return information
      * about an entire table's worth of columns.
-     * @memeberof rxSortableColumn
+     * @memberof rxSortableColumn
      * @param {ElementFinder} tableElement - ElementFinder of the entire `<table>` node.
      * @returns {rxSortableColumns} Page object representing the {@link rxSortableColumns} object.
      */
@@ -366,7 +366,7 @@ exports.rxSortableColumn = {
     },
 
     /**
-     * @memeberof rxSortableColumn
+     * @memberof rxSortableColumn
      * @description A lookup for comparing sort directions against hard coded values, instead of integers.
      * @returns {Object} sortDirections Lookup of integer codes for sort directions from human-readable ones.
      * @property {Number} ascending - The numeral value one. Means the arrow is pointed down. [0-9, a-z]

--- a/src/utilities/rxNotify/scripts/rxNotify.page.js
+++ b/src/utilities/rxNotify/scripts/rxNotify.page.js
@@ -57,7 +57,7 @@ var notification = function (rootElement) {
          * @example
          * it('should have the right notification text', function () {
          *     var notificationText = encore.rxNotify.all.byText('Something bad happened').text;
-         *     expect(notificationType).to.eventually.equal('Something bad happened: Contact joe@rackspace.com');
+         *     expect(notificationText).to.eventually.equal('Something bad happened: Contact joe@rackspace.com');
          * });
          */
         text: {
@@ -240,7 +240,7 @@ var rxNotify = {
 
 exports.rxNotify = {
     /**
-     * @memeberof rxNotify
+     * @memberof rxNotify
      * @function
      * @type {rxNotify.notification}
      * @param {ElementFinder} [rxNotificationElement=$('.rx-notifications .rx-notification')] -
@@ -259,7 +259,7 @@ exports.rxNotify = {
     },
 
     /**
-     * @memeberof rxNotify
+     * @memberof rxNotify
      * @function
      * @description Returns a collection of functions used to interact with a group of notifications in a stack.
      * @returns {rxNotify}
@@ -282,7 +282,7 @@ exports.rxNotify = {
 
     /**
      * @deprecated Use {@link rxNotify.initialize} without arguments instead.
-     * @memeberof rxNotify
+     * @memberof rxNotify
      * @type {rxNotify.notification}
      * @description The first notification present on the page. Does not return
      * a collection of notification page objects, but a singular notification page object.
@@ -292,7 +292,7 @@ exports.rxNotify = {
     })(),
 
     /**
-     * @memeberof rxNotify
+     * @memberof rxNotify
      * @type {rxNotify}
      * @description Returns a collection of functions used to interact with all notifications on the page.
      * @see rxNotify.byStack


### PR DESCRIPTION
JIRA: (NONE)
This PR fixes an unclear example in the `rxNotify` page object documentation.
![screen shot 2016-04-05 at 2 20 56 pm](https://cloud.githubusercontent.com/assets/6632454/14295100/d551607a-fb39-11e5-9b14-2b60ec8f7d58.png)

##### LGTM
- [x] Dev LGTM


