### PR TITLE
chore(ghPages): prep for post-4.0 updates

### DIFF
--- a/components/switchDocs/switch-docs.html
+++ b/components/switchDocs/switch-docs.html
@@ -1,4 +1,4 @@
 <select rx-select
   ng-model="version"
-  ng-options="v as (v.path + (v.isReleased ? '' : ' (unreleased)')) for v in versions | orderBy:['-path']">
+  ng-options="v as v.label for v in versions">
 </select>

--- a/components/switchDocs/switchDocs.js
+++ b/components/switchDocs/switchDocs.js
@@ -29,24 +29,24 @@
         .module('demoApp')
         .constant('DOC_VERSIONS', [
             {
+                "label": "5.0.0-x (Unreleased)",
+                "path": "5.x",
+            },
+            {
+                "label": "4.x (Current)",
                 "path": "4.x",
-                "isReleased": false,
-                "isLegacy": false
             },
             {
+                "label": "3.x (LTS)",
                 "path": "3.x",
-                "isReleased": true,
-                "isLegacy": false
             },
             {
+                "label": "2.x",
                 "path": "2.x",
-                "isReleased": true,
-                "isLegacy": true
             },
             {
+                "label": "1.x",
                 "path": "1.x",
-                "isReleased": true,
-                "isLegacy": true
             }
         ]);//DOC_VERSIONS
 })();

--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <noscript><meta http-equiv="REFRESH" content="0;URL=3.x/" /></noscript>
+    <noscript><meta http-equiv="REFRESH" content="0;URL=4.x/" /></noscript>
   </head>
   <body>
     <p>Redirecting...</p>
 
     <!-- Redirect in JavaScript with meta refresh fallback above in noscript -->
     <script>
-      window.location.href = '3.x/' + (window.location.search || '') + (window.location.hash || '');
+      window.location.href = '4.x/' + (window.location.search || '') + (window.location.hash || '');
     </script>
   </body>
 </html>


### PR DESCRIPTION
Preparation for `gh-pages` branch for AFTER all of the releases.

### LGTMs
- [x] Dev LGTM
- [x] Design LGTM

### BEFORE
![screen shot 2017-03-29 at 1 31 48 pm](https://cloud.githubusercontent.com/assets/545605/24470689/6cdefe60-1485-11e7-8775-ab620c7daade.png)

### AFTER
![screen shot 2017-03-29 at 2 25 22 pm](https://cloud.githubusercontent.com/assets/545605/24472636/0b2f9c68-148c-11e7-8999-e8916df8f4c3.png)
