### PR TITLE
fix(AccountInfo): correct bug with badge tooltips [3.x]

### DIFF
--- a/src/elements/AccountInfo/templates/rxAccountInfo.html
+++ b/src/elements/AccountInfo/templates/rxAccountInfo.html
@@ -29,7 +29,7 @@
           ng-src="{{badge.url}}"
           data-name="{{badge.name}}"
           data-description="{{badge.description}}"
-          tooltip-html-unsafe="{{tooltipHtml(badge)}}"
+          uib-tooltip-html="tooltipHtml(badge)"
           tooltip-placement="bottom" />
       </div>
     </div>

--- a/src/elements/AccountInfo/templates/rxAccountInfoBanner.html
+++ b/src/elements/AccountInfo/templates/rxAccountInfoBanner.html
@@ -37,7 +37,7 @@
         <img ng-src="{{badge.url}}"
           data-name="{{badge.name}}"
           data-description="{{badge.description}}"
-          tooltip-html-unsafe="{{tooltipHtml(badge)}}"
+          uib-tooltip-html="tooltipHtml(badge)"
           tooltip-placement="bottom" />
       </div>
     </li>


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1269

### LGTMs
- [x] Dev LGTM

### Summary
Upgrading to ngBootstrap 0.14.3 for the 2.0.0 release broke account badge tooltips (ngBootstrap introduced a breaking change in their update). This PR fixes the AccountInfo template usage of ngBootstrap tooltips.