### PR TITLE
chore(Environment): Match origin as prod

### DIFF
--- a/src/utilities/Environment/scripts/Environment.js
+++ b/src/utilities/Environment/scripts/Environment.js
@@ -119,22 +119,29 @@ angular.module('encore.ui.utilities')
         // http://encore.dev/
         // http://apps.server/
         name: 'local',
-        pattern: /\/\/(?:apps\.)?(localhost|server|(.*)\.dev)(:\d{1,4})?/,
+        pattern: /\/\/(?:\w+\.)?(localhost|server|(.*)\.dev)(:\d{1,4})?/,
         url: '//' + $location.host() + ($location.port() !== 80 ? ':' + $location.port() : '') + '/{{path}}'
     }, {
-        // Matches only https://preprod.encore.rackspace.com
-        // Regexr: http://www.regexr.com/3de5p
+        // Matches only preprod and it's subdomains
+        // Regexr: http://www.regexr.com/3eani
+        // https://preprod.encore.rackspace.com
+        // https://apps.preprod.encore.rackspace.com
+        // https://cloud.preprod.encore.rackspace.com
         name: 'preprod',
-        pattern: /\/\/(?:apps\.)?preprod.encore.rackspace.com/,
+        pattern: /\/\/(?:\w+\.)?preprod.encore.rackspace.com/,
         url: '{{path}}'
     }, {
         // This is anything with a host preceeding encore.rackspace.com
-        // Regexr: http://www.regexr.com/3de5s
+        // Regexr: http://www.regexr.com/3eanl
         // https://staging.encore.rackspace.com/
         // https://preprod.encore.rackspace.com/
+        // https://apps.encore.rackspace.com
+        // https://apps.staging.encore.rackspace.com
+        // https://cloud.staging.encore.rackspace.com
         // https://apps.preprod.encore.rackspace.com/
+        // https://cloud.preprod.encore.rackspace.com/
         name: 'unified-preprod',
-        pattern: /\/\/(?:apps\.)?(\w+\.)encore.rackspace.com/,
+        pattern: /\/\/(?:\w+\.)?(\w+\.)encore.rackspace.com/,
         url: '{{path}}'
     }, {
         // This is *all* environments
@@ -148,10 +155,13 @@ angular.module('encore.ui.utilities')
         pattern: 'encore.rackspace.com',
         url: '{{path}}'
     }, {
-        // This is only https://encore.rackspace.com/
-        // Regexr: http://www.regexr.com/3de62
+        // This is only production only
+        // Regexr: http://www.regexr.com/3eal4
+        // https://encore.rackspace.com/
+        // https://apps.encore.rackspace.com
+        // https://origin.encore.rackspace.com
         name: 'unified-prod',
-        pattern: /\/\/(?:apps\.)?encore.rackspace.com/,
+        pattern: /\/\/(?:apps\.|origin\.)?encore.rackspace.com/,
         url: '{{path}}'
     }];
 

--- a/src/utilities/Environment/scripts/Environment.spec.js
+++ b/src/utilities/Environment/scripts/Environment.spec.js
@@ -30,45 +30,83 @@ describe('Environment', function () {
 
     it('should get current environment based on location passed in', function () {
         // test local
-        expect(envSvc.get('http://localhost:9001').name).to.equal('local');
+        expect(envSvc.envCheck('local', 'http://localhost:9001')).to.be.true;
 
         // test staging
-        expect(envSvc.get('http://staging.encore.rackspace.com').name).to.equal('unified-preprod');
+        expect(envSvc.envCheck('unified-preprod', 'http://staging.encore.rackspace.com')).to.be.true;
 
         // test prod
-        expect(envSvc.get('http://encore.rackspace.com').name).to.equal('unified');
+        expect(envSvc.envCheck('unified-prod', 'http://encore.rackspace.com')).to.be.true;
 
         // test unified-preprod
-        expect(envSvc.get('http://randenv.encore.rackspace.com').name).to.equal('unified-preprod');
+        expect(envSvc.envCheck('unified-preprod', 'http://randenv.encore.rackspace.com')).to.be.true;
 
         // test unified
-        expect(envSvc.get('http://encore.rackspace.com').name).to.equal('unified');
+        expect(envSvc.envCheck('unified', 'http://encore.rackspace.com')).to.be.true;
     });
 
     it('should get current environment based on location.absUrl', function () {
         // test local
         location.absUrl.returns('http://localhost:9001');
-        expect(envSvc.get().name).to.equal('local');
+        expect(envSvc.envCheck('local'), 'localhost:9001 is local').to.be.true;
         expect(envSvc.isLocal(), 'isLocal localhost:9001').to.be.true;
+        expect(envSvc.isPreProd(), 'test for preprod when environment is local').to.be.false;
+
+        // test local dev tld
+        location.absUrl.returns('http://apps.encore.dev');
+        expect(envSvc.envCheck('local'), 'apps.encore.dev is local').to.be.true;
+        expect(envSvc.isLocal(), 'isLocal apps.encore.dev').to.be.true;
         expect(envSvc.isPreProd(), 'test for preprod when environment is local').to.be.false;
 
         // test preprod
         location.absUrl.returns('http://preprod.encore.rackspace.com');
-        expect(envSvc.get().name).to.equal('preprod');
+        expect(envSvc.envCheck('preprod'), 'preprod.encore.rackspace.com is preprod').to.be.true;
         expect(envSvc.isPreProd(), 'isPreProd for preprod.encore.rackspace.com').to.be.true;
         expect(envSvc.isUnifiedPreProd(), 'test for unified-preprod when environment is preprod').to.be.true;
 
+        // test preprod apps
+        location.absUrl.returns('http://apps.preprod.encore.rackspace.com');
+        expect(envSvc.envCheck('preprod'), 'apps.preprod.encore.rackspace.com is preprod').to.be.true;
+        expect(envSvc.isPreProd(), 'isPreProd for apps.preprod.encore.rackspace.com').to.be.true;
+        expect(envSvc.isUnifiedPreProd(), 'test for unified-preprod when environment is preprod').to.be.true;
+
+        // test randenv
+        location.absUrl.returns('http://randenv.encore.rackspace.com');
+        expect(envSvc.envCheck('unified-preprod'), 'randenv.encore.rackspace.com is unified-preprod').to.be.true;
+        expect(envSvc.isPreProd(), 'isPreProd for randenv.encore.rackspace.com').to.be.false;
+        expect(envSvc.isUnifiedPreProd(), 'test for unified-preprod when environment is randenv').to.be.true;
+
         // test staging
         location.absUrl.returns('http://staging.encore.rackspace.com');
-        expect(envSvc.get().name).to.equal('unified-preprod');
+        expect(envSvc.envCheck('unified-preprod'), 'staging.encore.rackspace.com is unified-preprod').to.be.true;
         expect(envSvc.isUnifiedPreProd(), 'isUnifiedPreProd for staging.encore.rackspace.com').to.be.true;
+        expect(envSvc.isUnified(), 'test for unified when environment is unified-preprod').to.be.true;
+
+        // test staging apps
+        location.absUrl.returns('http://apps.staging.encore.rackspace.com');
+        expect(envSvc.envCheck('unified-preprod'), 'apps.staging.encore.rackspace.com is unified-preprod').to.be.true;
+        expect(envSvc.isUnifiedPreProd(), 'isUnifiedPreProd for apps.staging.encore.rackspace.com').to.be.true;
         expect(envSvc.isUnified(), 'test for unified when environment is unified-preprod').to.be.true;
 
         // test unified
         location.absUrl.returns('http://encore.rackspace.com');
-        expect(envSvc.get().name).to.equal('unified');
+        expect(envSvc.envCheck('unified'), 'encore.rackspace.com is unified').to.be.true;
         expect(envSvc.isUnified(), 'isUnified for encore.rackspace.com').to.be.true;
         expect(envSvc.isUnifiedProd(), 'isUnifiedProd for encore.rackspace.com').to.be.true;
+        expect(envSvc.isLocal(), 'test for local when environment is unified').to.be.false;
+
+        // test unified origin
+        location.absUrl.returns('http://origin.encore.rackspace.com');
+        expect(envSvc.envCheck('unified'), 'origin.encore.rackspace.com is unified').to.be.true;
+        expect(envSvc.isUnified(), 'isUnified for origin.encore.rackspace.com').to.be.true;
+        expect(envSvc.isUnifiedProd(), 'isUnifiedProd for origin.encore.rackspace.com').to.be.true;
+        expect(envSvc.isLocal(), 'test for local when environment is unified').to.be.false;
+
+        // test unified apps
+        location.absUrl.returns('http://apps.encore.rackspace.com');
+        expect(envSvc.envCheck('unified'), 'apps.encore.rackspace.com is unified').to.be.true;
+        expect(envSvc.isUnified(), 'isUnified for origin.encore.rackspace.com').to.be.true;
+        expect(envSvc.isUnifiedProd(), 'isUnifiedProd for origin.encore.rackspace.com').to.be.true;
         expect(envSvc.isLocal(), 'test for local when environment is unified').to.be.false;
     });
 


### PR DESCRIPTION
When we launched the domain name `origin.encore.rackspace.com` we realized that the `Environment` service was not recognizing it as a production environment.

This update allows for it to match.

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] QE LGTM

