### PR TITLE
chore(ghPages): 2.x support for versioned docs

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -70,6 +70,8 @@
     <script src="scripts/layout/page/layoutDataTableController.js"></script>
     <script src="scripts/layout/page/layoutRadioOptionTableController.js"></script>
 
+    <!-- NOTE: switchDocs only exists in `gh-pages` branch -->
+    <script src="../components/switchDocs/switchDocs.js"></script>
 </head>
 <body>
     <rx-app site-title="Encore Demo App" menu="demoNav" new-instance="true" collapsible-nav="true">

--- a/demo/scripts/demoApp.js
+++ b/demo/scripts/demoApp.js
@@ -220,6 +220,12 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
             type: 'no-title',
             children: [
                 {
+                    linkText: 'Version <%= pkg.version %>',
+                    directive: 'switch-docs',
+                    children: [{}],
+                    childVisibility: 'false'
+                },
+                {
                     linkText: 'Overview',
                     href: '#/overview'
                 },

--- a/demo/scripts/demoApp.js
+++ b/demo/scripts/demoApp.js
@@ -1,17 +1,11 @@
 function genericRouteController (breadcrumbs) {
-    return function (rxBreadcrumbsSvc, Environment, $interpolate) {
+    return function (rxBreadcrumbsSvc) {
         if (breadcrumbs === undefined) {
             breadcrumbs = [{
                 name: '',
                 path: ''
             }]
         }
-
-        breadcrumbs.forEach(function (breadcrumb) {
-            if (breadcrumb.path) {
-                breadcrumb.path = $interpolate(Environment.get().url)({ path: breadcrumb.path });
-            }
-        });
 
         rxBreadcrumbsSvc.set(breadcrumbs);
     }
@@ -195,7 +189,7 @@ angular.module('demoApp', ['encore.ui', 'ngRoute'])
         url: baseGithubUrl + '{{path}}'
     });
 
-    rxBreadcrumbsSvc.setHome($interpolate(Environment.get().url)({ path: '#/overview' }), 'Overview');
+    rxBreadcrumbsSvc.setHome('#/overview', 'Overview');
 
     var linksForModuleCategory = function (kategory) {
         var filteredModules = _.filter(Modules, {

--- a/demo/templates/modules/showModule.html
+++ b/demo/templates/modules/showModule.html
@@ -15,7 +15,7 @@
           <a href="ngdocs/index.html#/api/{{ module.category }}.{{ module.api }}/" class="module-api button">View API</a>
         </span>
       </span>
-      <a href="https://github.com/rackerlabs/encore-ui/tree/master/src/{{ module.category }}/{{ module.name }}/" class="module-source button">View Source</a>
+      <a href="<%= config.github. src %>/{{ module.category }}/{{ module.name }}/" class="module-source button">View Source</a>
     </div>
   </div>
 

--- a/grunt-tasks/options/copy.js
+++ b/grunt-tasks/options/copy.js
@@ -182,7 +182,7 @@ module.exports = {
         expand: true,
         cwd: 'utils/rx-page-objects/doc/',
         src: '**',
-        dest: '<%= config.dir.build %>/rx-page-objects/'
+        dest: '<%= config.dir.docs %>/rx-page-objects/'
     },
     bower: {
         files: [

--- a/grunt-tasks/options/gh-pages.js
+++ b/grunt-tasks/options/gh-pages.js
@@ -5,7 +5,7 @@ module.exports = {
             base: '<%= config.dir.build %>',
             // always commit to source repo
             repo: 'https://github.com/rackerlabs/encore-ui.git',
-            message: 'docs(ghpages): release v<%= pkg.version %>',
+            message: 'docs(ghpages): release v<%= pkg.version %> [skip ci]',
             /*
              * This is the key to versioned docs. When we output all
              * documentation to the build/2.x directory, it will only add new

--- a/grunt-tasks/options/gh-pages.js
+++ b/grunt-tasks/options/gh-pages.js
@@ -1,8 +1,18 @@
 module.exports = {
     ghPages: {
         options: {
-            base: '<%= config.dir.docs %>',
-            message: 'docs(ghpages): release v<%= pkg.version %>'
+            // commit the entire build directory
+            base: '<%= config.dir.build %>',
+            // always commit to source repo
+            repo: 'https://github.com/rackerlabs/encore-ui.git',
+            message: 'docs(ghpages): release v<%= pkg.version %>',
+            /*
+             * This is the key to versioned docs. When we output all
+             * documentation to the build/2.x directory, it will only add new
+             * items to the gh-pages branch. This allows each major version to
+             * have its own directory and they won't interfere with one another.
+             */
+            add: true // IMPORTANT! Prevents overwriting documentation
         },
         src: '**/*'
     },

--- a/grunt-tasks/publish-docs.js
+++ b/grunt-tasks/publish-docs.js
@@ -1,0 +1,10 @@
+module.exports = function (grunt) {
+    var description = '(re)Publish documentation without release.';
+
+    grunt.registerTask('publishDocs', description, function () {
+        grunt.task.run([
+            'default', // build assets
+            'gh-pages:ghPages' // push to GitHub Pages
+        ]);
+    });
+};

--- a/grunt-tasks/shipit.js
+++ b/grunt-tasks/shipit.js
@@ -27,10 +27,8 @@ module.exports = function (grunt) {
                 tasks.push('rxPageObjects');
             }
 
-            if (arg === 'updateDemo') {
-                // update gh-pages branch, i.e. the demo app
-                tasks.push('gh-pages:ghPages');
-            }
+            // Update Documentation
+            tasks.push('gh-pages:ghPages');
 
             // update bower repo
             tasks.push('bower');

--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -7,6 +7,11 @@ var _banner = `/*
  */`;
 
 module.exports = {
+    github: {
+        base: 'https://github.com/rackerlabs/encore-ui',
+        branch: '2.x',
+        src: '<%= config.github.base %>/tree/<%= config.github.branch %>/src'
+    },
     dir: {
         app: 'src',
         bower: 'bower',

--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -11,8 +11,8 @@ module.exports = {
         app: 'src',
         bower: 'bower',
         build: 'build',
-        dist: '<%= config.dir.build %>/dist', // used for js/css files pushed to CDN/bower
-        docs: 'build', // used for demo, coverage, and jsdocs files to go to gh-pages
+        dist: '<%= config.dir.docs %>/dist', // used for js/css files pushed to CDN/bower
+        docs: 'build/2.x', // used for demo, coverage, and jsdocs files to go to gh-pages
         exportableStyles: '<%= config.dir.app %>/styles',
     },
     /* BOWER OUTPUT/DISTRIBUTION */

--- a/src/elements/Breadcrumbs/docs/examples/Breadcrumbs.simple.js
+++ b/src/elements/Breadcrumbs/docs/examples/Breadcrumbs.simple.js
@@ -1,7 +1,7 @@
 angular.module('demoApp')
 .controller('BreadcrumbsSimpleCtrl', function ($scope, rxBreadcrumbsSvc) {
     rxBreadcrumbsSvc.set([{
-        path: '/#/elements',
+        path: '#/elements',
         name: 'Elements',
     }, {
         name: '<strong>All Elements</strong>',

--- a/src/elements/Buttons/scripts/rxButton.js
+++ b/src/elements/Buttons/scripts/rxButton.js
@@ -32,7 +32,7 @@ angular.module('encore.ui.elements')
  * ## Styling
  *
  * There are several styles of buttons available, and they are documented in the
- * [Buttons Styleguide](/encore-ui/#/elements/Buttons). Any classes that need to be
+ * [Buttons Styleguide](../#/elements/Buttons). Any classes that need to be
  * added to the button should be passed to the `classes` attribute.
  *
  * @param {String} loadingMsg Text to be displayed when an operation is in progress.

--- a/src/elements/Forms/scripts/rxSearchBox.js
+++ b/src/elements/Forms/scripts/rxSearchBox.js
@@ -12,12 +12,12 @@ angular.module('encore.ui.elements')
  *
  * Though it is described as a search box, you can also use it for filtering
  * capabilities (as seen by the placeholder text in the "Customized"
- * {@link /encore-ui/#/elements/Forms#search-box demo}).
+ * [demo](../#/elements/Forms#search-box)).
  *
  * # Styling
  * You can style the `<rx-search-box>` element via custom CSS classes the same
  * way you would any HTML element. See the customized search box in the
- * {@link /encore-ui/#/elements/Forms#search-box demo} for an example.
+ * [demo](../#/elements/Forms#search-box) for an example.
  *
  * <pre>
  * <rx-search-box

--- a/src/elements/Forms/scripts/rxToggleSwitch.js
+++ b/src/elements/Forms/scripts/rxToggleSwitch.js
@@ -18,7 +18,7 @@ angular.module('encore.ui.elements')
  * time the switch is toggled (after the model property is written on the
  * scope).  It takes one argument, `value`, which is the new value of the model.
  * This can be used instead of a `$scope.$watch` on the `ng-model` property.
- * As shown in the {@link /encore-ui/#/elements/Forms demo}, the `disabled`
+ * As shown in the [demo](../#/elements/Forms), the `disabled`
  * attribute can be used to prevent further toggles if the `post-hook` performs
  * an asynchronous operation.
  *

--- a/src/elements/Modals/scripts/rxModalFooter.js
+++ b/src/elements/Modals/scripts/rxModalFooter.js
@@ -17,7 +17,7 @@ angular.module('encore.ui.elements')
  *
  * The modal's controller also inherits the `setState()` method on the scope,
  * which should be used to toggle different views or footers. See the
- * *Multi-View Example* in the element {@link /encore-ui/#/elements/Modals demo}
+ * *Multi-View Example* in the element [demo](../#/elements/Modals)
  * for an example of this design pattern's usage.
  *
  * The default `editing` state shows the standard submit and cancel buttons,

--- a/src/elements/Tables/scripts/rxStatusColumn.js
+++ b/src/elements/Tables/scripts/rxStatusColumn.js
@@ -22,7 +22,7 @@ angular.module('encore.ui.elements')
  * internally you will be receiving a number of different statuses from your
  * APIs, and will need to map them to these six statuses.
  *
- * The example in the {@link /encore-ui/#/components/rxStatusColumn demo} shows
+ * The example in the [demo](../#/components/rxStatusColumn) shows
  * a typical use of this directive, such as:
  *
  * <pre>

--- a/src/elements/Tables/scripts/rxStatusHeader.js
+++ b/src/elements/Tables/scripts/rxStatusHeader.js
@@ -14,11 +14,11 @@ angular.module('encore.ui.elements')
  * <th rx-status-header></th>
  * </pre>
  * Note that status columns are sortable with
- * {@link /encore-ui/#/components/rxSortableColumn rxSortableColumn}, just like any
+ * [rxSortableColumn](../#/elements/Tables#sortable-column), just like any
  * other column. The demo below shows an example of this.
  *
- * One few things to note about the
- * {@link /encore-ui/#/components/rxStatusColumn demo}: The `<th>` is defined as:
+ * One thing to note about the [demo](../#/elements/Tables#sortable-column):
+ * The `<th>` is defined as:
  *
  * <pre>
  * <th rx-status-header>

--- a/src/elements/typeahead/scripts/typeahead.js
+++ b/src/elements/typeahead/scripts/typeahead.js
@@ -18,7 +18,7 @@
  * receives focus.  This list is still filtered according to the input's value,
  * except when the input is empty.  In that case, all the options are shown.
  * To use this feature, add the `allowEmpty` parameter to the `filter` filter
- * in the `typeahead` attribute.  See the {@link /encore-ui/#/components/typeahead demo}
+ * in the `typeahead` attribute.  See the [demo](../#/elements/typeahead)
  * for an example.
  *
  */

--- a/src/utilities/rxNotify/scripts/rxNotify.js
+++ b/src/utilities/rxNotify/scripts/rxNotify.js
@@ -100,7 +100,7 @@ angular.module('encore.ui.utilities')
  * You can also create custom stacks for specific notification areas. Say you have a form on your page that you want to
  * add error messages to. You can create a custom stack for this form and send form-specific messages to it.
  *
- * Please see the *Custom Stack* usage example in the `rxNotify` {@link /encore-ui/#/components/rxForm demo}.
+ * Please see the *Custom Stack* usage example in the Notifications [demo](../#/elements/Notifications).
  *
  * ## Adding an `rxNotification` to the Default Stack
  *

--- a/utils/rx-page-objects/protractor.chrome.conf.js
+++ b/utils/rx-page-objects/protractor.chrome.conf.js
@@ -25,7 +25,8 @@ var config = {
     },
 
     plugins: [{
-        package: 'protractor-console-plugin'
+        package: 'protractor-console-plugin',
+        exclude: ['switchDocs.js']
     }],
 
     onPrepare: function () {


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1221

### Generated Documentation

This is not disrupting existing documentation at http://rackerlabs.github.io/encore-ui/.

Generated 2.x docs served at http://rackerlabs.github.io/encore-ui/2.x/#/overview.

### LGTMs
- [ ] Dev LGTM
- [ ] Dev+Vidyo LGTM

