### PR TITLE
fix(rxFloatingHeader): correct numerous rendering bugs [1.x]

### DIFF
--- a/src/components/rxBulkSelect/scripts/rxBulkSelect.js
+++ b/src/components/rxBulkSelect/scripts/rxBulkSelect.js
@@ -32,12 +32,14 @@ angular.module('encore.ui.rxBulkSelect')
     var elemString = '<tr rx-bulk-select-message></tr>';
     return {
         restrict: 'A',
+        require: [
+            '?^rxFloatingHeader'
+        ],
         scope: {
             bulkSource: '=',
             selectedKey: '@'
         },
         compile: function (elem, attrs) {
-
             // We add the `<tr rx-bulk-select-message>` row to the header here to save the devs
             // from having to do it themselves.
             var thead = elem.find('thead').eq(0);
@@ -45,7 +47,10 @@ angular.module('encore.ui.rxBulkSelect')
             messageElem.attr('resource-name', attrs.resourceName || attrs.bulkSource.replace(/s$/, ''));
             thead.append(messageElem);
 
-            return function (scope, element) {
+            return function (scope, element, attrs, controllers) {
+                scope._rxFloatingHeaderCtrl = controllers[0] || {
+                    reapply: _.noop
+                };
                 scope.tableElement = element;
             };
         },

--- a/src/components/rxFloatingHeader/docs/rxFloatingHeader.html
+++ b/src/components/rxFloatingHeader/docs/rxFloatingHeader.html
@@ -33,10 +33,10 @@
     </tbody>
 </table>
 
-  <p>
+<p>
   A common pattern is to include a filter with tables. You can have that as part of the floating header by setting
   it in a separate `&lt;tr&gt;` element.
-  </p>
+</p>
 
 
 <div ng-controller="rxFloatingHeaderCtrl">

--- a/src/components/rxFloatingHeader/scripts/rxFloatingHeader.js
+++ b/src/components/rxFloatingHeader/scripts/rxFloatingHeader.js
@@ -43,7 +43,7 @@ angular.module('encore.ui.rxFloatingHeader')
  * </pre>
  *
  */
-.directive('rxFloatingHeader', function ($document, rxDOMHelper) {
+.directive('rxFloatingHeader', function ($window, $timeout, rxDOMHelper, debounce) {
     return {
         restrict: 'A',
         controller: function ($scope) {
@@ -55,199 +55,183 @@ angular.module('encore.ui.rxFloatingHeader')
                     $scope.update();
                 }
             };
+
+            this.reapply = function () {
+                $scope.reapply();
+            };
         },
         link: function (scope, table) {
-            var state, seenFirstScroll, trs, ths, clones, inputs, maxHeight, header, singleThs, maxThWidth;
+            var header; // thead as angular.element
+            var isFloating = false;
+            var _window = angular.element($window);
+            var _resizeHandler;
 
-            var setup = function () {
+            /**
+             * @function
+             * @description Apply floating elements
+             */
+            function applyFloat () {
+                isFloating = true;
+                var fillerRows = [];
 
-                if (clones && clones.length) {
-                    _.each(clones, function (clone) {
-                        // Possible memory leak here? I tried clone.scope().$destroy(),
-                        // but it causes exceptions in Angular
-                        clone.remove();
-                    });
-                }
-                state = 'fixed';
-                seenFirstScroll = false;
-
-                // The original <tr> elements
-                trs = [];
-
-                // The original <th> elements
-                ths = [];
-
-                // All <th> elements that are the *only* <th> in their row
-                singleThs = [];
-
-                // The maximum width we could find for a <th>
-                maxThWidth = 0;
-
-                // Clones of the <tr> elements
-                clones = [];
-
-                // any <input> elements in the <thead>
-                inputs = [];
-                header = angular.element(table.find('thead'));
-
-                // Are we currently floating?
-                var floating = false;
-                // Grab all the original `tr` elements from the `thead`,
+                var topOffset = 0;
                 _.each(header.find('tr'), function (tr) {
-                    tr = angular.element(tr);
+                    var row = angular.element(tr);
 
-                    // If `scope.setup()` has been called, it means we'd previously
-                    // worked with these rows before. We want them in as clean a state as possible
-                    if (!floating && tr.hasClass('rx-floating-header')) {
-                        floating = true;
-                    }
+                    // Ensure that the rows are offset so they
+                    // don't overlap while floating.
+                    row.css({ 'top': topOffset.toString() + 'px' });
+                    topOffset += parseInt(rxDOMHelper.height(row));
 
-                    // We are going to clone all the <tr> elements in the <thead>, and insert them
-                    // into the DOM whenever the original <tr> elements need to float. This keeps the
-                    // height of the table correct, and prevents it from jumping up when we put
-                    // the <tr> elements into a floating state.
-                    // It also makes sure the column widths stay correct, as the widths of the columns
-                    // are determined by the current fixed header, not the floating header.
-                    var clone = tr.clone();
-                    clones.push(clone);
-                    if (floating) {
-                        clone.removeClass('rx-floating-header');
-                    }
+                    // explicitly apply current geometry to all cells in the row
+                    _.each(row.find('th'), function (th) {
+                        var cell = angular.element(th);
 
-                    if (floating) {
-                        // We're currently floating, so add the class back, and
-                        // push the clone back on
-                        header.append(clone);
-                    }
-                    trs.push(tr);
-
-                    var thsInTr = _.map(tr.find('th'), angular.element);
-                    ths = ths.concat(thsInTr);
-
-                    // This <tr> only had one <th> in it. Grab that <th> and its clone
-                    // Also grab the width of the <th>, and compare it to our max width.
-                    // We need to do this because if a <th> was hidden, and then made to
-                    // appear while floating, its width will be too short, and will need
-                    // to be updated
-                    if (thsInTr.length === 1) {
-                        var th = thsInTr[0];
-                        var width = rxDOMHelper.width(th);
-                        if (width !== 'auto') {
-                            var numeric = _.parseInt(width);
-                            if (numeric > maxThWidth) {
-                                maxThWidth = numeric;
-                            }
+                        var _width = rxDOMHelper.width(cell);
+                        if (_width !== 'auto') {
+                            cell.css({ 'width': _width });
                         }
 
-                        singleThs.push([th, angular.element(clone.find('th'))]);
-                    }
-                });
-
-                // Explicitly set the width on every <th> that is the *only*
-                // <th> in its <tr>
-                maxThWidth = maxThWidth.toString() + 'px';
-                _.each(singleThs, function (thPair) {
-                    thPair[0].css({ width: maxThWidth });
-                    thPair[1].css({ width: maxThWidth });
-                });
-
-                // Apply .filter-header to any <input> elements
-                _.each(ths, function (th) {
-                    var input = th.find('input');
-                    if (input.length) {
-                        var type = input.attr('type');
-                        if (!type || type === 'text') {
-                            th.addClass('filter-header');
-                            input.addClass('filter-box');
-                            inputs.push(input);
+                        var _height = rxDOMHelper.height(cell);
+                        if (_height !== 'auto') {
+                            cell.css({ 'height': _height });
                         }
+                    });
+
+                    // generate filler row
+                    var fillerRow = row.clone();
+                    _.each(fillerRow.find('th'), function (th) {
+                        var cell = angular.element(th);
+                        // Ensure we're not duplicating header content by
+                        // replacing the cell content. The cell inherits
+                        // the explicit geometry determined above.
+                        cell.html('~');
+                    });
+                    fillerRows.push(fillerRow);
+
+                    /* float the ORIGINAL row */
+                    // Must happen after cloning, or else all header rows would float.
+                    row.addClass('rx-floating-header');
+                });
+
+                // append filler rows to header to reserve geometry
+                _.each(fillerRows, function (row) {
+                    header.append(row);
+                });
+            }//applyFloat()
+
+            /**
+             * @function
+             * @description Remove floating elements
+             * Handles cleanup of unnecessary styles, classes, and elements.
+             */
+            function removeFloat () {
+                isFloating = false;
+
+                _.each(header.find('tr'), function (tr) {
+                    var row = angular.element(tr);
+
+                    if (row.hasClass('rx-floating-header')) {
+                        // Cleanup classes/CSS
+                        row.removeClass('rx-floating-header');
+                        row.css({ top: null });
+
+                        _.each(row.find('th'), function (th) {
+                            var cell = angular.element(th);
+                            cell.css({ width: null });
+                        });
+                    } else {
+                        /* Filler Row */
+                        row.remove();
                     }
                 });
-            };
+            }//removeFloat()
 
-            setup();
-
-            scope.updateHeaders = function () {
-                if (_.isUndefined(maxHeight)) {
-                    maxHeight = table[0].offsetHeight;
+            /**
+             * @function
+             * @description Reapply float for certain scenarios
+             *
+             * This function is the key to recalculating floating header
+             * geometry for various scenarios while headers are already
+             * floating.
+             */
+            function reapplyFloat () {
+                if (isFloating) {
+                    removeFloat();
+                    applyFloat();
                 }
+            }//reapplyFloat()
 
-                maxHeight = _.max([maxHeight, table[0].offsetHeight]);
+            /**
+             * @function
+             * @description Applys/Removes floating headers
+             *
+             * **NOTE**: This will not work inside of scrollable elements.
+             * It will only float to the top of the page.
+             */
+            function update () {
+                var maxHeight = table[0].offsetHeight;
 
                 if (rxDOMHelper.shouldFloat(table, maxHeight)) {
-                    if (state === 'fixed') {
-                        state = 'float';
-                        var thWidths = [],
-                            trHeights = [];
-
-                        // Get the current height of each `tr` that we want to float
-                        _.each(trs, function (tr) {
-                            trHeights.push(parseInt(rxDOMHelper.height(tr)));
-                        });
-
-                        // Grab the current widths of each `th` that we want to float
-                        thWidths = _.map(ths, rxDOMHelper.width);
-
-                        // Put the cloned `tr` elements back into the DOM
-                        _.each(clones, function (clone) {
-                            header.append(clone);
-                        });
-
-                        // Apply the rx-floating-header class to each `tr` and
-                        // set a correct `top` for each, to make sure they stack
-                        // properly
-                        // We previously did tr.css({ 'width': rxDOMHelper.width(tr) })
-                        // but it *seems* that setting the widths of the `th` is enough
-                        var topOffset = 0;
-                        _.each(trs, function (tr, index) {
-                            tr.addClass('rx-floating-header');
-                            tr.css({ 'top': topOffset.toString() + 'px' });
-                            topOffset += trHeights[index];
-                        });
-
-                        // Explicitly set the widths of each `th` element that we floated
-                        _.each(_.zip(ths, thWidths), function (pair) {
-                            var th = pair[0];
-                            var width = pair[1];
-                            th.css({ 'width': width });
-                        });
+                    // If we're not floating, start floating
+                    if (!isFloating) {
+                        applyFloat();
                     }
-
                 } else {
-                    if (state === 'float' || !seenFirstScroll) {
-                        state = 'fixed';
-                        seenFirstScroll = true;
-
-                        // Make sure that an input filter doesn't have focus when
-                        // we re-dock the header, otherwise the browser will scroll
-                        // the screen back up ot the input
-                        _.each(inputs, function (input) {
-                            if ($document[0].activeElement === input[0]) {
-                                input[0].blur();
-                            }
-                        });
-
-                        _.each(trs, function (tr) {
-                            tr.removeClass('rx-floating-header');
-                        });
-
-                        // Detach each cloaned `tr` from the DOM,
-                        // but don't destroy it
-                        _.each(clones, function (clone) {
-                            clone.remove();
-                        });
+                    // If we're floating, stop floating
+                    if (isFloating) {
+                        removeFloat();
                     }
                 }
+            }//update()
 
-            };
+            // added to scope to call from controller (if needed)
+            scope.reapply = reapplyFloat;
+            scope.update = update;
 
-            rxDOMHelper.onscroll(function () {
-                scope.updateHeaders();
+            /* Event Handlers */
+            _resizeHandler = debounce(reapplyFloat, 500);
+            _window.bind('scroll', update);
+            _window.bind('resize', _resizeHandler);
+
+            scope.$on('$destroy', function () {
+                _window.unbind('scroll', update);
+                _window.unbind('resize', _resizeHandler);
             });
 
-            scope.update = function () {
-                setup();
-            };
+            /*
+             * Prepare the table for floating.
+             *
+             * We have to wrap the setup logic in a $timeout so that
+             * rxFloatingHeader can find compiled <input> elements in the header
+             * rows to apply dynamic classes. Otherwise, it'll only see the
+             * uncompiled markup, and the classes won't be added.
+             */
+            $timeout(function () {
+                header = angular.element(table.find('thead'));
+
+                _.each(header.find('tr'), function (tr) {
+                    var row = angular.element(tr);
+
+                    _.each(row.find('th'), function (th) {
+                        var cell = angular.element(th);
+
+                        // This has to run on the next digest cycle to
+                        // find compiled <input> elements in other directives.
+                        var input = cell.find('input');
+
+                        if (input.length) {
+                            var type = input.attr('type');
+                            if (!type || type === 'text') {
+                                cell.addClass('filter-header');
+                                input.addClass('filter-box');
+                            }
+                        }
+                    });
+                });
+
+                update();
+            });//setup logic
         },
     };
 });

--- a/src/components/rxFloatingHeader/scripts/rxFloatingHeader.spec.js
+++ b/src/components/rxFloatingHeader/scripts/rxFloatingHeader.spec.js
@@ -1,5 +1,5 @@
 describe('rxFloatingHeader', function () {
-    var scope, compile, el;
+    var scope, compile, el, $timeout, headerInputs;
     var validTemplate =
         '<table rx-floating-header>' +
             '<thead>' +
@@ -46,7 +46,6 @@ describe('rxFloatingHeader', function () {
             setScrollTop: function (val) { scrollTop = val; },
         };
     };
-
     var mockJq = rxDOMHelper();
 
     beforeEach(function () {
@@ -58,41 +57,78 @@ describe('rxFloatingHeader', function () {
         });
 
         // Inject in angular constructs
-        inject(function ($location, $rootScope, $compile) {
+        inject(function ($location, $rootScope, $compile, _$timeout_) {
             scope = $rootScope.$new();
             compile = $compile;
+            $timeout = _$timeout_;
         });
 
         el = helpers.createDirective(validTemplate, compile, scope);
         scope.$digest();
+
+        $timeout.flush();
     });
 
-    it('should apply .filter-header and .filter-box to headers and inputs', function () {
-        var ths = el.find('th');
-        var inputs = el.find('input');
+    describe('header', function () {
+        var header, headerCells, cell;
 
-        // .filter-header should only be added to the <th> which has an <input>,
-        // in this case the first <th>
-        expect(ths, 'three th elements').to.have.length(3);
-        expect(ths.eq(0).hasClass('filter-header'), 'first th').to.be.true;
-        expect(ths.eq(1).hasClass('filter-header'), 'second th').to.be.false;
-        expect(ths.eq(2).hasClass('filter-header'), 'third th').to.be.false;
+        before(function () {
+            header = el.find('thead');;
+            headerCells = header.find('th');
+            headerInputs = el.find('input');
+        });
 
-        expect(inputs, 'one input').to.have.length(1);
-        expect(inputs.eq(0).hasClass('filter-box')).to.be.true;
+        it('should have 3 cells', function () {
+            expect(headerCells).to.have.length(3);
+        });
+
+        it('should have one <input> element with "filter-box" class', function () {
+            expect(headerInputs).to.have.length(1);
+            expect(headerInputs.eq(0).hasClass('filter-box')).to.be.true;
+        });
+
+        describe('first cell', function () {
+            beforeEach(function () {
+                cell = headerCells.eq(0);
+            });
+
+            it('should have "filter-header" class', function () {
+                expect(cell.hasClass('filter-header')).to.be.true;
+            });
+        });//first cell
+
+        describe('second cell', function () {
+            beforeEach(function () {
+                cell = headerCells.eq(1);
+            });
+
+            it('should not have "filter-header" class', function () {
+                expect(cell.hasClass('filter-header')).to.be.false;
+            });
+        });//second cell
+
+        describe('third cell', function () {
+            beforeEach(function () {
+                cell = headerCells.eq(2);
+            });
+
+            it('should not have "filter-header" class', function () {
+                expect(cell.hasClass('filter-header')).to.be.false;
+            });
+        });//third cell
     });
 
     it('should add .rx-floating-header when we scroll past the header', function () {
-        scope.updateHeaders();
+        scope.update();
         expect(el.find('thead tr').hasClass('rx-floating-header')).to.be.true;
     });
 
     it('should remove .rx-floating-header when we scroll back up', function () {
-        scope.updateHeaders();
+        scope.update();
         expect(el.find('thead tr').hasClass('rx-floating-header'), 'add class').to.be.true;
 
         mockJq.setShouldFloat(false);
-        scope.updateHeaders();
+        scope.update();
         expect(el.find('thead tr').hasClass('rx-floating-header'), 'removed class').to.be.false;
     });
 });

--- a/src/components/rxPaginate/scripts/rxPaginate.js
+++ b/src/components/rxPaginate/scripts/rxPaginate.js
@@ -30,7 +30,10 @@ angular.module('encore.ui.rxPaginate')
         templateUrl: 'templates/rxPaginate.html',
         replace: true,
         restrict: 'E',
-        require: '?^rxLoadingOverlay',
+        require: [
+            '?^rxLoadingOverlay',
+            '?^rxFloatingHeader'
+        ],
         scope: {
             pageTracking: '=',
             numberOfPages: '@',
@@ -40,15 +43,19 @@ angular.module('encore.ui.rxPaginate')
             sortColumn: '=?',
             sortDirection: '=?'
         },
-        link: function (scope, element, attrs, rxLoadingOverlayCtrl) {
-
+        link: function (scope, element, attrs, ctrls) {
             var errorMessage = attrs.errorMessage;
 
-            rxLoadingOverlayCtrl = rxLoadingOverlayCtrl || {
+            var rxLoadingOverlayCtrl = ctrls[0] || {
                 show: _.noop,
                 hide: _.noop,
                 showAndHide: _.noop
             };
+
+            var rxFloatingHeaderCtrl = ctrls[1] || {
+                reapply: _.noop
+            };
+
             // We need to find the `<table>` that contains
             // this `<rx-paginate>`
             var parentElement = element.parent();
@@ -64,7 +71,6 @@ angular.module('encore.ui.rxPaginate')
 
             // Everything here is restricted to using server-side pagination
             if (!_.isUndefined(scope.serverInterface)) {
-
                 var params = function () {
                     var direction = scope.sortDirection ? 'DESCENDING' : 'ASCENDING';
                     return {
@@ -132,9 +138,36 @@ angular.module('encore.ui.rxPaginate')
                 }
 
                 notifyPageTracking();
-
             }
 
+            /*
+             * Wrap pageTracking functions to reapply floating header
+             * when navigating to another page of data.
+             */
+            scope.goToFirstPage = function () {
+                rxFloatingHeaderCtrl.reapply();
+                scope.pageTracking.goToFirstPage();
+            };
+
+            scope.goToPrevPage = function () {
+                rxFloatingHeaderCtrl.reapply();
+                scope.pageTracking.goToPrevPage();
+            };
+
+            scope.goToPage = function (n) {
+                rxFloatingHeaderCtrl.reapply();
+                scope.pageTracking.goToPage(n);
+            };
+
+            scope.goToNextPage = function () {
+                rxFloatingHeaderCtrl.reapply();
+                scope.pageTracking.goToNextPage();
+            };
+
+            scope.goToLastPage = function () {
+                rxFloatingHeaderCtrl.reapply();
+                scope.pageTracking.goToLastPage();
+            };
         }
     };
 });

--- a/src/components/rxPaginate/templates/rxPaginate.html
+++ b/src/components/rxPaginate/templates/rxPaginate.html
@@ -7,21 +7,21 @@
     <div flex="100" flex-order="1" flex-gt-md="40" flex-order-gt-md="2" flex-gt-lg="35">
       <div class="page-links" layout="row" layout-align="center">
         <div ng-class="{disabled: pageTracking.isFirstPage()}" class="pagination-first">
-          <a hide show-gt-lg ng-click="pageTracking.goToFirstPage()" ng-hide="pageTracking.isFirstPage()">First</a>
+          <a hide show-gt-lg ng-click="goToFirstPage()" ng-hide="pageTracking.isFirstPage()">First</a>
         </div>
         <div ng-class="{disabled: pageTracking.isFirstPage()}" class="pagination-prev">
-          <a ng-click="pageTracking.goToPrevPage()" ng-hide="pageTracking.isFirstPage()">« Prev</a>
+          <a ng-click="goToPrevPage()" ng-hide="pageTracking.isFirstPage()">« Prev</a>
         </div>
 
         <div ng-repeat="n in pageTracking | Page" ng-class="{active: pageTracking.isPage(n), 'page-number-last': pageTracking.isPageNTheLastPage(n)}" class="pagination-page">
-          <a ng-click="pageTracking.goToPage(n)">{{n + 1}}</a>
+          <a ng-click="goToPage(n)">{{n + 1}}</a>
         </div>
 
         <div ng-class="{disabled: pageTracking.isLastPage() || pageTracking.isEmpty()}" class="pagination-next">
-          <a ng-click="pageTracking.goToNextPage()" ng-hide="pageTracking.isLastPage() || pageTracking.isEmpty()"> Next »</a>
+          <a ng-click="goToNextPage()" ng-hide="pageTracking.isLastPage() || pageTracking.isEmpty()"> Next »</a>
         </div>
         <div ng-class="{disabled: pageTracking.isLastPage()}" class="pagination-last">
-          <a hide show-gt-lg ng-click="pageTracking.goToLastPage()" ng-hide="pageTracking.isLastPage()">Last</a>
+          <a hide show-gt-lg ng-click="goToLastPage()" ng-hide="pageTracking.isLastPage()">Last</a>
         </div>
       </div>
     </div>

--- a/src/utilities/rxBulkSelectController/scripts/rxBulkSelectController.js
+++ b/src/utilities/rxBulkSelectController/scripts/rxBulkSelectController.js
@@ -29,6 +29,7 @@ angular.module('encore.ui.utilities')
     var updateMessageStats = function () {
         messageStats.numSelected = numSelected();
         messageStats.total = $scope.bulkSource.length;
+        $scope._rxFloatingHeaderCtrl.reapply();
     };
 
     this.key = function () {
@@ -75,10 +76,12 @@ angular.module('encore.ui.utilities')
 
     this.increment = function () {
         messageStats.numSelected += 1;
+        $scope._rxFloatingHeaderCtrl.reapply();
     };
 
     this.decrement = function () {
         messageStats.numSelected -= 1;
+        $scope._rxFloatingHeaderCtrl.reapply();
     };
 
     this.registerHeader = function (uncheck) {

--- a/src/utilities/rxBulkSelectController/scripts/rxBulkSelectController.spec.js
+++ b/src/utilities/rxBulkSelectController/scripts/rxBulkSelectController.spec.js
@@ -39,6 +39,7 @@ describe('utilities:rxBulkSelectController', function () {
         beforeEach(function () {
             ctrlScope = rootScope.$new();
             ctrlScope.tableElement = {};
+            ctrlScope._rxFloatingHeaderCtrl = { reapply: _.noop };
             ctrlScope.selectedKey = 'rowIsSelected';
             ctrlScope.bulkSource = scope.servers;
 


### PR DESCRIPTION
* Float original header rows
  * Generate filler rows to reserve geometry (smoother float transition)
* Using rxPaginate, correct recalculation of column widths
  when navigating to a different page of data.
* Correct phantom pixel when floating
* Clean up demo markup
* Also fixed a performance bug, too!

JIRA: https://jira.rax.io/browse/FRMW-1255

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] Design LGTM
- [x] QE LGTM


# Summary

## BEFORE

### Jumpy Geometry
![rxpaginate-jumpy-geometry-before](https://cloud.githubusercontent.com/assets/545605/22837069/ad07b610-ef84-11e6-84c0-2f091ecfd13d.gif)
* dynamic elements added to header were not reserving the proper space (too little) which resulted in the data "jumping up" when it begins to float

### Phantom Pixel / No Recalculate While Floating
![rxfloatingheader-phantompx-norecalc-before](https://cloud.githubusercontent.com/assets/545605/22837071/ad17a84a-ef84-11e6-918c-b465c229faf7.gif)
* due to browser quirks, a phantom pixel shows up around the floating header (right side Chrome, left side Firefox)
* while floating, when the browser is resized, the floating header doesn't update
  * the user has to scroll back up and refloat the headers to correct

### rxPaginate demo
![rxpaginate-floating-header-before](https://cloud.githubusercontent.com/assets/545605/22837070/ad145b5e-ef84-11e6-9871-dc4cdc303e27.gif)
* broken compatibility in the demo due to inline styles

## AFTER

### Corrected Phantom Pixel / Update While Floating
![rxfloatingheader-nophantom-resizerecalc-after](https://cloud.githubusercontent.com/assets/545605/22837186/1697bfd0-ef85-11e6-93d7-5417480eec96.gif)
* phantom pixel is gone
* header updates on page resize while floating

### rxPaginate Compatibility
![rxpaginate-floating-header-after](https://cloud.githubusercontent.com/assets/545605/22837187/1696602c-ef85-11e6-892a-669321121e17.gif)
* demo corrected to allow column sizing to calculate naturally
* no jumpy geometry (smooth float)
* header updates as paginated data naturally changes column widths
