### PR TITLE
feat(switchDocs): add version switching directive

### DIFF
--- a/components/switchDocs/switch-docs.html
+++ b/components/switchDocs/switch-docs.html
@@ -1,0 +1,4 @@
+<select rx-select
+  ng-model="version"
+  ng-options="v as (v.path + (v.isReleased ? '' : ' (unreleased)')) for v in versions | orderBy:['-path']">
+</select>

--- a/components/switchDocs/switchDocs.js
+++ b/components/switchDocs/switchDocs.js
@@ -1,0 +1,52 @@
+(function () {
+    angular
+        .module('demoApp')
+        .directive('switchDocs', SwitchDocsDirective);
+
+    function SwitchDocsDirective ($location, DOC_VERSIONS) {
+        return {
+            restrict: 'E',
+            templateUrl: '../components/switchDocs/switch-docs.html',
+            controller: function ($scope) {
+                $scope.versions = DOC_VERSIONS;
+
+                // Determine which version is currently being viewed
+                $scope.version = $scope.versions.filter(function (version) {
+                    return $location.absUrl().search('/' + version.path) >= 0;
+                })[0];
+
+                /* Navigate to different version on change */
+                $scope.$watch('version', function (newVal, oldVal) {
+                    if (oldVal && (oldVal.path !== newVal.path)) {
+                        window.location.href = '../' + newVal.path;
+                    }
+                });
+            }
+        };
+    };//SwitchDocsDirective
+
+    angular
+        .module('demoApp')
+        .constant('DOC_VERSIONS', [
+            {
+                "path": "4.x",
+                "isReleased": false,
+                "isLegacy": false
+            },
+            {
+                "path": "3.x",
+                "isReleased": true,
+                "isLegacy": false
+            },
+            {
+                "path": "2.x",
+                "isReleased": true,
+                "isLegacy": true
+            },
+            {
+                "path": "1.x",
+                "isReleased": true,
+                "isLegacy": true
+            }
+        ]);//DOC_VERSIONS
+})();


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1220

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM

### Summary
* This PR adds the shared `<switch-docs>` directive to be used by the different versions of the docs.
* This PR does not add the automatic forwarding to the latest release documentation.
* This PR is expected to be merged into the `gh-pages` branch.