### PR TITLE
chore(ghPages): 3.x support for versioned docs

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -69,6 +69,8 @@
     <script src="scripts/layout/page/layoutDataTableController.js"></script>
     <script src="scripts/layout/page/layoutRadioOptionTableController.js"></script>
 
+    <!-- NOTE: switchDocs only exists in `gh-pages` branch -->
+    <script src="../components/switchDocs/switchDocs.js"></script>
 </head>
 <body>
     <rx-app site-title="Encore Demo App" menu="demoNav" new-instance="true" collapsible-nav="true">

--- a/demo/scripts/demoApp.js
+++ b/demo/scripts/demoApp.js
@@ -190,6 +190,12 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
             type: 'no-title',
             children: [
                 {
+                    linkText: 'Version <%= pkg.version %>',
+                    directive: 'switch-docs',
+                    children: [{}],
+                    childVisibility: 'false'
+                },
+                {
                     linkText: 'Overview',
                     href: '#/overview'
                 },

--- a/grunt-tasks/options/copy.js
+++ b/grunt-tasks/options/copy.js
@@ -81,7 +81,7 @@ module.exports = {
         expand: true,
         cwd: 'utils/rx-page-objects/doc/',
         src: '**',
-        dest: '<%= config.dir.build %>/rx-page-objects/'
+        dest: '<%= config.dir.docs %>/rx-page-objects/'
     },
     bower: {
         files: [

--- a/grunt-tasks/options/gh-pages.js
+++ b/grunt-tasks/options/gh-pages.js
@@ -1,8 +1,18 @@
 module.exports = {
     ghPages: {
         options: {
-            base: '<%= config.dir.docs %>',
-            message: 'docs(ghpages): release v<%= pkg.version %>'
+            // commit the entire build directory
+            base: '<%= config.dir.build %>',
+            // always commit to source repo
+            repo: 'https://github.com/rackerlabs/encore-ui.git',
+            message: 'docs(ghpages): release v<%= pkg.version %>',
+            /*
+             * This is the key to versioned docs. When we output all
+             * documentation to the build/3.x directory, it will only add new
+             * items to the gh-pages branch. This allows each major version to
+             * have its own directory and they won't interfere with one another.
+             */
+            add: true // IMPORTANT! Prevents overwriting documentation
         },
         src: '**/*'
     },

--- a/grunt-tasks/publish-docs.js
+++ b/grunt-tasks/publish-docs.js
@@ -1,0 +1,10 @@
+module.exports = function (grunt) {
+    var description = '(re)Publish documentation without release.';
+
+    grunt.registerTask('publishDocs', description, function () {
+        grunt.task.run([
+            'default', // build assets
+            'gh-pages:ghPages' // push to GitHub Pages
+        ]);
+    });
+};

--- a/grunt-tasks/shipit.js
+++ b/grunt-tasks/shipit.js
@@ -4,7 +4,6 @@ module.exports = function (grunt) {
         var tasks = [];
 
         if (validTypes.indexOf(versionType) > -1) {
-
             if (arg === 'hotfix' && versionType !== 'patch') {
                 grunt.fatal('A hotfix release can only have a `patch` type. `major` and `minor` are not allowed');
             }
@@ -24,10 +23,8 @@ module.exports = function (grunt) {
                 tasks.push('rxPageObjects');
             }
 
-            if (arg === 'updateDemo') {
-                // update gh-pages branch, i.e. the demo app
-                tasks.push('gh-pages:ghPages');
-            }
+            // Update Documentation
+            tasks.push('gh-pages:ghPages');
 
             // update bower repo
             tasks.push('bower');

--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -11,8 +11,8 @@ module.exports = {
         app: 'src',
         bower: 'bower',
         build: 'build',
-        dist: '<%= config.dir.build %>/dist', // used for js/css files pushed to CDN/bower
-        docs: 'build', // used for demo, coverage, and jsdocs files to go to gh-pages
+        dist: '<%= config.dir.docs %>/dist', // used for js/css files pushed to CDN/bower
+        docs: 'build/3.x', // used for demo, coverage, and jsdocs files to go to gh-pages
         exportableStyles: '<%= config.dir.app %>/styles',
     },
     /* BOWER OUTPUT/DISTRIBUTION */

--- a/utils/rx-page-objects/protractor.chrome.conf.js
+++ b/utils/rx-page-objects/protractor.chrome.conf.js
@@ -25,7 +25,8 @@ var config = {
     },
 
     plugins: [{
-        package: 'protractor-console-plugin'
+        package: 'protractor-console-plugin',
+        exclude: ['switchDocs.js']
     }],
 
     onPrepare: function () {


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1219

### Generated Documentation
**This is not disrupting existing documentation at http://rackerlabs.github.io/encore-ui/.**

Generated 3.x docs served at http://rackerlabs.github.io/encore-ui/3.x/#/overview.
_NOTE:_ The version selection is not available yet in the navigation. This will come in the next PR.

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] Design LGTM
- [x] QE LGTM (no change to functional javascript)

### Summary
With the local development server, the navigation will behave like this.
![version-nav-demo-local](https://cloud.githubusercontent.com/assets/545605/20998903/990e25f8-bcd6-11e6-986d-c9b23f75d0c2.gif)

PR #1875 added the necessary logic for it to behave like this on production.
![version-nav-demo](https://cloud.githubusercontent.com/assets/545605/20998921/b87c4b04-bcd6-11e6-954c-3db4ebf1b371.gif)

