### PR TITLE
fix(demo): correct angular error in Layout 2 demo [4.x]

### DIFF
--- a/demo/scripts/layout/page/layoutDataTableController.js
+++ b/demo/scripts/layout/page/layoutDataTableController.js
@@ -1,6 +1,6 @@
 angular.module('demoApp')
-.controller('layoutDataTableCtrl', function ($scope, PageTracking) {
-    $scope.pager = PageTracking.createInstance();
+.controller('layoutDataTableCtrl', function ($scope, rxPageTracker) {
+    $scope.pager = rxPageTracker.createInstance();
     $scope.people = [
         { name: 'Patrick Deuley', occupation: 'Design Chaplain', number: 1, status: 'ACTIVE' },
         { name: 'Hussam Dawood', occupation: 'Cat Lover', number: 2, status: 'DISABLED' },

--- a/demo/templates/styles/layouts/data-table-page.html
+++ b/demo/templates/styles/layouts/data-table-page.html
@@ -20,7 +20,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="person in people | filter:searchText | Paginate:pager">
+      <tr ng-repeat="person in people | filter:searchText | rxPaginate:pager">
         <td rx-status-column status="{{ person.status }}"></td>
         <td><a href="#">Lorem ipsum</a></td>
         <td>{{ person.name }}</td>

--- a/utils/visual-regression/components/rxForm.midway.js
+++ b/utils/visual-regression/components/rxForm.midway.js
@@ -5,7 +5,7 @@ describe('demo components', function () {
     });
 
     it('checkboxes', function () {
-        screenshot.snap(this, $('table[ng-controller="rxCheckboxCtrl"]'), { threshold: 1 });
+        screenshot.snap(this, $('table[ng-controller="checkboxDocsCtrl"]'), { threshold: 1 });
     });
 
     it('radios', function () {

--- a/utils/visual-regression/styleguide/layouts.midway.js
+++ b/utils/visual-regression/styleguide/layouts.midway.js
@@ -23,7 +23,7 @@ describe('layouts', function () {
         });
 
         it('full table', function () {
-            screenshot.snap(this, $('.page-body'));
+            screenshot.snap(this, $('main'));
         });
     });
 


### PR DESCRIPTION
Fix console error in `Styleguide > Layouts > Layout 2: Data Table` due to removing deprecated items. Additionally, fixing visual regression selectors (first corrected in #1971) to properly update visual regression images.

### LGTMs
- [x] Dev LGTM
- [x] Vidyo LGTM
