### PR TITLE
fix(AccountInfo): correct bug with badge tooltips [2.x]

### DIFF
--- a/src/elements/AccountInfo/templates/rxAccountInfo.html
+++ b/src/elements/AccountInfo/templates/rxAccountInfo.html
@@ -29,7 +29,7 @@
           ng-src="{{badge.url}}"
           data-name="{{badge.name}}"
           data-description="{{badge.description}}"
-          tooltip-html-unsafe="{{tooltipHtml(badge)}}"
+          uib-tooltip-html="tooltipHtml(badge)"
           tooltip-placement="bottom" />
       </div>
     </div>

--- a/src/elements/AccountInfo/templates/rxAccountInfoBanner.html
+++ b/src/elements/AccountInfo/templates/rxAccountInfoBanner.html
@@ -37,7 +37,7 @@
         <img ng-src="{{badge.url}}"
           data-name="{{badge.name}}"
           data-description="{{badge.description}}"
-          tooltip-html-unsafe="{{tooltipHtml(badge)}}"
+          uib-tooltip-html="tooltipHtml(badge)"
           tooltip-placement="bottom" />
       </div>
     </li>

--- a/utils/rx-page-objects/test/rxIfEnvironment.midway.js
+++ b/utils/rx-page-objects/test/rxIfEnvironment.midway.js
@@ -19,7 +19,7 @@ describe('rxIfEnvironment', function () {
     });
 
     it('should not change the original environment', function () {
-        browser.get('http://rackerlabs.github.io/encore-ui/#/overview');
+        browser.get('http://rackerlabs.github.io/encore-ui/2.x/#/overview');
         expect(environment.original()).to.eventually.equal('localhost');
     });
 


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1269

### LGTMs
- [x] Dev LGTM

### Summary
Upgrading to ngBootstrap 0.14.3 for the 2.0.0 release broke account badge tooltips (ngBootstrap introduced a breaking change in their update). This PR fixes the AccountInfo template usage of ngBootstrap tooltips.