### PR TITLE
fix(rxApp): fix embedded demo for Firefox

### DIFF
--- a/src/components/rxApp/docs/rxApp.js
+++ b/src/components/rxApp/docs/rxApp.js
@@ -128,5 +128,9 @@ angular.module('demoApp')
     }];
 
     // Load docs homepage ('Overview')
-    $scope.embedUrl = $location.absUrl().split('#')[0];
+    // NOTE: Trailing forward slash is not an accident.
+    // This is required to get Firefox to load the iframe.
+    //
+    // The resulting url should have double forward slashes `//`.
+    $scope.embedUrl = $location.absUrl().split('#')[0] + '/';
 });


### PR DESCRIPTION
JIRA: n/a

### Background

The "Embedded rxApp" example at http://rackerlabs.github.io/encore-ui/#/components/rxApp does not work with Firefox (any version... at least between 22 and 48alpha), but it works in Chrome. Hard coding the `src` value on the iframe didn't help for an Angular-loaded template. The basic demo at http://output.jsbin.com/sihocux verified that static iframes work perfectly in all browsers. When I attempted to modify the `src` attribute to go to an Angular-redirect url, I noticed it worked again and discovered that adding a single forward slash to the original url fixed everything.

[insert facepalm here]

### LGTMs
- [x] Dev LGTM
