### PR TITLE
fix(metadataSimpleExample): consistentify date format with styleguide

### DIFF
--- a/src/elements/Metadata/docs/examples/metadata.simple.html
+++ b/src/elements/Metadata/docs/examples/metadata.simple.html
@@ -24,7 +24,7 @@
     <section>
       <rx-meta label="Amount">{{ someAmount | currency }}</rx-meta>
       <rx-meta label="Phone Number Field">888 - 888 - 8888</rx-meta>
-      <rx-meta label="Date Field">{{ someDate | date:'MMMM d, yyyy @ HH:mm (UTCZ)' }}</rx-meta>
+      <rx-meta label="Date Field">{{ someDate | date:'MMM d, yyyy @ HH:mm (UTCZ)' }}</rx-meta>
       <rx-meta label="Link Field">
         <a href="#">Link</a>
       </rx-meta>


### PR DESCRIPTION
#### Description:
This example is at http://rackerlabs.github.io/encore-ui/#/elements/Metadata

It conflicts with http://rackerlabs.github.io/encore-ui/#/styles/formatting
which states
> _Dates in any context should be formatted this way: Mar 2, 2015 @ 15:40 (UTC-0600) — a three-letter capitalized month abbreviation (no period), followed by the day of the month (no leading zeroes), a comma, the four-digit year, an @ symbol, military time, and UTC in parentheses._

CC: @ErnieAtLYD 

![screen shot 2016-06-06 at 3 14 21 pm](https://cloud.githubusercontent.com/assets/6632454/15934669/0a582a24-2e2a-11e6-9375-0e0b007ebd37.png)

![screen shot 2016-06-06 at 3 14 42 pm](https://cloud.githubusercontent.com/assets/6632454/15934675/0e9e0752-2e2a-11e6-9681-210ed8876125.png)




JIRA: NONE

### LGTMs
- [ ] Dev LGTM
- [ ] Dev+Vidyo LGTM
- [ ] Design LGTM
- [ ] QE LGTM

