### PR TITLE
refactor(rxCopy): updated css styles for tables with rxCopy element

### DIFF
--- a/src/elements/Copy/docs/Copy.docs.html
+++ b/src/elements/Copy/docs/Copy.docs.html
@@ -37,6 +37,10 @@
     table layout to your table, so there is a high liklihood that you will
     see a change to your column widths after it is applied.
   </li>
+  <li>
+    By default, an rxCopy element will be hidden if it is an immediate child of
+    an <code>.rxCopyTable</code> cell.
+  </li>
 </ul>
 <rx-example name="copy.tables"></rx-example>
 

--- a/src/elements/Copy/docs/examples/copy.tables.html
+++ b/src/elements/Copy/docs/examples/copy.tables.html
@@ -29,5 +29,16 @@
         <rx-copy class="subdued">Secondary Copy Value 3</rx-copy>
       </td>
     </tr>
+    <tr>
+      <td colspan="3" class="expanded-container">
+        <div class="expanded-content">
+          <p>
+            <rx-copy>
+              {{loremIpsum}}
+            </rx-copy>
+          </p>
+        </div>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/src/elements/Copy/styles/rxCopy.less
+++ b/src/elements/Copy/styles/rxCopy.less
@@ -115,16 +115,25 @@ table {
     // TODO: this should become the default for 3.0.0 tables
     table-layout: fixed;
 
-    rx-copy {
-      #rxCopy.compact();
+    & > thead,
+    & > tbody,
+    & > tfoot {
+      & > tr {
+        & > td,
+        & > th {
+          & > rx-copy {
+            #rxCopy.compact();
 
-      .rxCopy__action {
-        visibility: hidden;
-      }
+            .rxCopy__action {
+              visibility: hidden;
+            }
 
-      &:hover {
-        .rxCopy__action {
-          visibility: visible;
+            &:hover {
+              .rxCopy__action {
+                visibility: visible;
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
JIRA: https://jira.rax.io/browse/FRMW-1378

### LGTMs
- [x] Dev LGTM
- [x] Dev+Vidyo LGTM
- [x] Design LGTM

# Before
![rxcopy-table-before](https://user-images.githubusercontent.com/10750223/28587621-6eb1bb00-713d-11e7-8659-a609c56dd6e6.png)

# After
![rxcopy-table-after](https://user-images.githubusercontent.com/10750223/28587626-729b8160-713d-11e7-8a30-828a70a26853.png)
