### PR TITLE
frmw1334-inlinenotification

### DIFF
--- a/src/elements/Forms/docs/examples/forms.intermediatecontrols.html
+++ b/src/elements/Forms/docs/examples/forms.intermediatecontrols.html
@@ -35,12 +35,14 @@
         <rx-help-text>Must contain foo.</rx-help-text>
         <div ng-if="formIntermediateControls.userEmail.$dirty && formIntermediateControls.userEmail.$invalid">
           <div ng-messages="formIntermediateControls.userEmail.$error" ng-messages-multiple>
-            <rx-inline-error ng-message="email">
-              Invalid Email
-            </rx-inline-error>
-            <rx-inline-error ng-message="foocheck">
-              Your email must contain 'foo'
-            </rx-inline-error>
+            <span ng-message="email">
+              <rx-inline-error>Invalid Email</rx-inline-error>
+            </span>
+            <span ng-message="foocheck">
+              <rx-inline-error>
+                Your email must contain 'foo'
+              </rx-inline-error>
+            </span>
           </div>
         </div>
       </rx-field-content>

--- a/src/elements/Forms/docs/forms.docs.html
+++ b/src/elements/Forms/docs/forms.docs.html
@@ -85,7 +85,7 @@
 <ul class="list">
   <li>
     Inline Error messages should make use of the
-    <a href="ngdocs/index.html#/api/rxForm.directive:rxInlineError">
+    <a href="ngdocs/index.html#/api/elements.directive:rxInlineError">
       rxInlineError
     </a> directive.
   </li>

--- a/src/elements/Forms/scripts/rxInlineError.js
+++ b/src/elements/Forms/scripts/rxInlineError.js
@@ -35,6 +35,8 @@ angular.module('encore.ui.elements')
  */
 .directive('rxInlineError', function () {
     return {
-        restrict: 'E'
+        restrict: 'E',
+        transclude: true,
+        template: '<i class="fa fa-exclamation-circle"></i><span ng-transclude></span>'
     };
 });

--- a/src/elements/Forms/styles/rxForm.less
+++ b/src/elements/Forms/styles/rxForm.less
@@ -32,7 +32,11 @@ rx-help-text {
 
 rx-inline-error {
   color: @rxForm-error-text-color;
-  font-weight: 900;
+  display: flex;
+
+  .fa {
+    width: 1em;
+  }
 }
 
 rx-help-text {
@@ -244,13 +248,17 @@ rx-field-name {
               }
             }
           }
-
+          
           rx-search-box {
             flex: 1 1;
           }
         }//rx-input
       }//rx-field-content
     }//rx-field
+
+    rx-inline-error {
+      font-style: italic;
+    }//rx-inline-error in forms
 
     // replaces .form-actions
     // [rx-form] > rx-form-section > div


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1334

### LGTMs
- [x] Dev LGTM
- [x] Design LGTM
- [x] Dev+Vidyo LGTM

# Inline Error Message (in Forms)
## Before (intermediate controls)
![forms-inline-error-before-1](https://cloud.githubusercontent.com/assets/10750223/25973388/7e3e23b0-3669-11e7-837f-efeb631a3657.png)

## After
![forms-inline-error-after-1](https://cloud.githubusercontent.com/assets/10750223/25973475/e1dc1512-3669-11e7-9268-01c93e47dd5e.png)

## Before (text area)
![forms-inline-error-before-2](https://cloud.githubusercontent.com/assets/10750223/25973497/f9f1d54c-3669-11e7-8f75-1a124ac9bbb8.png)

## After
![forms-inline-error-after-2](https://cloud.githubusercontent.com/assets/10750223/25973508/044cc84e-366a-11e7-9b9b-6ea39cebeb6b.png)

# Inline Error Message (not in Forms)
## Before
(didn't exist)

## After
<img width="303" alt="error-not-forms-after" src="https://cloud.githubusercontent.com/assets/10750223/26004334/093f6c12-36fb-11e7-9b0b-df5ee64b93e2.png">

