### PR TITLE
chore(ghPages): 1.x support for versioned docs

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -71,6 +71,8 @@
     <!-- controllers -->
     <script src="scripts/layout/page/layoutDataTableController.js"></script>
 
+    <!-- NOTE: switchDocs only exists in `gh-pages` branch -->
+    <script src="../components/switchDocs/switchDocs.js"></script>
 </head>
 <body>
     <rx-app site-title="Encore Demo App" menu="demoNav" new-instance="true" collapsible-nav="true">

--- a/demo/scripts/demoApp.js
+++ b/demo/scripts/demoApp.js
@@ -238,6 +238,12 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
             type: 'no-title',
             children: [
                 {
+                    linkText: 'Version <%= pkg.version %>',
+                    directive: 'switch-docs',
+                    children: [{}],
+                    childVisibility: 'false'
+                },
+                {
                     linkText: 'Overview',
                     href: '#/overview'
                 },

--- a/demo/scripts/demoApp.js
+++ b/demo/scripts/demoApp.js
@@ -1,17 +1,11 @@
 function genericRouteController (breadcrumbs) {
-    return function (rxBreadcrumbsSvc, Environment, $interpolate) {
+    return function (rxBreadcrumbsSvc) {
         if (breadcrumbs === undefined) {
             breadcrumbs = [{
                 name: '',
                 path: ''
             }]
         }
-
-        breadcrumbs.forEach(function (breadcrumb) {
-            if (breadcrumb.path) {
-                breadcrumb.path = $interpolate(Environment.get().url)({ path: breadcrumb.path });
-            }
-        });
 
         rxBreadcrumbsSvc.set(breadcrumbs);
     }
@@ -213,7 +207,7 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
         url: baseGithubUrl + '{{path}}'
     });
 
-    rxBreadcrumbsSvc.setHome($interpolate(Environment.get().url)({ path: '#/overview' }), 'Overview');
+    rxBreadcrumbsSvc.setHome('#/overview', 'Overview');
 
     var linksForModuleCategory = function (kategory) {
         var filteredModules = _.filter(Modules, {

--- a/demo/templates/modules/showModule.html
+++ b/demo/templates/modules/showModule.html
@@ -15,7 +15,7 @@
           <a href="ngdocs/index.html#/api/{{ module.category }}.{{ module.api }}/" class="module-api button">View API</a>
         </span>
       </span>
-      <a href="https://github.com/rackerlabs/encore-ui/tree/master/src/{{ module.category }}/{{ module.name }}/" class="module-source button">View Source</a>
+      <a href="<%= config.github.src %>/{{ module.category }}/{{ module.name }}/" class="module-source button">View Source</a>
     </div>
   </div>
 

--- a/grunt-tasks/options/copy.js
+++ b/grunt-tasks/options/copy.js
@@ -182,7 +182,7 @@ module.exports = {
         expand: true,
         cwd: 'utils/rx-page-objects/doc/',
         src: '**',
-        dest: '<%= config.dir.build %>/rx-page-objects/'
+        dest: '<%= config.dir.docs %>/rx-page-objects/'
     },
     bower: {
         files: [

--- a/grunt-tasks/options/gh-pages.js
+++ b/grunt-tasks/options/gh-pages.js
@@ -5,7 +5,7 @@ module.exports = {
             base: '<%= config.dir.build %>',
             // always commit to source repo
             repo: 'https://github.com/rackerlabs/encore-ui.git',
-            message: 'docs(ghpages): release v<%= pkg.version %>',
+            message: 'docs(ghpages): release v<%= pkg.version %> [skip ci]',
             /*
              * This is the key to versioned docs. When we output all
              * documentation to the build/1.x directory, it will only add new

--- a/grunt-tasks/options/gh-pages.js
+++ b/grunt-tasks/options/gh-pages.js
@@ -1,8 +1,18 @@
 module.exports = {
     ghPages: {
         options: {
-            base: '<%= config.dir.docs %>',
-            message: 'docs(ghpages): release v<%= pkg.version %>'
+            // commit the entire build directory
+            base: '<%= config.dir.build %>',
+            // always commit to source repo
+            repo: 'https://github.com/rackerlabs/encore-ui.git',
+            message: 'docs(ghpages): release v<%= pkg.version %>',
+            /*
+             * This is the key to versioned docs. When we output all
+             * documentation to the build/1.x directory, it will only add new
+             * items to the gh-pages branch. This allows each major version to
+             * have its own directory and they won't interfere with one another.
+             */
+            add: true // IMPORTANT! Prevents overwriting documentation
         },
         src: '**/*'
     },

--- a/grunt-tasks/publish-docs.js
+++ b/grunt-tasks/publish-docs.js
@@ -1,0 +1,10 @@
+module.exports = function (grunt) {
+    var description = '(re)Publish documentation without release.';
+
+    grunt.registerTask('publishDocs', description, function () {
+        grunt.task.run([
+            'default', // build assets
+            'gh-pages:ghPages' // push to GitHub Pages
+        ]);
+    });
+};

--- a/grunt-tasks/shipit.js
+++ b/grunt-tasks/shipit.js
@@ -36,10 +36,8 @@ module.exports = function (grunt) {
                 tasks.push('rxPageObjects');
             }
 
-            if (arg === 'updateDemo') {
-                // update gh-pages branch, i.e. the demo app
-                tasks.push('gh-pages:ghPages');
-            }
+            // Update Documentation
+            tasks.push('gh-pages:ghPages');
 
             // update bower repo
             tasks.push('bower');

--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -3,8 +3,8 @@ module.exports = {
         app: 'src',
         bower: 'bower',
         build: 'build',
-        dist: '<%= config.dir.build %>/dist', // used for js/css files pushed to CDN/bower
-        docs: 'build', // used for demo, coverage, and jsdocs files to go to gh-pages
+        dist: '<%= config.dir.docs %>/dist', // used for js/css files pushed to CDN/bower
+        docs: 'build/1.x', // used for demo, coverage, and jsdocs files to go to gh-pages
         exportableStyles: '<%= config.dir.app %>/styles',
     },
     /* BOWER OUTPUT/DISTRIBUTION */

--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -1,4 +1,9 @@
 module.exports = {
+    github: {
+        base: 'https://github.com/rackerlabs/encore-ui',
+        branch: '1.x',
+        src: '<%= config.github.base %>/tree/<%= config.github.branch %>/src'
+    },
     dir: {
         app: 'src',
         bower: 'bower',

--- a/src/components/rxForm/rxForm.module.js
+++ b/src/components/rxForm/rxForm.module.js
@@ -59,21 +59,21 @@
  * `rx-field`, `rx-select-filter`, and `div` children elements in a columnar fashion.  This can be used in conjunction
  * with sections taking the full width of the form.
  *
- *  *See "Advanced Inputs" in the {@link /encore-ui/#/components/rxForm demo} for an example.*
+ *  *See "Advanced Inputs" in the [demo](../#/components/rxForm) for an example.*
  *
  * ## Responsive
  * `rx-field` and `div` elements that are immediate children of `rx-form-section` will grow from 250px to full width of
  * the section.  As such, you will see that these elements will wrap in the section if there's not enough width to
  * accomodate more than one child.
  *
- * *You can see this in the {@link /encore-ui/#/components/rxForm demo} if you resize the width of your browser.*
+ * *You can see this in the [demo](../#/components/rxForm) if you resize the width of your browser.*
  *
  * # Validation
  *
  * ## Required Fields
  * When displaying a field that should be required, please make use of the `ng-required` attribute for rxFieldName.
  * When the value evaluates to true, an asterisk will display to the left of the field name.  You can see an example
- * of this with the "Required Textarea" field name in the {@link /encore-ui/#/components/rxForm demo}.
+ * of this with the "Required Textarea" field name in the [demo](../#/components/rxForm).
  *
  * See {@link rxForm.directive:rxFieldName rxFieldName}
  * API Documentation for more information.
@@ -87,7 +87,7 @@
  * The example shown in the "Email Address" example, uses a custom `foocheck` validator. Note that it is enabled by
  * placing the `foocheck` attribute in the `<input>` element, and using it with
  * `ng-show="demoForm.userEmail.$error.foocheck"`.  Check out the Javascript tab in
- * the {@link /encore-ui/#/components/rxForm demo} to see how this validator is implemented.
+ * the [demo](../#/components/rxForm) to see how this validator is implemented.
  *
  * There are plenty of examples online showing the same thing.
  *

--- a/src/components/rxModalAction/scripts/rxModalFooter.js
+++ b/src/components/rxModalAction/scripts/rxModalFooter.js
@@ -15,7 +15,7 @@ angular.module('encore.ui.rxModalAction')
  * they were defined with.
  *
  * The modal's controller also inherits the `setState()` method on the scope, which should be used to toggle different
- * views or footers. See the *Multi-View Example* in the component {@link /encore-ui/#/components/rxModalAction demo}
+ * views or footers. See the *Multi-View Example* in the component [demo](../#/components/rxModalAction)
  * for an example of this design pattern's usage.
  *
  * The default `editing` state shows the standard submit and cancel buttons, and the only other state provided by the

--- a/src/components/rxPaginate/rxPaginate.module.js
+++ b/src/components/rxPaginate/rxPaginate.module.js
@@ -91,7 +91,7 @@
  * </tfoot>
  * </pre>
  *
- * See the rxPaginate compoent {@link /encore-ui/#/components/rxPaginate demo} for more examples of this.
+ * See the rxPaginate compoent [demo](../#/components/rxPaginate) for more examples of this.
  *
  * This applies to both UI-based pagination and API-based pagination.
  *
@@ -245,7 +245,7 @@
  * the current filter/sort criteria. But the point is that you can't just call `getItems()` yourself
  * to cause an update. The framework has to call that method, so it knows to wait on the returned promise.
  *
- * This is shown in the rxPaginate component {@link /encore-ui/#/components/rxPaginate demo} with a "Refresh" button
+ * This is shown in the rxPaginate component [demo](../#/components/rxPaginate) with a "Refresh" button
  * above the API-paginated example.
  *
  * ## Error Handling

--- a/src/components/rxPermission/scripts/rxPermission.js
+++ b/src/components/rxPermission/scripts/rxPermission.js
@@ -6,7 +6,7 @@ angular.module('encore.ui.rxPermission')
  * @scope
  * @description
  * Simple directive which will show or hide content based on whether or not the user has the specified role. See
- * the `rxPermission` component {@link /encore-ui/#/components/rxPermission demo} for an example.
+ * the `rxPermission` component [demo](../#/components/rxPermission) for an example.
  *
  * @requires rxPermission.service:Permission
  *

--- a/src/components/rxSearchBox/scripts/rxSearchBox.js
+++ b/src/components/rxSearchBox/scripts/rxSearchBox.js
@@ -12,12 +12,12 @@ angular.module('encore.ui.rxSearchBox')
  *
  * Though it is described as a search box, you can also use it for filtering
  * capabilities (as seen by the placeholder text in the "Customized"
- * {@link /encore-ui/#/components/rxSearchBox demo}).
+ * [demo](../#/components/rxSearchBox)).
  *
  * # Styling
  * You can style the `<rx-search-box>` element via custom CSS classes the same
  * way you would any HTML element. See the customized search box in the
- * {@link /encore-ui/#/components/rxSearchBox demo} for an example.
+ * [demo](../#/components/rxSearchBox) for an example.
  *
  * <pre>
  * <rx-search-box

--- a/src/components/rxStatusColumn/scripts/rxStatusColumn.js
+++ b/src/components/rxStatusColumn/scripts/rxStatusColumn.js
@@ -22,7 +22,7 @@ angular.module('encore.ui.rxStatusColumn')
  * internally you will be receiving a number of different statuses from your
  * APIs, and will need to map them to these six statuses.
  *
- * The example in the {@link /encore-ui/#/components/rxStatusColumn demo} shows a typical
+ * The example in the [demo](../#/components/rxStatusColumn) shows a typical
  * use of this directive, such as:
  *
  * <pre>

--- a/src/components/rxStatusColumn/scripts/rxStatusHeader.js
+++ b/src/components/rxStatusColumn/scripts/rxStatusHeader.js
@@ -14,11 +14,11 @@ angular.module('encore.ui.rxStatusColumn')
  * <th rx-status-header></th>
  * </pre>
  * Note that status columns are sortable with
- * {@link /encore-ui/#/components/rxSortableColumn rxSortableColumn}, just like any
+ * [rxSortableColumn](../#/components/rxSortableColumn), just like any
  * other column. The demo below shows an example of this.
  *
- * One few things to note about the
- * {@link /encore-ui/#/components/rxStatusColumn demo}: The `<th>` is defined as:
+ * One thing to note about the [demo](../#/components/rxStatusColumn):
+ * The `<th>` is defined as:
  *
  * <pre>
  * <th rx-status-header>

--- a/src/components/rxToggleSwitch/scripts/rxToggleSwitch.js
+++ b/src/components/rxToggleSwitch/scripts/rxToggleSwitch.js
@@ -18,7 +18,7 @@ angular.module('encore.ui.rxToggleSwitch')
  * time the switch is toggled (after the model property is written on the
  * scope).  It takes one argument, `value`, which is the new value of the model.
  * This can be used instead of a `$scope.$watch` on the `ng-model` property.
- * As shown in the {@link /encore-ui/#/components/rxToggleSwitch demo}, the `disabled`
+ * As shown in the [demo](../#/components/rxToggleSwitch), the `disabled`
  * attribute can be used to prevent further toggles if the `post-hook` performs
  * an asynchronous operation.
  *

--- a/src/components/tooltips/tooltips.module.js
+++ b/src/components/tooltips/tooltips.module.js
@@ -21,9 +21,9 @@
  * <rx-button tooltip="...">
  * </pre>
  *
- * If you're creating your own custom directive, it's fine to use the `tooltip` 
+ * If you're creating your own custom directive, it's fine to use the `tooltip`
  * directive inside of your directive's template.  See the tooltips component
- * {@link /encore-ui/#/components/tooltips demo} for example usage.
+ * [demo](../#/components/tooltips) for example usage.
  *
  * The [Angular-UI Bootstrap Tooltip](https://github.com/angular-ui/bootstrap/tree/master/src/tooltip)
  * plugin is included as a dependency for EncoreUI.

--- a/src/components/typeahead/typeahead.module.js
+++ b/src/components/typeahead/typeahead.module.js
@@ -18,7 +18,7 @@
  * receives focus.  This list is still filtered according to the input's value,
  * except when the input is empty.  In that case, all the options are shown.
  * To use this feature, add the `allowEmpty` parameter to the `filter` filter
- * in the `typeahead` attribute.  See the {@link /encore-ui/#/components/typeahead demo}
+ * in the `typeahead` attribute.  See the [demo](../#/components/typeahead)
  * for an example.
  *
  */

--- a/src/elements/Breadcrumbs/docs/examples/Breadcrumbs.simple.js
+++ b/src/elements/Breadcrumbs/docs/examples/Breadcrumbs.simple.js
@@ -1,7 +1,7 @@
 angular.module('demoApp')
 .controller('BreadcrumbsSimpleCtrl', function ($scope, rxBreadcrumbsSvc) {
     rxBreadcrumbsSvc.set([{
-        path: '/#/elements',
+        path: '#/elements',
         name: 'Elements',
     }, {
         name: '<strong>All Elements</strong>',

--- a/src/elements/Buttons/scripts/rxButton.js
+++ b/src/elements/Buttons/scripts/rxButton.js
@@ -32,7 +32,7 @@ angular.module('encore.ui.elements')
  * ## Styling
  *
  * There are several styles of buttons available, and they are documented in the
- * [Buttons Styleguide](/encore-ui/#/elements/Buttons). Any classes that need to be
+ * [Buttons Styleguide](../#/elements/Buttons). Any classes that need to be
  * added to the button should be passed to the `classes` attribute.
  *
  * @param {String} loadingMsg Text to be displayed when an operation is in progress.

--- a/src/utilities/rxNotify/scripts/rxNotify.js
+++ b/src/utilities/rxNotify/scripts/rxNotify.js
@@ -29,7 +29,7 @@ angular.module('encore.ui.utilities')
  * You can also create custom stacks for specific notification areas. Say you have a form on your page that you want to
  * add error messages to. You can create a custom stack for this form and send form-specific messages to it.
  *
- * Please see the *Custom Stack* usage example in the `rxNotify` {@link /encore-ui/#/components/rxForm demo}.
+ * Please see the *Custom Stack* usage example in the `rxNotify` [demo](../#/components/rxNotify).
  *
  * ## Adding an `rxNotification` to the Default Stack
  *

--- a/utils/rx-page-objects/protractor.chrome.conf.js
+++ b/utils/rx-page-objects/protractor.chrome.conf.js
@@ -25,7 +25,8 @@ var config = {
     },
 
     plugins: [{
-        package: 'protractor-console-plugin'
+        package: 'protractor-console-plugin',
+        exclude: ['switchDocs.js']
     }],
 
     onPrepare: function () {


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1222

Similar changes as #1874 

### Generated Documentation

This is not disrupting existing documentation at http://rackerlabs.github.io/encore-ui/.

Generated 1.x docs served at http://rackerlabs.github.io/encore-ui/1.x/#/overview.

### LGTMs
- [ ] Dev LGTM
- [ ] Dev+Vidyo LGTM
