### PR TITLE
chore(3x): prepare `master` for long-running 3.x branch [3.x]

### DIFF
--- a/grunt-tasks/util/config.js
+++ b/grunt-tasks/util/config.js
@@ -9,7 +9,7 @@ var _banner = `/*
 module.exports = {
     github: {
         base: 'https://github.com/rackerlabs/encore-ui',
-        branch: 'master',
+        branch: '3.x',
         src: '<%= config.github.base %>/tree/<%= config.github.branch %>/src'
     },
     dir: {


### PR DESCRIPTION
`master` will be branched to `3.x` for a long-running support branch of 3.6.x versions

### LGTMs
- [x] Dev LGTM
