### PR TITLE
docs(rxToggleSwitch): rename 'var switch = ' in @example

### DIFF
--- a/utils/rx-page-objects/src/rxToggleSwitch.page.js
+++ b/utils/rx-page-objects/src/rxToggleSwitch.page.js
@@ -44,12 +44,12 @@ var rxToggleSwitch = {
      * set to this position, nothing happens.
      * @example
      * it('should enable the switch', function () {
-     *     var switch = encore.rxToggleSwitch.initialize();
-     *     expect(switch.isEnabled()).to.eventually.be.false;
-     *     switch.enable();
-     *     expect(switch.isEnabled()).to.eventually.be.true;
-     *     switch.enable(); // does nothing the second time it is called
-     *     expect(switch.isEnabled()).to.eventually.be.true;
+     *     var mySwitch = encore.rxToggleSwitch.initialize();
+     *     expect(mySwitch.isEnabled()).to.eventually.be.false;
+     *     mySwitch.enable();
+     *     expect(mySwitch.isEnabled()).to.eventually.be.true;
+     *     mySwitch.enable(); // does nothing the second time it is called
+     *     expect(mySwitch.isEnabled()).to.eventually.be.true;
      * });
      */
     enable: {
@@ -87,12 +87,12 @@ var rxToggleSwitch = {
      * set to this position, nothing happens.
      * @example
      * it('should disable the switch', function () {
-     *     var switch = encore.rxToggleSwitch.initialize();
-     *     expect(switch.isEnabled()).to.eventually.be.true;
-     *     switch.disable();
-     *     expect(switch.isEnabled()).to.eventually.be.false;
-     *     switch.disable(); // does nothing the second time it is called
-     *     expect(switch.isEnabled()).to.eventually.be.false;
+     *     var mySwitch = encore.rxToggleSwitch.initialize();
+     *     expect(mySwitch.isEnabled()).to.eventually.be.true;
+     *     mySwitch.disable();
+     *     expect(mySwitch.isEnabled()).to.eventually.be.false;
+     *     mySwitch.disable(); // does nothing the second time it is called
+     *     expect(mySwitch.isEnabled()).to.eventually.be.false;
      * });
      */
     disable: {
@@ -112,9 +112,9 @@ var rxToggleSwitch = {
      * @type {String}
      * @example
      * it('should toggle to the "on" position', function () {
-     *     var switch = encore.rxToggleSwitch.initialize();
-     *     switch.enable();
-     *     expect(switch.text).to.eventually.equal('ON');
+     *     var mySwitch = encore.rxToggleSwitch.initialize();
+     *     mySwitch.enable();
+     *     expect(mySwitch.text).to.eventually.equal('ON');
      * });
      */
     text: {


### PR DESCRIPTION
This PR is a quick improvement to the example documentation for `rxToggleSwitch`.
http://rackerlabs.github.io/encore-ui/rx-page-objects/rxToggleSwitch.html

Because `switch` is a reserved word in JavaScript,
`var switch = ...`
would be better as
`var mySwitch = ...` 

This caused an issue for @arc6789 this morning.

![screen shot 2016-06-17 at 11 03 38 am](https://cloud.githubusercontent.com/assets/6632454/16156758/4ffd0836-347b-11e6-8f16-de456e74c117.png)

![screen shot 2016-06-17 at 11 08 22 am](https://cloud.githubusercontent.com/assets/6632454/16156893/dbd3cdea-347b-11e6-97ad-388ea3c83568.png)

### LGTMs
- [x] Dev LGTM
