### PR TITLE
docs(overview): link to 5.0 migration guide

### DIFF
--- a/demo/templates/overview.html
+++ b/demo/templates/overview.html
@@ -17,7 +17,6 @@
           How to get started with your project using EncoreUI
           components and styles.
         </p>
-
       </section>
 
       <section>
@@ -56,11 +55,11 @@
         </a>
         <p>List of what features and updates are included in each release</p>
 
-        <a href="https://github.com/rackerlabs/encore-ui/wiki/4.0-Migration-Guide">
+        <a href="https://github.com/rackerlabs/encore-ui/wiki/5.0-Migration-Guide">
           <i class="fa fa-external-link"></i>
-          4.0 Migration Guide
+          5.0 Migration Guide
         </a>
-        <p>Instructions on upgrading from EncoreUI 3.x to 4.0</p>
+        <p>Instructions on upgrading from EncoreUI 3.x to 5.x</p>
 
         <a href="https://github.com/rackerlabs/encore-ui/wiki/Common-Questions">
           <i class="fa fa-external-link"></i>


### PR DESCRIPTION
Update link to point to 5.0 migration guide in Overview page.

### LGTMs
- [x] Dev LGTM