### PR TITLE
fix(rxAge): Fixes parseInt bug

### DIFF
--- a/src/utilities/rxAge/scripts/rxAge.js
+++ b/src/utilities/rxAge/scripts/rxAge.js
@@ -73,9 +73,9 @@ angular.module('encore.ui.utilities')
         var date = moment(new Date(dateString));
         var diff = now.diff(date);
         var duration = moment.duration(diff);
-        var days = parseInt(duration.asDays(), 10);
-        var hours = parseInt(duration.asHours(), 10);
-        var mins = parseInt(duration.asMinutes(), 10);
+        var days = Math.floor(duration.asDays());
+        var hours = Math.floor(duration.asHours());
+        var mins = Math.floor(duration.asMinutes());
         var age = [];
 
         if (_.isBoolean(maxUnits)) {


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1000

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] QE LGTM

With really small durations moment returns a small float
parseInt handles this weirdly returning 1 and sometimes 2
Changes implementation to use Math.floor

Issue: https://github.com/rackerlabs/encore-ui/issues/1767