### PR TITLE
docs(rx-page-objects): fix typos

### DIFF
--- a/utils/rx-page-objects/src/rxCharacterCount.exercise.js
+++ b/utils/rx-page-objects/src/rxCharacterCount.exercise.js
@@ -7,7 +7,7 @@ var rxCharacterCount = require('./rxCharacterCount.page').rxCharacterCount;
  * @exports exercise/rxCharacterCount
  * @returns {function} A function to be passed to mocha's `describe`.
  * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxCharacterCount} [options.instance={@link rxCharacterCount.intiailize}] - Component to exercise.
+ * @param {rxCharacterCount} [options.instance={@link rxCharacterCount.initialize}] - Component to exercise.
  * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
  * @param {Number} [options.maxCharacters=254] - The total number of characters allowed.
  * @param {Number} [options.nearLimit=10] - The number of remaining characters needed to trigger the "near-limit" class.

--- a/utils/rx-page-objects/src/rxDatePicker.page.js
+++ b/utils/rx-page-objects/src/rxDatePicker.page.js
@@ -372,7 +372,7 @@ exports.rxDatePicker = {
      * @function
      * @memberof rxDatePicker
      * @param {ElementFinder} rxDatePickerElement - ElementFinder to be transformed into an rxDatePicker page object.
-     * @returns {rxDatePicker} Page object representing the rxDatepicker element.
+     * @returns {rxDatePicker} Page object representing the rxDatePicker element.
      */
     initialize: function (rxDatePickerElement) {
         if (rxDatePickerElement === undefined) {

--- a/utils/rx-page-objects/src/rxFloatingHeader.page.js
+++ b/utils/rx-page-objects/src/rxFloatingHeader.page.js
@@ -5,7 +5,7 @@ exports.rxFloatingHeader = {
     /**
      * @deprecated Use rxMisc.scrollToElement
      * @description
-     * **ALIASED**: Plese use {@link rxMisc.scrollToElement} instead.
+     * **ALIASED**: Please use {@link rxMisc.scrollToElement} instead.
      * This function will be removed in a future release of the framework.
      */
     scrollToElement: function (elem) {
@@ -15,7 +15,7 @@ exports.rxFloatingHeader = {
     /**
      * @deprecated Use rxMisc.compareYLocations
      * @description
-     * **ALIASED**: Plese use {@link rxMisc.compareYLocations} instead.
+     * **ALIASED**: Please use {@link rxMisc.compareYLocations} instead.
      * This function will be removed in a future release of the framework.
      */
     compareYLocations: function (e1, e2) {
@@ -25,7 +25,7 @@ exports.rxFloatingHeader = {
     /**
      * @deprecated Use rxMisc.compareXLocations
      * @description
-     * **ALIASED**: Plese use {@link rxMisc.compareXLocations} instead.
+     * **ALIASED**: Please use {@link rxMisc.compareXLocations} instead.
      * This function will be removed in a future release of the framework.
      */
     compareXLocations: function (e1, e2) {
@@ -35,7 +35,7 @@ exports.rxFloatingHeader = {
     /**
      * @deprecated Use rxMisc.transformLocation
      * @description
-     * **ALIASED**: Plese use {@link rxMisc.transformLocation} instead.
+     * **ALIASED**: Please use {@link rxMisc.transformLocation} instead.
      * This function will be removed in a future release of the framework.
      */
     transformLocation: function (elementOrLocation, attribute) {

--- a/utils/rx-page-objects/src/rxModalAction.page.js
+++ b/utils/rx-page-objects/src/rxModalAction.page.js
@@ -123,7 +123,7 @@ exports.rxModalAction = {
      * @param {Object} [customFunctionality={}] - Page object to extend on top of {@link rxModalAction}.
      * @returns {rxModalAction}
      * @example
-     * var customFunctionalty = {
+     * var customFunctionality = {
      *     txtNewPassword: {
      *         get: function () {
      *             // `this.rootElement` is never defined here.
@@ -152,7 +152,7 @@ exports.rxModalAction = {
      *
      * // this modal not only has a close button, title, etc...
      * // but also a couple of form elements for checking an old password and a new password.
-     * changePasswordModal = modal.initialize(customFunctionalty);
+     * changePasswordModal = modal.initialize(customFunctionality);
      */
     initialize: function (customFunctionality) {
         if (!_.isObject(customFunctionality)) {

--- a/utils/rx-page-objects/src/rxNotify.page.js
+++ b/utils/rx-page-objects/src/rxNotify.page.js
@@ -278,7 +278,7 @@ exports.rxNotify = {
      * @function
      * @type {rxNotify.notification}
      * @param {ElementFinder} [rxNotificationElement=$('.rx-notifications .rx-notification')] -
-     * The *singluar* rxNotify notification element to be transformed into an {@link rxNotify.notification} page object.
+     * The *singular* rxNotify notification element to be transformed into an {@link rxNotify.notification} page object.
      * @description Create a single {@link rxNotify.notification} page object from a DOM element.
      * @example
      * it('should have a notification', function () {

--- a/utils/rx-page-objects/src/rxSearchBox.exercise.js
+++ b/utils/rx-page-objects/src/rxSearchBox.exercise.js
@@ -6,7 +6,7 @@ var rxSearchBox = require('./rxSearchBox.page').rxSearchBox;
  * @see rxSearchBox
  * @exports exercise/rxSearchBox
  * @param {Object} [options] - Test options. Used to build valid tests.
- * @param {rxSearchBox} [options.instance=rxSearchbox.initialize()] - Component to exercise.
+ * @param {rxSearchBox} [options.instance=rxSearchBox.initialize()] - Component to exercise.
  * @param {String} [options.cssSelector] - DEPRECATED: Fallback selector string to initialize widget with.
  * @param {Boolean} [options.disabled=false] - Determines if the search box is disabled at the start of the exercise.
  * @param {String} [options.placeholder='Search...'] - Expected placeholder value.

--- a/utils/rx-page-objects/src/rxTags.page.js
+++ b/utils/rx-page-objects/src/rxTags.page.js
@@ -69,7 +69,7 @@ var tag = function (tagElement) {
          * @returns {Boolean}
          * @example
          * it('should focus on the last tag when clicking it', function () {
-         *     encore.rxTags.intitialize().addTag('Banana').then(function (tag) {
+         *     encore.rxTags.initialize().addTag('Banana').then(function (tag) {
          *         expect(tag.isFocused()).to.eventually.be.false;
          *         tag.click();
          *         expect(tag.isFocused()).to.eventually.be.true;

--- a/utils/rx-page-objects/test/rxModalAction.midway.js
+++ b/utils/rx-page-objects/test/rxModalAction.midway.js
@@ -3,7 +3,7 @@ var modal = encore.rxModalAction;
 describe('rxModalAction', function () {
     var changePasswordModal, triggerModal;
 
-    var customFunctionalty = {
+    var customFunctionality = {
         txtNewPassword: {
             get: function () {
                 return this.rootElement.element(by.model('fields.password'));
@@ -33,7 +33,7 @@ describe('rxModalAction', function () {
             encore.rxMisc.slowClick($('#modChangePassword .modal-link'));
         };
 
-        changePasswordModal = modal.initialize(customFunctionalty);
+        changePasswordModal = modal.initialize(customFunctionality);
     });
 
     it('should not display the modal unless triggered', function () {


### PR DESCRIPTION
> _This PR fixes a couple of minor typos in the documentation for `rx-page-objects`_

### LGTMs
- [ ] Dev LGTM
- [ ] Dev LGTM

