### PR TITLE
fix(styles): rx-example using incorrect css class

### DIFF
--- a/demo/templates/rx-example.html
+++ b/demo/templates/rx-example.html
@@ -1,4 +1,4 @@
-<div class="example">
+<div class="rx-example">
   <tabset>
     <tab heading="Demo">
       <div ng-include="markup_url"></div>


### PR DESCRIPTION
JIRA: n/a

`.example` styles brought in from #1640 affected rxExample

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] Design LGTM

### Before
<img width="1120" alt="screen shot 2016-05-05 at 8 32 18 pm" src="https://cloud.githubusercontent.com/assets/545605/15061949/c9513eba-1300-11e6-837f-87f22ef41310.png">

### After
<img width="1112" alt="screen shot 2016-05-05 at 8 34 26 pm" src="https://cloud.githubusercontent.com/assets/545605/15061951/cfe1132c-1300-11e6-9254-09578da52776.png">
