### PR TITLE
FRM-452 fix(rxCharacterCount): Solve max call stack

### DIFF
--- a/src/components/rxCharacterCount/scripts/rxCharacterCount.js
+++ b/src/components/rxCharacterCount/scripts/rxCharacterCount.js
@@ -72,7 +72,7 @@ angular.module('encore.ui.rxCharacterCount')
  * <textarea ng-model="model" rx-character-count></textarea>
  * </pre>
  */
-.directive('rxCharacterCount', function ($compile) {
+.directive('rxCharacterCount', function ($compile, $timeout) {
     var counterStart = '<div class="character-countdown" ';
     var counterEnd =   'ng-class="{ \'near-limit\': nearLimit, \'over-limit\': overLimit }"' +
                   '>{{ remaining }}</div>';
@@ -168,9 +168,18 @@ angular.module('encore.ui.rxCharacterCount')
             }
 
             scope.$on('$destroy', function () {
-                element.off('input', writeLimitText);
-                wrapper.remove();
+                element.off('input');
+                $timeout(function () {
+                    // When the element containing the rx-character-count is removed, we have to
+                    // ensure we also remove the `wrapper`, which we created. We have to manually
+                    // destroy its scope and remove the element itself. All of this has to happen
+                    // in a $timeout() to ensure it occurs on the next $digest cycle, otherwise
+                    // we go into an infinite loop
+                    wrapper.scope().$destroy();
+                    wrapper.remove();
+                });
             });
+
         }
     };
 });


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-452

### LGTMs
- [x] Dev LGTM
- [x] Dev LGTM
- [x] QE LGTM

In some situations, our cleanup code in rxCharacterCount was causing
a "maximum call stack size exceeded" error. I've moved some of the cleanup
code into a $timeout to solve this.