### PR TITLE
refactor(rxErrorFormatter): rx-prefixes update to ErrorFormatter

### DIFF
--- a/src/utilities/ErrorFormatter/docs/ErrorFormatter.meta.json
+++ b/src/utilities/ErrorFormatter/docs/ErrorFormatter.meta.json
@@ -1,7 +1,0 @@
-{
-    "displayName": "ErrorFormatter",
-    "stability": "stable",
-    "description": "Provides a helper method to parse and format error objects.",
-    "api": "service:ErrorFormatter",
-    "keywords": []
-}

--- a/src/utilities/ErrorFormatter/docs/examples/ErrorFormatter.simple.js
+++ b/src/utilities/ErrorFormatter/docs/examples/ErrorFormatter.simple.js
@@ -1,7 +1,0 @@
-angular.module('demoApp')
-.controller('ErrorFormatterSimpleCtrl', function ($scope, ErrorFormatter) {
-    $scope.setErrorMsg = function (msg) {
-        var error = { message: msg };
-        $scope.errorMsg = ErrorFormatter.buildErrorMsg('Error: ${message}', error);
-    };
-});

--- a/src/utilities/rxErrorFormatter/docs/examples/rxErrorFormatter.simple.html
+++ b/src/utilities/rxErrorFormatter/docs/examples/rxErrorFormatter.simple.html
@@ -1,10 +1,10 @@
 <div ng-controller="ErrorFormatterSimpleCtrl">
   <p>
     <button class="button"
-      ng-click="setErrorMsg('this is an error message set with ErrorFormatter.')">
+      ng-click="setErrorMsg('this is an error message set with rxErrorFormatter.')">
       Set Error Message
     </button>
-    should set an error message with <code>ErrorFormatter</code>.
+    should set an error message with <code>rxErrorFormatter</code>.
   </p>
   <p>{{errorMsg}}</p>
 </div>

--- a/src/utilities/rxErrorFormatter/docs/examples/rxErrorFormatter.simple.js
+++ b/src/utilities/rxErrorFormatter/docs/examples/rxErrorFormatter.simple.js
@@ -1,0 +1,7 @@
+angular.module('demoApp')
+.controller('ErrorFormatterSimpleCtrl', function ($scope, rxErrorFormatter) {
+    $scope.setErrorMsg = function (msg) {
+        var error = { message: msg };
+        $scope.errorMsg = rxErrorFormatter.buildErrorMsg('Error: ${message}', error);
+    };
+});

--- a/src/utilities/rxErrorFormatter/docs/rxErrorFormatter.docs.html
+++ b/src/utilities/rxErrorFormatter/docs/rxErrorFormatter.docs.html
@@ -2,4 +2,4 @@
   Provides a helper method to parse and format error objects.
 </p> 
 
-<rx-example name="ErrorFormatter.simple"></rx-example>
+<rx-example name="rxErrorFormatter.simple"></rx-example>

--- a/src/utilities/rxErrorFormatter/docs/rxErrorFormatter.meta.json
+++ b/src/utilities/rxErrorFormatter/docs/rxErrorFormatter.meta.json
@@ -1,0 +1,9 @@
+{
+    "displayName": "rxErrorFormatter",
+    "stability": "stable",
+    "description": "Provides a helper method to parse and format error objects.",
+    "api": "service:rxErrorFormatter",
+    "keywords": [
+      "ErrorFormatter"
+    ]
+}

--- a/src/utilities/rxErrorFormatter/scripts/rxErrorFormatter.js
+++ b/src/utilities/rxErrorFormatter/scripts/rxErrorFormatter.js
@@ -1,18 +1,18 @@
 angular.module('encore.ui.utilities')
 /**
  * @ngdoc service
- * @name utilities.service:ErrorFormatter
+ * @name utilities.service:rxErrorFormatter
  * @description
  * Provides a helper method to parse error objects for `message` and format them
  * as necessary for `Status.setError()`.  See {@link utilities.service:Status Status} Service
  * for more information.
  *
- * # Error Messages Using ErrorFormatter
+ * # Error Messages Using rxErrorFormatter
  *
- * `ErrorFormmatter` provides a specialized template `error` string
+ * `rxErrorFormatter` provides a specialized template `error` string
  * with an `object:{}` as the second parameter containing the replacements for
  * the template in the error string.  If in a proper format, the object can be
- * automatically parsed using an `ErrorFormatter` and displayed to the user.
+ * automatically parsed using an `rxErrorFormatter` and displayed to the user.
  *
  * For example:
  *
@@ -34,7 +34,7 @@ angular.module('encore.ui.utilities')
  * ReferenceError: <replacement> is not defined
  * </pre>
  */
-.factory('ErrorFormatter', function () {
+.factory('rxErrorFormatter', function () {
     /*
      * formatString is a string with ${message} in it somewhere, where ${message}
      * will come from the `error` object. The `error` object either needs to have
@@ -51,4 +51,19 @@ angular.module('encore.ui.utilities')
     return {
         buildErrorMsg: buildErrorMsg
     };
+})
+
+/**
+ * @deprecated
+ * Please use rxErrorFormatter instead. This item will be removed on the 4.0.0 release.
+ * @ngdoc service
+ * @name utilities.service:ErrorFormatter
+ * @requires utilities.service:rxErrorFormatter
+ */
+.service('ErrorFormatter', function (rxErrorFormatter) {
+    console.warn(
+        'DEPRECATED: ErrorFormatter - Please use rxErrorFormatter. ' +
+        'ErrorFormatter will be removed in EncoreUI 4.0.0'
+    );
+    return rxErrorFormatter;
 });

--- a/src/utilities/rxErrorFormatter/scripts/rxErrorFormatter.spec.js
+++ b/src/utilities/rxErrorFormatter/scripts/rxErrorFormatter.spec.js
@@ -1,11 +1,11 @@
-describe('utilities: ErrorFormatter', function () {
+describe('utilities: rxErrorFormatter', function () {
     var errorFormatter;
 
     beforeEach(function () {
         module('encore.ui.utilities');
 
-        inject(function (ErrorFormatter) {
-            errorFormatter = ErrorFormatter;
+        inject(function (rxErrorFormatter) {
+            errorFormatter = rxErrorFormatter;
         });
     });
 


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1149

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM

### Summary

* rename `Utilities > ErrorFormatter` to `Utilities > rxErrorFormatter`
* leave `ErrorFormatter` alias for backward compatibility (documented as deprecated)

### Demo

| before | after |
| --- | --- |
| ![errorformatter-before](https://cloud.githubusercontent.com/assets/10750223/21061807/8af4436a-be13-11e6-8126-efe4046d6150.png)| ![rxerrorformatter-after](https://cloud.githubusercontent.com/assets/10750223/21061813/956659aa-be13-11e6-9b88-478d1b8e9b85.png)

### Demo Nav

| before | after |
| --- | --- |
| ![demo-error-before](https://cloud.githubusercontent.com/assets/10750223/21062025/8816bc08-be14-11e6-9f85-29aa3e988020.png) | ![demo-error-after](https://cloud.githubusercontent.com/assets/10750223/21062033/9373c956-be14-11e6-9066-fa45ca0c3dd3.png)

### ngDocs

| page | before | after |
| --- | --- | --- |
| Environment | ![ngdocs-error-before](https://cloud.githubusercontent.com/assets/10750223/21064085/a166f6be-be1e-11e6-8ade-722ace54eeea.png) | ![ngdocs-error-after](https://cloud.githubusercontent.com/assets/10750223/21064077/965537c2-be1e-11e6-96cb-2c2aa47a391d.png)|
| rxEnvironment | N/A | ![ngdocs-rxerror-after](https://cloud.githubusercontent.com/assets/10750223/21064063/85c02566-be1e-11e6-9b9f-f8fe70b2b0c8.png)|
