### PR TITLE
fix(rxPageObjects): lock to typescript 2.0.2

### DIFF
--- a/utils/rx-page-objects/package.json
+++ b/utils/rx-page-objects/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "protractor-console-plugin": "^0.1.1",
-    "typescript": "^2.0.0-dev.20160707",
+    "typescript": "2.0.2",
     "typings": "^1.3.1"
   }
 }


### PR DESCRIPTION
JIRA: n/a

### LGTMs
- [x] Dev LGTM

TypeScript 2.0.3 (patch-level release) introduced breaking changes. Locking to 2.0.2 until we have time to properly upgrade.