### PR TITLE
Upgrade to the latest ng1.3-compatible version of ngBootstrap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "angular-sanitize": "~1.3.20",
     "angular-resource": "~1.3.20",
     "angular-route": "~1.3.20",
-    "angular-bootstrap": "~0.13.0",
+    "angular-bootstrap": "0.14.3",
     "lodash": "~2.4.1",
     "moment": "~2.9.0",
     "html2canvas": "~0.4.1",

--- a/grunt-tasks/modules.js
+++ b/grunt-tasks/modules.js
@@ -142,6 +142,10 @@ module.exports = function (grunt) {
 
         // Set the concat task to concatenate the given src modules
         var srcFiles = _.pluck(modules, 'srcFiles'); // OK
+
+        // Prepend ngBootstrap overrides to suppress v0.14.3 deprecation warnings
+        srcFiles = [ 'src/ngBootstrapOverrides.js' ].concat(srcFiles);
+
         grunt.config('concat.dist.src', grunt.config('concat.dist.src').concat(srcFiles));
 
         // Set the concat-with-templates task to concat the given src & tpl modules

--- a/src/components/rxCharacterCount/scripts/rxCharacterCount.js
+++ b/src/components/rxCharacterCount/scripts/rxCharacterCount.js
@@ -171,11 +171,9 @@ angular.module('encore.ui.rxCharacterCount')
                 element.off('input');
                 $timeout(function () {
                     // When the element containing the rx-character-count is removed, we have to
-                    // ensure we also remove the `wrapper`, which we created. We have to manually
-                    // destroy its scope and remove the element itself. All of this has to happen
+                    // ensure we also remove the `wrapper`, which we created. This has to happen
                     // in a $timeout() to ensure it occurs on the next $digest cycle, otherwise
-                    // we go into an infinite loop
-                    wrapper.scope().$destroy();
+                    // we go into an infinite loop.
                     wrapper.remove();
                 });
             });

--- a/src/components/rxModalAction/scripts/rxModalAction.js
+++ b/src/components/rxModalAction/scripts/rxModalAction.js
@@ -66,7 +66,7 @@ angular.module('encore.ui.rxModalAction')
  * </rx-modal-action>
  * </pre>
  */
-.directive('rxModalAction', function ($modal) {
+.directive('rxModalAction', function ($uibModal) {
     var createModal = function (config, scope) {
         config = _.defaults(config, {
             templateUrl: config.templateUrl,
@@ -76,7 +76,7 @@ angular.module('encore.ui.rxModalAction')
 
         config.windowClass = 'rxModal';
 
-        var modal = $modal.open(config);
+        var modal = $uibModal.open(config);
 
         return modal;
     };

--- a/src/components/rxModalAction/scripts/rxModalAction.spec.js
+++ b/src/components/rxModalAction/scripts/rxModalAction.spec.js
@@ -42,7 +42,7 @@ describe('rxModalAction', function () {
 
         // Provide any mocks needed
         module(function ($provide) {
-            $provide.value('$modal', modalApi);
+            $provide.value('$uibModal', modalApi);
         });
 
         // Inject in angular constructs

--- a/src/components/tooltips/tooltips.module.js
+++ b/src/components/tooltips/tooltips.module.js
@@ -21,7 +21,7 @@
  * <rx-button tooltip="...">
  * </pre>
  *
- * If you're creating your own custom directive, it's fine to use the `tooltip` 
+ * If you're creating your own custom directive, it's fine to use the `tooltip`
  * directive inside of your directive's template.  See the tooltips component
  * {@link /encore-ui/#/components/tooltips demo} for example usage.
  *

--- a/src/ngBootstrapOverrides.js
+++ b/src/ngBootstrapOverrides.js
@@ -1,0 +1,29 @@
+/**
+ * This file is meant to be a bandaid while we remove our dependency
+ * on ngBootstrap.  ngBootstrap 0.14.3 throws all sorts of console
+ * warnings for renamed directives.  Rather than having all apps update
+ * their code to correct the ngBootstrap warnings and update again
+ * when we remove those dependencies, we'll disable the warnings and
+ * work on the replacements for ngBoostrap directives. This way apps
+ * will only need to update once (to rx-prefixed directives).
+ */
+
+// Components > typeahead
+angular.module('ui.bootstrap.typeahead')
+    .value('$typeaheadSuppressWarning', true);
+
+// Components > tooltips
+angular.module('ui.bootstrap.tooltip')
+    .value('$tooltipSuppressWarning', true);
+
+// Elements > Tabs
+angular.module('ui.bootstrap.tabs')
+    .value('$tabsSuppressWarning', true);
+
+// Elements > Progress Bars
+angular.module('ui.bootstrap.progressbar')
+    .value('$progressSuppressWarning', true);
+
+// Components > rxModalAction
+angular.module('ui.bootstrap.modal')
+    .value('$modalSuppressWarning', true);


### PR DESCRIPTION
JIRA: n/a

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] QE LGTM

### Summary
This PR updates to ngBootstrap 0.14.3 (last version to support ng1.3). With it, many console warnings appeared, suggesting to modify usage to use the new `uib` prefixed directives and services.

Two actions were taken:

1. Dependencies were updated only where it would be seamless to our consumers (`$modal` -> `$uibModal`), leaving most implementations as is.
2. Suppressed deprecation warnings from ngBootstrap to prevent getting in the way of consumers' development workflow.

### Result
This will get us to the latest supported ngBootstrap functionality, while making it seamless to our consumers. This should buy us time to remove our dependency on ngBootstrap before we upgrade to ng1.4+ in Spring 2017 (estimated).