### PR TITLE
test(ci): Move all selenium based work to codeship

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,40 +2,21 @@ sudo: false
 language: node_js
 node_js:
   - "5.1.1" # same as .node-version
-addons:
-  firefox: "35.0"
-  apt:
-    packages:
-      - libcairo2-dev
-      - libjpeg8-dev
-      - libpango1.0-dev
-      - libgif-dev
-      - build-essential
-      - g++
 before_install:
+- node ./utils/quitIfFork.js
 - npm install -g grunt-cli bower
 install:
 - travis_retry npm install
 - bower install
-- ./node_modules/.bin/webdriver-manager update --standalone
 before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - bower install
 - grunt connect:keepalive &
-- nohup bash -c "./node_modules/.bin/webdriver-manager start 2>&1 &"
-- sleep 5 # wait for selenium server to actually come up
 script:
 - grunt
 - grunt test:full
-- ./node_modules/.bin/protractor
 - grunt karma:minified
 after_success:
 - grunt coveralls
-- ./utils/visual-regression/clone.sh
-- ./utils/visual-regression/test.sh
-- ./utils/visual-regression/push.sh
-- ./utils/visual-regression/pr.sh
 env:
   global:
   - secure: S6sdJYgRgdlwGR14hTH8zYSkF+bvjKiCEpsxHdiQLJL6T9hgByObdkpiOiKnt4Y2uuAfY0JUKsM/TG4apN22mH0R+xafmYx7+uMMEcBDB5EWJtohdaCkg/GgRFRTs5FkkJKBS+lIObDjjRyeGFh2uGjyXTTgtp+m1FIFj3mOQlw=

--- a/utils/quitIfFork.js
+++ b/utils/quitIfFork.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+'use strict';
+
+let errorMessage = `
+*************************************************************
+*************************************************************
+*******************  "YOU SHALL NOT PASS"  ******************
+*************************************************************
+*************************************************************
+
+Stop pushing from forks! This is to remind you that all builds should be targeting rackerlabs/encore-ui.
+For most people seeing this message, it means to stop running "git push origin branch-name", and start
+running "git push upstream branch-name" when creating pull requests. To fix this:
+
+If you are not a Rackspace employee:
+
+1. Thank you for your interest in making EncoreUI better.
+2. Make a comment on the pull request mentioning @rackerlabs/encore-ui-admin stating that you need your PR reviewed.
+
+We'll do our best to make sure that someone can clone your branch and re-run it for you to make sure that
+it passes all of our quality checks. In the meantime, thank you for your patience.
+
+Otherwise:
+
+1. Close the PR associated with this travis build.
+2. Push the exact same branch up to the upstream remote located at git@github.com:rackerlabs/encore-ui.git
+3. Create a new pull request.
+`;
+
+if (process.env.TRAVIS_SECURE_ENV_VARS === 'false') {
+    console.error(errorMessage);
+    process.exit(1);
+};


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-853

Half of this stuff is now located at https://codeship.com/projects/102410

This does not include getting rid of `grunt phantomjs-check:allModules`, which will happen after this PR lands.

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM