### PR TITLE
[3.x] fix(phantomjs): upgrade to PhantomJS 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "karma-firefox-launcher": "0.1.4",
     "karma-mocha": "0.1.10",
     "karma-ng-html2js-preprocessor": "0.1.2",
-    "karma-phantomjs-launcher": "0.1.4",
+    "karma-phantomjs-launcher": "1.0.2",
     "karma-requirejs": "0.2.2",
     "load-grunt-tasks": "2.0.0",
     "lodash": "2.4.1",

--- a/src/utilities/urlUtils/scripts/urlUtils.spec.js
+++ b/src/utilities/urlUtils/scripts/urlUtils.spec.js
@@ -182,7 +182,7 @@ describe('utilities:urlUtils', function () {
             var parsed = urlutils.parseUrl('http://something.com/foo/bar?test=four#foobar');
             expect(parsed.protocol).to.equal('http:');
             expect(parsed.hostname).to.equal('something.com');
-            expect(parsed.port).to.equal('0');
+            expect(parsed.port).to.equal('');
             expect(parsed.pathname).to.equal('/foo/bar');
             expect(parsed.search).to.equal('?test=four');
             expect(parsed.hash).to.equal('#foobar');
@@ -211,7 +211,7 @@ describe('utilities:urlUtils', function () {
             var parsed = urlutils.parseUrl(null);
             expect(parsed.protocol).to.equal(':');
             expect(parsed.hostname).to.equal('');
-            expect(parsed.port).to.equal('0');
+            expect(parsed.port).to.equal('');
             expect(parsed.pathname).to.equal('');
             expect(parsed.search).to.equal('');
             expect(parsed.hash).to.equal('');


### PR DESCRIPTION
JIRA: n/a

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] QE LGTM

* update for macOS Sierra compatibility and unit test correctness

PhantomJS 1.x **will not run** on macOS Sierra.